### PR TITLE
Restructure skills, config, and model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ pyagent --model gemini                         # gemini-2.5-flash
 pyagent --model gemini/gemini-2.5-pro
 ```
 
+If `--model` is omitted, pyagent picks one in this order:
+
+1. **`default_model`** in `config.toml` (e.g. `default_model = "openai"`).
+2. **Auto-detect** from the API-key env vars: `ANTHROPIC_API_KEY` →
+   `OPENAI_API_KEY` → `GEMINI_API_KEY`/`GOOGLE_API_KEY`. The first that's
+   set wins.
+3. If neither is available, pyagent exits with a pointed error telling
+   you which env vars it looks for.
+
+The session header prints the resolved provider/model so you can confirm
+what was picked.
+
 Make sure the matching API key from the table above is set in your
 environment before launching.
 
@@ -149,16 +161,15 @@ Memory work is meant to happen **organically**, mid-conversation: when the
 agent learns a preference, a convention, or something genuinely worth
 remembering, it updates the appropriate ledger then and there.
 
-As a safety net, the CLI also runs a single **end-of-session pass** when
-you exit (Ctrl+D or Ctrl+C at the prompt). It asks the agent to sweep the
-conversation for anything that should have been recorded but wasn't, and
-to update the ledgers. If the agent has already kept things tidy, it will
-say so and exit. The pass only fires when the session actually added new
-turns; resumed-but-idle sessions exit immediately. A second Ctrl+C during
-the pass skips it cleanly.
-
-To skip the pass entirely (throwaway chats, sensitive conversations,
-scripted runs), launch with `--no-memory-pass-on-exit`.
+An optional **end-of-session pass** is available as a safety net: launch
+with `--memory-pass-on-exit` and the CLI will, on exit (Ctrl+D or Ctrl+C
+at the prompt), ask the agent to sweep the conversation for anything
+that should have been recorded but wasn't, and update the ledgers. The
+pass only fires when the session actually added new turns; resumed-but-
+idle sessions exit immediately. A second Ctrl+C during the pass skips
+it cleanly. It's off by default — the expectation is that the agent
+records memory organically mid-conversation, so this is for rare
+"final sweep" cases.
 
 Conversation history and large tool outputs are persisted separately, under
 `.pyagent/sessions/<session-id>/`. Resume a session with `pyagent --resume
@@ -166,18 +177,19 @@ Conversation history and large tool outputs are persisted separately, under
 
 ## Skills
 
-Skills are bundles of instructions (and optional helper tools) the agent can
-load on demand. The system prompt advertises *that* a skill exists; the agent
-calls `use_skill(<name>)` when its description matches what the user is
-asking for, and the skill's body lands in context for the rest of the
+Skills are bundles of instructions (and optional helper scripts) the agent
+can load on demand. The system prompt advertises *that* a skill exists; the
+agent calls `read_skill(<name>)` when its description matches what the user
+is asking for, and the skill's body lands in context for the rest of the
 session.
 
 A skill is a directory with a `SKILL.md`:
 
 ```
 example-skill/
-  SKILL.md         # YAML-ish frontmatter + instructions for the agent
-  tools.py         # optional, exports a TOOLS = {"name": fn, ...} dict
+  SKILL.md          # YAML-ish frontmatter + instructions for the agent
+  scripts/          # optional — CLI helpers the agent invokes via the shell tool
+    cli.py
 ```
 
 Frontmatter fields:
@@ -186,39 +198,100 @@ Frontmatter fields:
 | --- | --- |
 | `name` | Catalog identifier the agent uses to load the skill. |
 | `description` | One-line summary; the agent uses this to decide relevance. |
-| `tools` | Optional. Path (relative to `SKILL.md`) of a Python file whose `TOOLS` dict gets registered with the agent on first activation. |
 
-Discovery order (first wins, local overrides everything):
+Skills don't register Python tools. Helper scripts under `scripts/` are
+invoked via the regular shell tool, so they go through the same Bash safety
+checks as any other command.
 
-1. `./.pyagent/skills/<name>/SKILL.md` — project-local
-2. `<config-dir>/skills/<name>/SKILL.md` — user-installed
+Discovery order (later wins, project-local overrides everything):
 
-Skills that ship a `tools` module run arbitrary Python on activation, so the
-first `use_skill(<name>)` call in a session prompts the human for one-time
-approval. Pure-instructional skills (no `tools`) skip the prompt — their
-effects route through the existing tool layer with its own permissions.
+1. `<package>/skills/<name>/` — bundled with pyagent
+2. `<config-dir>/skills/<name>/` — user-installed
+3. `./.pyagent/skills/<name>/` — project-local
+
+The catalog re-renders before every model call, so a skill you (or the
+agent) just authored shows up on the next call — no restart needed.
 
 ### Bundled skills
 
-Run `pyagent-skills list` to see what's bundled and what's installed.
-Install a bundled skill into your config dir with:
+Bundled skills load directly from the package — no install step, no copy on
+disk. Upgrading pyagent updates them for free.
 
-```
-pyagent-skills install aviation-weather
-pyagent-skills install flight-tracker
-pyagent-skills install faa-registry
+Only **`write-skill`** is enabled out of the box. The rest are opt-in to
+keep the catalog tight. Enable additional bundled skills by listing their
+names in `<config-dir>/config.toml`:
+
+```toml
+built_in_skills_enabled = ["write-skill", "flight-tracker"]
 ```
 
-Bundled skills:
+Setting `built_in_skills_enabled` replaces the default list, so include
+every bundled skill you want available — `write-skill` included.
+
+Run `pyagent-skills list` to see each bundled skill's name, description,
+and current `[enabled]` / `[disabled]` state.
 
 | Skill | What it does |
 | --- | --- |
-| `write-skill` | Authoring guide — install this if you want the agent to be able to write new skills for you. |
+| `write-skill` | Authoring guide — load this when you want the agent to write a new skill for you. **Enabled by default.** |
 | `aviation-weather` | METARs, TAFs, PIREPs, AFD, AIRMETs/SIGMETs around an airport. Uses aviationweather.gov; no key needed. |
 | `flight-tracker` | Live aircraft state vectors near a point or by ICAO24 hex via OpenSky. Anonymous works; OAuth2 client credentials unlock more. |
 | `faa-registry` | Look up FAA aircraft registry records (US tail numbers) by N-number, owner, or make/model. |
 
-`pyagent-skills uninstall <name>` removes an installed copy. Project-local
-skills under `./.pyagent/skills/` always override an installed one of the
-same name — drop a `SKILL.md` in there to customize a bundled skill for a
-single project without touching the installed copy.
+To customize a bundled skill, copy its directory into `<config-dir>/skills/`
+or `./.pyagent/skills/` and edit. The override takes precedence regardless
+of `built_in_skills_enabled` — user-installed and project-local tiers are
+never gated by config.
+
+`pyagent-skills uninstall <name>` removes a user- or project-local copy.
+Bundled skills can't be uninstalled (they ship with the package); to keep
+one out of the catalog, just leave it out of `built_in_skills_enabled`.
+
+## Configuration
+
+Pyagent reads its config from `<config-dir>/config.toml`. A missing file is
+fine — bundled defaults apply. The `pyagent-config` CLI inspects and
+initializes the file:
+
+```
+pyagent-config show          # effective merged config (defaults + overrides)
+pyagent-config defaults      # bundled defaults as a commented-out template
+pyagent-config init          # write the template to config.toml if absent
+```
+
+`init` never overwrites; pass `--force` if you really want to start over.
+The written template is fully commented out, so the file's presence does
+not change behavior — uncomment lines to override defaults.
+
+## Managing sessions
+
+Conversation history lives under `./.pyagent/sessions/<session-id>/`. The
+`pyagent-sessions` CLI inspects and cleans it up:
+
+```
+pyagent-sessions list                          # all sessions, newest first
+pyagent-sessions delete <id>                   # remove one session
+pyagent-sessions delete --all                  # remove every session in this project
+pyagent-sessions prune --older-than 30         # delete anything inactive 30+ days
+pyagent-sessions prune --keep 10               # keep newest 10, drop the rest
+```
+
+`prune` defaults to dry-run; pass `--no-dry-run` to actually delete.
+
+## Resetting
+
+Pyagent's reset flags overwrite files in `<config-dir>` with the bundled
+defaults. They never touch your workspace (`./.pyagent/`) — sessions and
+project-local skills are yours to manage.
+
+| Flag | Effect |
+| --- | --- |
+| `--reset-soul` / `--reset-tools` / `--reset-primer` | Overwrite the spec doc with the bundled default. |
+| `--reset-user` | Overwrite `USER.md` (preferences). |
+| `--reset-memory` | Overwrite `MEMORY.md` (long-term memory). |
+| `--reset-skills` | Remove every user-installed skill under `<config-dir>/skills/`. |
+| `--reset-all` | All of the above, with one consolidated confirmation. |
+| `--yes` / `-y` | Skip the confirmation prompt for destructive resets. |
+
+The destructive resets (USER, MEMORY, skills) prompt before doing anything;
+spec-doc resets don't, since those are pure revert-to-ship-state.

--- a/pyagent/agent.py
+++ b/pyagent/agent.py
@@ -206,13 +206,17 @@ class Agent:
         on_usage: Callable[[dict[str, int]], None] | None = None,
         cancel_event: threading.Event | None = None,
     ) -> str:
-        system = self._system_prompt()
         self.conversation.append({"role": "user", "content": prompt})
         texts: list[str] = []
         while True:
             # Drain any async-subagent replies that arrived since the
             # last LLM call so the model sees them on this turn.
             self._drain_pending_async()
+            # Rebuild every inner call so a skill installed mid-run
+            # shows up on the next iteration. The catalog renders
+            # sorted; identical filesystem state ⇒ identical string
+            # ⇒ prompt cache stays warm.
+            system = self._system_prompt()
             turn = self._call_llm(self.conversation, system)
             self.conversation.append(turn)
             usage = turn.get("usage") if isinstance(turn, dict) else None

--- a/pyagent/agent_proc.py
+++ b/pyagent/agent_proc.py
@@ -426,7 +426,6 @@ def _bootstrap(
     os.chdir(config["cwd"])
     permissions.set_workspace(config["cwd"])
     permissions.pre_approve(paths.config_dir())
-    permissions.deny(paths.config_dir() / "skills" / ".auto_installed")
     for p in config.get("approved_paths", []):
         permissions.pre_approve(p)
     permissions.set_prompt_handler(state.permission_handler)

--- a/pyagent/cli.py
+++ b/pyagent/cli.py
@@ -2,6 +2,7 @@ import logging
 import multiprocessing
 import re
 import readline  # imported for side effect: enables line editing and history in input()
+import shutil
 import sys
 from multiprocessing.connection import Connection
 from pathlib import Path
@@ -13,6 +14,8 @@ from rich.markdown import Markdown
 from rich.traceback import install as install_traceback
 
 from pyagent import agent_proc
+from pyagent import config
+from pyagent import llms
 from pyagent import paths
 from pyagent import permissions
 from pyagent import protocol
@@ -120,24 +123,42 @@ _PRICING_USD_PER_MTOK: dict[str, tuple[float, float]] = {
 }
 
 
-# Default model name per provider, mirroring each LLM client's
-# constructor default. Used when the user passes bare `--model
-# anthropic` (no `/name`) so the cost meter still resolves a price.
-_DEFAULT_MODELS: dict[str, str] = {
-    "anthropic": "claude-sonnet-4-6",
-    "openai": "gpt-4o",
-    "gemini": "gemini-2.5-flash",
-}
-
-
 def _model_name(model_str: str) -> str:
     """Extract the bare model name from a 'provider/name' string.
 
-    Falls back to the provider's default model if no `/name` was
-    given so the pricing lookup still works on `--model anthropic`.
+    Falls back to the provider's default model (via the llms registry)
+    if no `/name` was given so the pricing lookup still works on
+    `--model anthropic`.
     """
-    provider, _, name = model_str.partition("/")
-    return name or _DEFAULT_MODELS.get(provider, "")
+    _, _, name = llms.resolve_model(model_str).partition("/")
+    return name
+
+
+def _resolve_model(cli_model: str | None) -> str:
+    """Pick a model string. Precedence: --model > config.default_model
+    > auto-detect from API-key env vars. Raises a click error if all
+    three are empty so the user gets a pointed message instead of a
+    "ANTHROPIC_API_KEY is not set" deep in the SDK.
+    """
+    if cli_model:
+        return llms.resolve_model(cli_model)
+    cfg_default = (config.load().get("default_model") or "").strip()
+    if cfg_default:
+        return llms.resolve_model(cfg_default)
+    detected = llms.auto_detect_provider()
+    if detected:
+        return llms.resolve_model(detected.name)
+    expected = ", ".join(
+        v
+        for spec in llms.PROVIDERS
+        for v in spec.env_vars
+    )
+    raise click.UsageError(
+        "no model selected and no API-key env var is set.\n"
+        f"Set one of: {expected}\n"
+        "Or pass --model <provider> (e.g. --model openai),\n"
+        "or pin a default with `pyagent-config init` then editing default_model."
+    )
 
 
 def _estimate_cost_usd(
@@ -262,9 +283,9 @@ def _update_agents_state(
         return
 
 
-# A safety-net pass at session end. Organic ledger work is supposed to
-# happen mid-conversation (see SOUL.md); this sweep catches whatever
-# slipped through.
+# Optional safety-net pass at session end. Organic ledger work is
+# supposed to happen mid-conversation (see SOUL.md), so this sweep is
+# off by default — opt in with --memory-pass-on-exit when you want it.
 _END_OF_SESSION_PROMPT = (
     "The session is wrapping up. Review this conversation: if anything "
     "should have been recorded in your USER or MEMORY ledger and wasn't, "
@@ -486,9 +507,12 @@ def _drive_turn(
 )
 @click.option(
     "--model",
-    default="anthropic",
-    show_default=True,
-    help="Provider, optionally with '/model-name' (e.g. anthropic, openai/gpt-4o).",
+    default=None,
+    help=(
+        "Provider, optionally with '/model-name' (e.g. anthropic, "
+        "openai/gpt-4o). If unset: use config.default_model, else "
+        "auto-detect from API-key env vars."
+    ),
 )
 @click.option(
     "--resume",
@@ -529,16 +553,30 @@ def _drive_turn(
     help="Overwrite <config-dir>/MEMORY.md with the bundled template. Destructive — wipes long-term memory.",
 )
 @click.option(
-    "--reset-all",
+    "--reset-skills",
     is_flag=True,
-    help="Shortcut: --reset-soul --reset-tools --reset-primer --reset-user --reset-memory together.",
+    help="Remove every user-installed skill under <config-dir>/skills/. "
+    "Bundled skills are unaffected (they ship with the package).",
 )
 @click.option(
-    "--no-memory-pass-on-exit",
-    "no_memory_pass_on_exit",
+    "--reset-all",
     is_flag=True,
-    help="Skip the end-of-session memory pass. Useful for throwaway "
-    "sessions, sensitive conversations, or scripted runs.",
+    help="Shortcut: every --reset-* flag together (SOUL, TOOLS, PRIMER, USER, MEMORY, skills).",
+)
+@click.option(
+    "--yes",
+    "-y",
+    "assume_yes",
+    is_flag=True,
+    help="Skip the confirmation prompt for destructive resets (USER, MEMORY, skills).",
+)
+@click.option(
+    "--memory-pass-on-exit",
+    "memory_pass_on_exit",
+    is_flag=True,
+    help="Run a safety-net memory pass at session end. Off by default — "
+    "the agent is expected to record memory organically mid-conversation. "
+    "Enable when you want a final sweep for things that may have slipped.",
 )
 @click.option(
     "--verbose",
@@ -550,15 +588,17 @@ def main(
     soul: Path | None,
     tools_md: Path | None,
     primer: Path | None,
-    model: str,
+    model: str | None,
     resume_id: str | None,
     reset_soul: bool,
     reset_tools: bool,
     reset_primer: bool,
     reset_user: bool,
     reset_memory: bool,
+    reset_skills: bool,
     reset_all: bool,
-    no_memory_pass_on_exit: bool,
+    assume_yes: bool,
+    memory_pass_on_exit: bool,
     verbose: bool,
 ) -> None:
     install_traceback(show_locals=False)
@@ -567,25 +607,77 @@ def main(
     if verbose:
         logging.getLogger("pyagent").setLevel(logging.INFO)
 
-    any_reset = False
-    for flag, name, seed in (
-        (reset_soul or reset_all, "SOUL.md", "SOUL.md"),
-        (reset_tools or reset_all, "TOOLS.md", "TOOLS.md"),
-        (reset_primer or reset_all, "PRIMER.md", "PRIMER.md"),
-        (reset_user or reset_all, "USER.md", "USER.md"),
-        (reset_memory or reset_all, "MEMORY.md", "MEMORY.md"),
-    ):
-        if flag:
-            path = paths.reset_to_default(name, seed)
-            console.print(f"[yellow]reset {name} → {path}[/yellow]")
-            any_reset = True
+    will_reset_soul = reset_soul or reset_all
+    will_reset_tools = reset_tools or reset_all
+    will_reset_primer = reset_primer or reset_all
+    will_reset_user = reset_user or reset_all
+    will_reset_memory = reset_memory or reset_all
+    will_reset_skills = reset_skills or reset_all
+    any_reset = any(
+        (
+            will_reset_soul,
+            will_reset_tools,
+            will_reset_primer,
+            will_reset_user,
+            will_reset_memory,
+            will_reset_skills,
+        )
+    )
+
     if any_reset:
+        skills_root = paths.config_dir() / "skills"
+        skill_dirs: list[Path] = []
+        if will_reset_skills and skills_root.exists():
+            skill_dirs = sorted(p for p in skills_root.iterdir() if p.is_dir())
+
+        destructive: list[str] = []
+        if will_reset_user:
+            destructive.append("USER.md (accumulated preferences)")
+        if will_reset_memory:
+            destructive.append("MEMORY.md (long-term memory)")
+        if will_reset_skills:
+            if skill_dirs:
+                names = ", ".join(p.name for p in skill_dirs)
+                destructive.append(
+                    f"{len(skill_dirs)} user-installed skill(s): {names}"
+                )
+            else:
+                destructive.append("user-installed skills (none currently)")
+
+        if destructive and not assume_yes:
+            console.print("[red]This will permanently remove:[/red]")
+            for line in destructive:
+                console.print(f"  - {line}")
+            if not click.confirm("Continue?", default=False):
+                console.print("[dim]aborted.[/dim]")
+                return
+
+        for flag, name, seed in (
+            (will_reset_soul, "SOUL.md", "SOUL.md"),
+            (will_reset_tools, "TOOLS.md", "TOOLS.md"),
+            (will_reset_primer, "PRIMER.md", "PRIMER.md"),
+            (will_reset_user, "USER.md", "USER.md"),
+            (will_reset_memory, "MEMORY.md", "MEMORY.md"),
+        ):
+            if flag:
+                path = paths.reset_to_default(name, seed)
+                console.print(f"[yellow]reset {name} → {path}[/yellow]")
+
+        if will_reset_skills:
+            for d in skill_dirs:
+                shutil.rmtree(d)
+                console.print(f"[yellow]removed user skill {d.name}[/yellow]")
+            if not skill_dirs:
+                console.print(f"[dim]no user-installed skills in {skills_root}[/dim]")
+
         if resume_id:
             console.print(
                 f"[dim](--resume {resume_id} ignored: reset flags exit "
                 "without launching the REPL)[/dim]"
             )
         return
+
+    model = _resolve_model(model)
 
     if resume_id:
         session = Session(session_id=resume_id)
@@ -605,7 +697,7 @@ def main(
     prior = session.load_history()
     _seed_input_history(prior)
 
-    config = {
+    agent_config = {
         "cwd": str(Path.cwd().resolve()),
         "model": model,
         "session_id": session.id,
@@ -629,7 +721,7 @@ def main(
     parent_conn, child_conn = ctx.Pipe(duplex=True)
     proc = ctx.Process(
         target=agent_proc.child_main,
-        args=(config, child_conn),
+        args=(agent_config, child_conn),
         name="pyagent-agent",
         daemon=False,
     )
@@ -652,11 +744,8 @@ def main(
             watcher.start()
             thinking.start()
 
-        provider, _, model_name = model.partition("/")
         console.print(f"[dim]session: {session.id}[/dim]")
-        console.print(
-            f"[dim]model:   {provider}/{model_name or 'default'}[/dim]"
-        )
+        console.print(f"[dim]model:   {model}[/dim]")
         if prior:
             console.print(f"[dim]resumed {len(prior)} entries[/dim]")
 
@@ -728,7 +817,7 @@ def main(
                 console.print("[red]agent subprocess exited unexpectedly[/red]")
                 break
 
-        if not no_memory_pass_on_exit and turns_run > 0 and proc.is_alive():
+        if memory_pass_on_exit and turns_run > 0 and proc.is_alive():
             try:
                 protocol.send(
                     parent_conn,

--- a/pyagent/cli.py
+++ b/pyagent/cli.py
@@ -77,7 +77,7 @@ def _on_tool_call(
 ) -> None:
     summary = _summarize_args(args)
     label = f"{name}  {summary}" if summary else name
-    console.print(f"{_agent_label(agent_id)}[dim]· {label}[/dim]")
+    console.print(f"{_agent_label(agent_id)}[dim grey42]· {label}[/dim grey42]")
 
 
 def _on_tool_result(

--- a/pyagent/config.py
+++ b/pyagent/config.py
@@ -7,13 +7,27 @@ you actually want to change.
 
 Schema (current):
 
+    default_model = ""                          # provider or provider/model
+    built_in_skills_enabled = ["write-skill"]   # bundled skills in the catalog
+
     [subagents]
     max_depth  = 3   # maximum spawn-tree height; root is depth 0
     max_fanout = 5   # max simultaneous children any single agent can hold
 
-The caps exist to mitigate fork-bomb behavior — a confused turn could
-spawn unboundedly otherwise, amplifying cost per process and outpacing
-the human's ability to hit Esc.
+The subagent caps exist to mitigate fork-bomb behavior — a confused
+turn could spawn unboundedly otherwise, amplifying cost per process
+and outpacing the human's ability to hit Esc.
+
+`default_model` pins the provider/model used when `--model` is not
+passed. Empty string means auto-detect from API-key env vars.
+
+`built_in_skills_enabled` lists which *built-in* skills (the ones shipped
+under `pyagent/skills/` in the package) appear in the catalog. Setting
+this key in user config replaces the default list entirely, so include
+every built-in skill you want enabled. User-installed skills (under
+`<config-dir>/skills/`) and project-local skills (under
+`./.pyagent/skills/`) are always discovered regardless of this list —
+their presence on disk *is* the user's enablement signal.
 """
 
 from __future__ import annotations
@@ -30,6 +44,8 @@ logger = logging.getLogger(__name__)
 CONFIG_FILENAME = "config.toml"
 
 DEFAULTS: dict[str, Any] = {
+    "default_model": "",
+    "built_in_skills_enabled": ["write-skill"],
     "subagents": {
         "max_depth": 3,
         "max_fanout": 5,
@@ -73,3 +89,61 @@ def load() -> dict[str, Any]:
 def path() -> Path:
     """Where the config file lives (whether or not it exists)."""
     return paths.config_dir() / CONFIG_FILENAME
+
+
+_TOML_HEADER = (
+    "# pyagent configuration\n"
+    "# Loaded from this file; missing keys fall back to bundled defaults.\n"
+    "# Lists replace (do not merge), so if you set a list, include every\n"
+    "# value you want — defaults for that key no longer apply.\n"
+)
+
+
+def _render_toml_value(v: Any) -> str:
+    """Render a Python value as TOML. Supports scalars and flat lists."""
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    if isinstance(v, int):
+        return str(v)
+    if isinstance(v, str):
+        escaped = v.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    if isinstance(v, list):
+        return "[" + ", ".join(_render_toml_value(x) for x in v) + "]"
+    raise TypeError(f"unsupported toml value: {v!r}")
+
+
+def render_toml(data: dict[str, Any], commented: bool = False) -> str:
+    """Render a config dict as TOML text. Top-level scalars/lists first,
+    then tables — the order TOML requires.
+
+    If `commented`, every value line is prefixed with `# ` so the file
+    serves as documentation: the user uncomments lines they want to
+    override.
+    """
+    prefix = "# " if commented else ""
+    lines = [_TOML_HEADER]
+    flat = [(k, v) for k, v in data.items() if not isinstance(v, dict)]
+    tables = [(k, v) for k, v in data.items() if isinstance(v, dict)]
+    for k, v in flat:
+        lines.append(f"{prefix}{k} = {_render_toml_value(v)}")
+    for k, v in tables:
+        lines.append("")
+        lines.append(f"{prefix}[{k}]")
+        for k2, v2 in v.items():
+            lines.append(f"{prefix}{k2} = {_render_toml_value(v2)}")
+    return "\n".join(lines) + "\n"
+
+
+def init_default(force: bool = False) -> tuple[Path, bool]:
+    """Write the documented default schema to the config file.
+
+    Returns (path, written). If the file already exists and `force` is
+    False, returns (path, False) without touching it.
+    """
+    target = path()
+    if target.exists() and not force:
+        return target, False
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(render_toml(DEFAULTS, commented=True))
+    return target, True

--- a/pyagent/config_cli.py
+++ b/pyagent/config_cli.py
@@ -1,0 +1,71 @@
+"""`pyagent-config` — inspect and initialize the pyagent config file.
+
+Three subcommands:
+
+- `show`      print the effective merged config (defaults + user overrides)
+- `defaults`  print the bundled defaults as a commented-out TOML template
+- `init`      write the commented-out template to the config file if absent
+
+The file lives at `<config-dir>/config.toml`. Missing or empty file means
+defaults apply; nothing breaks. `init` exists so a user who wants a
+starting point doesn't have to copy-paste from the README.
+"""
+
+from __future__ import annotations
+
+import click
+
+from pyagent import config
+
+
+@click.group()
+def main() -> None:
+    """Inspect and initialize pyagent's config file."""
+
+
+@main.command("show")
+def show_cmd() -> None:
+    """Print the effective merged config (defaults + user overrides)."""
+    click.echo(config.render_toml(config.load(), commented=False), nl=False)
+    click.echo()
+    click.echo(f"# loaded from: {config.path()}", err=True)
+    click.echo(
+        f"# (file {'exists' if config.path().exists() else 'absent — defaults only'})",
+        err=True,
+    )
+
+
+@main.command("defaults")
+def defaults_cmd() -> None:
+    """Print the bundled defaults as a commented-out TOML template.
+
+    Pipe to a file, or use `pyagent-config init` to drop it in place.
+    """
+    click.echo(config.render_toml(config.DEFAULTS, commented=True), nl=False)
+
+
+@main.command("init")
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Overwrite an existing config.toml. Off by default.",
+)
+def init_cmd(force: bool) -> None:
+    """Create the config file with documented defaults if it doesn't exist.
+
+    Never overwrites — pass --force only if you want to start over.
+    The written template has every line commented out, so the file's
+    presence does not change behavior. Uncomment the lines you want to
+    override.
+    """
+    target, written = config.init_default(force=force)
+    if not written:
+        click.echo(f"config.toml already exists at {target}")
+        click.echo("(pass --force to overwrite)")
+        return
+    click.echo(f"wrote default config to {target}")
+    click.echo("Edit the file and uncomment lines to override defaults.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyagent/defaults/PRIMER.md
+++ b/pyagent/defaults/PRIMER.md
@@ -37,10 +37,26 @@ rest is on you.
 
 ## Subagents
 
-- Reach for `spawn_subagent` when the work *fits* — focused
-  expertise (custom system prompt) or fan-out parallelism.
-  Not because they exist. Each one runs its own LLM, on its own
-  tokens.
+- **Default to spawning when the shape fits.** You don't need
+  the user's permission, and you don't need to be asked. The
+  shapes that fit:
+  - **Fan-out** — independent jobs (search a wide area, edit
+    several unrelated files, try two approaches and compare).
+    One subagent per job, async, gather.
+  - **Context insulation** — open-ended research, log spelunking,
+    reading a large unfamiliar file, anything that would dump a
+    lot of bytes into *your* window when only the conclusion
+    matters. Send the question, get the answer, your context
+    stays clean.
+  - **Fresh eyes** — review, critique, or sanity-check work
+    you're too close to. A different system prompt buys
+    perspective the parent agent literally can't get.
+  The cost frame isn't "are the tokens worth it" — it's "is the
+  wall-clock and context savings worth the tokens." For the
+  shapes above, usually yes.
+- Skip subagents when the work is small enough you'd finish
+  before one boots, or so entangled with your live context that
+  re-briefing costs more than doing it yourself.
 - Sync vs async is a wall-clock decision. `call_subagent` blocks
   your turn until the subagent replies. `call_subagent_async` +
   `wait_for_subagents` runs many at once and gathers when they're

--- a/pyagent/defaults/TOOLS.md
+++ b/pyagent/defaults/TOOLS.md
@@ -30,10 +30,11 @@ by the API; this is about *when and how* to use them.
   you so the ledgers follow the user across working directories. Using
   `read_file` / `write_file` instead would create copies in whatever
   directory you happen to be in — use the ledger tools.
-- **Delegating to a fresh agent** — `spawn_subagent` when the work
-  needs a different system prompt (focused expertise, narrower role)
-  or when several jobs can run in parallel. The new agent boots in
-  its own subprocess with the same default tool set as you.
+- **Delegating to a fresh agent** — `spawn_subagent` is your
+  default for fan-out, context insulation, and fresh-eyes review.
+  Don't wait to be told; the shapes are listed in PRIMER. The new
+  agent boots in its own subprocess with the same default tool set
+  as you.
   - One job, one expertise → `spawn_subagent` then `call_subagent`
     to block on the result inline.
   - Several jobs in parallel → spawn one per job, fire
@@ -41,8 +42,9 @@ by the API; this is about *when and how* to use them.
     pause until at least one is back. Async replies arrive on your
     next turn as user-role messages of the form
     `[subagent <name> (<id>) reports]: <text>` — read the inbox.
-  - Don't spawn for work you could do directly. Each subagent burns
-    its own tokens.
+  - Skip subagents only when the job is small enough to finish
+    before one boots, or so tangled in your live context that
+    re-briefing costs more than doing it yourself.
   - `terminate_subagent` when done. Live subagents count against
     the fanout cap (default 5; depth cap default 3). Caps refuse
     with a `<refused: …>` marker — adapt, don't retry.

--- a/pyagent/llms/__init__.py
+++ b/pyagent/llms/__init__.py
@@ -1,13 +1,112 @@
-"""LLM provider clients and the interface they share."""
+"""LLM provider clients and the interface they share.
 
-from typing import Any, Protocol
+Adding a provider: append one entry to `PROVIDERS`. The same registry
+drives `get_client()` dispatch and env-var auto-detection — there is no
+second place to update.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Callable, Protocol
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    """One LLM provider's registration data.
+
+    Attributes:
+        name: Provider identifier used in `--model` ("anthropic", "openai", ...).
+        env_vars: API-key environment variables, in the order the client
+            checks them. The first one set is enough to auto-detect this
+            provider. Empty tuple = no env requirement (e.g. local stub).
+        default_model: Concrete model name the client picks when no model
+            is specified. Mirrors the client's own constructor default; kept
+            here so callers (e.g. the session-header printer) can format
+            the resolved string without instantiating the client.
+        factory: Callable that takes optional `model=` and returns a client.
+            The actual SDK import happens here, so unused providers don't
+            pay the import cost.
+    """
+
+    name: str
+    env_vars: tuple[str, ...]
+    default_model: str
+    factory: Callable[..., "LLMClient"]
+
+
+def _anthropic_factory(**kw: Any) -> "LLMClient":
+    from pyagent.llms.anthropic import AnthropicClient
+
+    return AnthropicClient(**kw)
+
+
+def _openai_factory(**kw: Any) -> "LLMClient":
+    from pyagent.llms.openai import OpenAIClient
+
+    return OpenAIClient(**kw)
+
+
+def _gemini_factory(**kw: Any) -> "LLMClient":
+    from pyagent.llms.gemini import GeminiClient
+
+    return GeminiClient(**kw)
+
+
+def _pyagent_factory(**kw: Any) -> "LLMClient":
+    from pyagent.llms.pyagent import EchoClient, LoremClient
+
+    name = kw.get("model")
+    stubs = {"echo": EchoClient, "loremipsum": LoremClient}
+    cls = stubs.get(name) if name else EchoClient
+    if cls is None:
+        raise ValueError(
+            f"Unknown pyagent stub {name!r} (expected: {sorted(stubs)})"
+        )
+    return cls() if not name else cls(model=name)
+
+
+# Order matters: auto-detection picks the first provider whose env_vars
+# are satisfied. Real providers come before the local stub so a user
+# with a real API key never gets the echo stub by accident.
+PROVIDERS: list[ProviderSpec] = [
+    ProviderSpec(
+        name="anthropic",
+        env_vars=("ANTHROPIC_API_KEY",),
+        default_model="claude-sonnet-4-6",
+        factory=_anthropic_factory,
+    ),
+    ProviderSpec(
+        name="openai",
+        env_vars=("OPENAI_API_KEY",),
+        default_model="gpt-4o",
+        factory=_openai_factory,
+    ),
+    ProviderSpec(
+        name="gemini",
+        env_vars=("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+        default_model="gemini-2.5-flash",
+        factory=_gemini_factory,
+    ),
+    ProviderSpec(
+        name="pyagent",
+        env_vars=(),
+        default_model="echo",
+        factory=_pyagent_factory,
+    ),
+]
+
+
+def _by_name(name: str) -> ProviderSpec | None:
+    for p in PROVIDERS:
+        if p.name == name:
+            return p
+    return None
 
 
 def get_client(model: str) -> "LLMClient":
     """Resolve a "provider/model" string to a concrete LLMClient instance.
-
-    The model name is optional; when omitted, each client's own default model
-    is used.
 
     Examples:
         get_client("anthropic")                     # AnthropicClient defaults
@@ -16,47 +115,44 @@ def get_client(model: str) -> "LLMClient":
         get_client("gemini/gemini-2.5-flash")
         get_client("pyagent/echo")                  # local stub, no API call
 
-    Args:
-        model: Provider name, optionally followed by "/model-name". Provider
-            must be one of "anthropic", "openai", "gemini", or "pyagent".
-
-    Returns:
-        A client instance for the requested provider.
-
     Raises:
         ValueError: If the provider is unknown.
     """
     provider, _, name = model.partition("/")
+    spec = _by_name(provider)
+    if spec is None:
+        known = ", ".join(p.name for p in PROVIDERS)
+        raise ValueError(f"Unknown provider {provider!r} (expected: {known})")
     kwargs = {"model": name} if name else {}
+    return spec.factory(**kwargs)
 
-    if provider == "anthropic":
-        from pyagent.llms.anthropic import AnthropicClient
 
-        return AnthropicClient(**kwargs)
-    if provider == "openai":
-        from pyagent.llms.openai import OpenAIClient
+def resolve_model(model: str) -> str:
+    """Return 'provider/model-name' with the bundled default filled in
+    for any unspecified part. No SDK imports, no client construction.
 
-        return OpenAIClient(**kwargs)
-    if provider == "gemini":
-        from pyagent.llms.gemini import GeminiClient
+    Unknown providers are returned unchanged so `get_client` can raise.
+    """
+    provider, _, name = model.partition("/")
+    spec = _by_name(provider)
+    if spec is None:
+        return model
+    return f"{provider}/{name or spec.default_model}"
 
-        return GeminiClient(**kwargs)
-    if provider == "pyagent":
-        from pyagent.llms.pyagent import EchoClient, LoremClient
 
-        stubs = {"echo": EchoClient, "loremipsum": LoremClient}
-        cls = stubs.get(name) if name else EchoClient
-        if cls is None:
-            raise ValueError(
-                f"Unknown pyagent stub {name!r} "
-                f"(expected: {sorted(stubs)})"
-            )
-        return cls() if not name else cls(model=name)
+def auto_detect_provider() -> ProviderSpec | None:
+    """Return the first provider whose env_vars are satisfied in the
+    current process environment, or None if none are.
 
-    raise ValueError(
-        f"Unknown provider {provider!r} "
-        "(expected anthropic, openai, gemini, pyagent)"
-    )
+    Providers with no env_vars (local stubs) are skipped — they would
+    always match and would shadow real providers.
+    """
+    for spec in PROVIDERS:
+        if not spec.env_vars:
+            continue
+        if any(os.environ.get(v) for v in spec.env_vars):
+            return spec
+    return None
 
 
 class LLMClient(Protocol):

--- a/pyagent/skills/__init__.py
+++ b/pyagent/skills/__init__.py
@@ -18,44 +18,30 @@ existing shell tool. Nothing is imported into the agent's process —
 each script call is a subprocess, gated by the same Bash safety as
 any other shell command.
 
-Resolution order (first wins, local overrides everything):
-  1. ./.pyagent/skills/<name>/SKILL.md       — project-local
-  2. <config-dir>/skills/<name>/SKILL.md     — user-installed
+Resolution order (later wins, so project-local overrides everything):
+  1. <package>/skills/<name>/SKILL.md         — bundled with pyagent
+  2. <config-dir>/skills/<name>/SKILL.md      — user-installed
+  3. ./.pyagent/skills/<name>/SKILL.md        — project-local
 
-Bundled skills live at `pyagent/skills/<name>/` inside the package.
-They are normally opt-in via `pyagent-skills install`, with one
-exception: a bundled skill whose frontmatter sets `auto_install: true`
-is seeded into `<config-dir>/skills/<name>/` on first run.
-
-Auto-install is tracked in `<config-dir>/skills/.auto_installed`,
-which lists the bundled skill names that have already been seeded.
-On launch, any flagged bundled skill *not* in that file gets copied
-in (and added to the file). Uninstalling a seeded skill removes the
-directory but leaves the line — so it stays uninstalled across
-restarts. To opt back in, either rerun `pyagent-skills install
-<name>` or delete the matching line from `.auto_installed`.
-
-Note: `.auto_installed` lives in the user's writable config dir, so
-the agent can technically modify it through its normal file/shell
-tools. The marker is a convention to keep auto-install behavior
-predictable, not a security boundary.
+Bundled skills load directly from the installed package. Upgrading
+pyagent updates them for free. To customize a bundled skill, copy its
+directory into the user-installed or project-local root and edit
+there — the override takes precedence.
 """
 
 from __future__ import annotations
 
 import logging
-import shutil
 from dataclasses import dataclass
 from importlib import resources
 from pathlib import Path
 
-from pyagent import paths
+from pyagent import config, paths
 
 logger = logging.getLogger(__name__)
 
 LOCAL_SKILLS_DIR = Path(".pyagent") / "skills"
 PACKAGE_SKILLS_PKG = "pyagent.skills"
-_AUTO_INSTALLED_MARKER = ".auto_installed"
 
 
 @dataclass
@@ -125,96 +111,28 @@ def _bundled_root() -> Path:
     return Path(str(resources.files(PACKAGE_SKILLS_PKG)))
 
 
-_AUTO_INSTALLED_HEADER = (
-    "# Bundled skills that have been auto-seeded into this directory.\n"
-    "# Each line is a skill name. A name listed here is treated as\n"
-    "# already-handled and will NOT be re-seeded on subsequent runs,\n"
-    "# even if the matching directory is removed. Delete a line to\n"
-    "# opt that skill back into auto-install on next launch.\n"
-)
-
-
-def _read_auto_installed(target_root: Path) -> set[str]:
-    marker = target_root / _AUTO_INSTALLED_MARKER
-    if not marker.exists():
+def _enabled_bundled_names() -> set[str]:
+    """Names of built-in skills the user has opted into via config.toml."""
+    cfg = config.load()
+    raw = cfg.get("built_in_skills_enabled", [])
+    if not isinstance(raw, list):
+        logger.warning("config.built_in_skills_enabled is not a list; ignoring")
         return set()
-    try:
-        text = marker.read_text()
-    except OSError as e:
-        logger.warning("could not read %s: %s", marker, e)
-        return set()
-    return {
-        line.strip()
-        for line in text.splitlines()
-        if line.strip() and not line.lstrip().startswith("#")
-    }
-
-
-def _write_auto_installed(target_root: Path, names: set[str]) -> None:
-    marker = target_root / _AUTO_INSTALLED_MARKER
-    target_root.mkdir(parents=True, exist_ok=True)
-    body = "\n".join(sorted(names))
-    marker.write_text(_AUTO_INSTALLED_HEADER + body + ("\n" if body else ""))
-
-
-def _seed_auto_install_skills() -> None:
-    """Seed bundled skills with `auto_install: true` into the user's
-    config-dir skills folder.
-
-    A skill is seeded the first time it's seen. After that, its name
-    is recorded in `<config-dir>/skills/.auto_installed` and the
-    seeder will skip it forever — even if the destination directory
-    has been deleted via `pyagent-skills uninstall`. Removing the
-    line from `.auto_installed` (or running `pyagent-skills install`
-    manually) is how a user opts back in.
-
-    Errors are logged and swallowed — a broken seed must never block
-    discovery of the user's other skills.
-    """
-    try:
-        bundled = _bundled_root()
-    except (ModuleNotFoundError, FileNotFoundError):
-        return
-    if not bundled.exists():
-        return
-    target_root = paths.config_dir() / "skills"
-    seeded = _read_auto_installed(target_root)
-    changed = False
-    for skill_md in bundled.glob("*/SKILL.md"):
-        try:
-            fm, _ = _parse_frontmatter(skill_md.read_text())
-        except OSError as e:
-            logger.warning("auto_install scan: %s unreadable: %s", skill_md, e)
-            continue
-        if fm.get("auto_install", "").strip().lower() != "true":
-            continue
-        name = fm.get("name") or skill_md.parent.name
-        if name in seeded:
-            continue
-        dest = target_root / name
-        if not dest.exists():
-            try:
-                target_root.mkdir(parents=True, exist_ok=True)
-                shutil.copytree(skill_md.parent, dest)
-            except OSError as e:
-                logger.warning("auto_install seed of %s failed: %s", name, e)
-                continue
-            logger.info("seeded bundled skill %s -> %s", name, dest)
-        seeded.add(name)
-        changed = True
-    if changed:
-        try:
-            _write_auto_installed(target_root, seeded)
-        except OSError as e:
-            logger.warning(
-                "could not update %s: %s", target_root / _AUTO_INSTALLED_MARKER, e
-            )
+    return {n for n in raw if isinstance(n, str)}
 
 
 def discover() -> dict[str, Skill]:
-    """Discover all installed skills. Local overrides user."""
-    _seed_auto_install_skills()
-    skills = _scan_dir(paths.config_dir() / "skills")
+    """Discover all skills across the three tiers. Later tiers win.
+
+    Bundled skills are filtered against `built_in_skills_enabled` in
+    config.toml — only explicitly enabled ones appear. User-installed
+    and project-local tiers are unfiltered (their presence on disk is
+    the enablement).
+    """
+    bundled = _scan_dir(_bundled_root())
+    enabled = _enabled_bundled_names()
+    skills = {n: s for n, s in bundled.items() if n in enabled}
+    skills.update(_scan_dir(paths.config_dir() / "skills"))
     skills.update(_scan_dir(LOCAL_SKILLS_DIR))
     return skills
 
@@ -231,6 +149,11 @@ def catalog(skills: dict[str, Skill]) -> str:
         "load that skill's instructions. The call is idempotent — if a "
         "long session has pushed the body out of working memory or you "
         "are unsure of a script's exact syntax, just call it again.",
+        "",
+        "This list re-renders before every model call, so a skill you "
+        "or the user just installed shows up on the next call — no "
+        "session restart needed. The body still requires `read_skill` "
+        "to load.",
         "",
     ]
     for skill in sorted(skills.values(), key=lambda s: s.name):

--- a/pyagent/skills/write-skill/SKILL.md
+++ b/pyagent/skills/write-skill/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: write-skill
 description: Author a new pyagent skill — directory layout, SKILL.md frontmatter, helper scripts, and where to put it. Load this when the user asks you to create a skill.
-auto_install: true
 ---
 
 # Writing a pyagent skill
@@ -26,14 +25,27 @@ in the frontmatter. Hyphens are fine (`pdf-extract`, `git-cleanup`).
 
 ## Where to put `<root>`
 
-Pick based on scope. Discovery order is local-wins:
+Pick based on scope. Discovery is three-tier; later tiers override
+earlier ones:
 
-- `./.pyagent/skills/` — **project-local**. Lives in the user's working
-  directory. Overrides any user-wide skill of the same name.
+- `<package>/skills/` — **bundled** with pyagent itself. Read-only
+  from the agent's perspective; you don't author here. Updated by
+  upgrading the pyagent install. Bundled skills are gated by
+  `built_in_skills_enabled` in `<config-dir>/config.toml` — only
+  listed ones load. (Skills you author land in one of the two tiers
+  below, which are never gated.)
 - `<config-dir>/skills/` — **user-wide**. Available across every
   project the user runs pyagent in. The `<config-dir>` is OS-dependent
   (`~/.config/pyagent/` on Linux,
   `~/Library/Application Support/pyagent/` on macOS).
+- `./.pyagent/skills/` — **project-local**. Lives in the user's working
+  directory. Overrides user-wide and bundled skills of the same name.
+
+A user-wide or project-local skill with the same name as a bundled
+one shadows the bundled copy entirely — that's how customization
+works: copy the bundled directory to one of the override roots and
+edit there. The override loads regardless of whether the bundled
+skill is in `built_in_skills_enabled`.
 
 If you don't know which the user wants, ask once. Don't guess on
 behalf of "future projects".
@@ -56,15 +68,6 @@ Fields:
   domain. Bad: "Helper for PDF stuff." Good: "Extract text or tables
   from a PDF file on disk. Use when the user provides a .pdf path and
   wants its contents."
-- **auto_install** (optional, bundled skills only) — Set to `true` on
-  a bundled skill (one shipped under `pyagent/skills/<name>/` in the
-  package) to have it seeded into `<config-dir>/skills/<name>/` on
-  first run. Auto-install is one-shot per name: pyagent records seeded
-  names in `<config-dir>/skills/.auto_installed` and never re-seeds a
-  listed name, so `pyagent-skills uninstall <name>` keeps it
-  uninstalled across restarts. Has no meaning on user-installed or
-  project-local skills. The marker file falls under PRIMER's general
-  rule on pyagent config — leave it to the user.
 
 There is no `tools:` field. Skills don't register Python functions as
 agent tools — they ship CLI scripts the agent runs via the shell tool.
@@ -119,10 +122,10 @@ Conventions:
 
 ## Activation lifecycle
 
-1. Every turn, pyagent rescans the local and user roots, reads each
-   `SKILL.md` it finds, and rebuilds the catalog injected into the
-   system prompt. A skill authored or installed mid-session shows up
-   on the next turn — no restart needed.
+1. Before every model call, pyagent rescans all three roots (bundled,
+   user, project-local) and rebuilds the catalog injected into the
+   system prompt. A skill authored mid-session shows up on the next
+   inner call — no restart needed.
 2. When the agent calls `read_skill(<name>)`, the body is returned as
    the tool result, prefixed with the skill's resolved directory
    path. The lookup also reads from the live registry, so a freshly
@@ -143,10 +146,9 @@ When the user asks for a new skill, walk through:
    body. Keep the body focused — instructions, not a manual.
 4. **Write `scripts/cli.py`** (if applicable). Argparse subcommands,
    stdout output, executable-style entry point.
-5. **No restart needed** — the next turn's catalog rescan will pick
-   up the new skill. Mention the skill to the user so they know it's
-   available.
-6. If the user wants to package it for distribution: see the
-   `pyagent-skills install` mechanism — copying a directory under
-   `pyagent/skills/` in the source tree makes it bundled. That's a
-   developer-side workflow, not something to do from the agent.
+5. **No restart needed** — the next inner call's catalog rescan will
+   pick up the new skill. Mention the skill to the user so they know
+   it's available.
+6. If the user wants to ship it as a built-in: copy the directory
+   under `pyagent/skills/` in the source tree. That's a developer-side
+   workflow, not something to do from the agent.

--- a/pyagent/skills_cli.py
+++ b/pyagent/skills_cli.py
@@ -1,35 +1,21 @@
-"""`pyagent-skills` — manage installed skills.
+"""`pyagent-skills` — inspect and remove skills.
 
-Bundled skills live under `pyagent/skills/<name>/` in this package.
-Users opt in by running `pyagent-skills install <name>`, which copies
-the bundled directory into `<config-dir>/skills/<name>/` so the agent
-discovers it on the next run.
+Bundled skills live under `pyagent/skills/<name>/` in the package and
+load directly from there at runtime — no install step. To customize a
+bundled skill, copy its directory into `<config-dir>/skills/` (user
+scope) or `./.pyagent/skills/` (project scope) and edit. The override
+takes precedence at discovery time.
 """
 
 from __future__ import annotations
 
 import shutil
-from importlib import resources
 from pathlib import Path
 
 import click
 
 from pyagent import paths
 from pyagent import skills as skills_mod
-
-_BUNDLED_PKG = "pyagent.skills"
-
-
-def _bundled_root() -> Path:
-    """Locate the on-disk path of `pyagent/skills/`. Works for editable
-    installs and normal site-packages — both expose a real Path.
-    """
-    root = resources.files(_BUNDLED_PKG)
-    return Path(str(root))
-
-
-def _bundled_skills() -> dict[str, skills_mod.Skill]:
-    return skills_mod._scan_dir(_bundled_root())
 
 
 def _installed_root() -> Path:
@@ -38,68 +24,59 @@ def _installed_root() -> Path:
 
 @click.group()
 def main() -> None:
-    """Manage pyagent skills (catalog the agent can load on demand)."""
+    """Inspect and remove pyagent skills."""
 
 
 @main.command("list")
 def list_cmd() -> None:
-    """List bundled and installed skills."""
-    bundled = _bundled_skills()
+    """List skills across all three tiers, with state annotations."""
+    bundled = skills_mod._scan_dir(skills_mod._bundled_root())
     installed = skills_mod._scan_dir(_installed_root())
     local = skills_mod._scan_dir(skills_mod.LOCAL_SKILLS_DIR)
+    enabled = skills_mod._enabled_bundled_names()
 
-    def render(label: str, found: dict[str, skills_mod.Skill]) -> None:
-        click.secho(label, bold=True)
-        if not found:
-            click.echo("  (none)")
-            return
-        for skill in sorted(found.values(), key=lambda s: s.name):
+    overridden_in_bundled = {n for n in bundled if n in installed or n in local}
+    overridden_in_installed = {n for n in installed if n in local}
+
+    click.secho("Bundled (ships with pyagent):", bold=True)
+    if bundled:
+        for skill in sorted(bundled.values(), key=lambda s: s.name):
+            state = "enabled" if skill.name in enabled else "disabled"
+            tags = [state]
+            if skill.name in overridden_in_bundled:
+                tags.append("overridden")
+            click.echo(f"  [{', '.join(tags)}] {skill.name}: {skill.description}")
+    else:
+        click.echo("  (none)")
+    click.echo()
+    click.echo(
+        "  Enable a bundled skill by adding its name to "
+        "built_in_skills_enabled in config.toml."
+    )
+    click.echo(
+        "  Run `pyagent-config init` to create the file with documented defaults,"
+    )
+    click.echo(f"  then edit {paths.config_dir() / 'config.toml'}.")
+    click.echo()
+
+    click.secho(f"User ({_installed_root()}):", bold=True)
+    if installed:
+        for skill in sorted(installed.values(), key=lambda s: s.name):
+            tag = "  (overridden)" if skill.name in overridden_in_installed else ""
+            click.echo(f"  {skill.name}{tag}: {skill.description}")
+    else:
+        click.echo("  (none)")
+    click.echo()
+
+    click.secho(
+        f"Project-local ({skills_mod.LOCAL_SKILLS_DIR}, wins all ties):",
+        bold=True,
+    )
+    if local:
+        for skill in sorted(local.values(), key=lambda s: s.name):
             click.echo(f"  {skill.name}: {skill.description}")
-
-    render("Bundled (run `pyagent-skills install <name>` to enable):", bundled)
-    click.echo()
-    render(f"Installed ({_installed_root()}):", installed)
-    click.echo()
-    render(f"Project-local ({skills_mod.LOCAL_SKILLS_DIR}, overrides installed):", local)
-
-
-@main.command("install")
-@click.argument("name")
-@click.option(
-    "--local",
-    "-l",
-    is_flag=True,
-    help=(
-        "Install into the current workspace's ./.pyagent/skills/ "
-        "instead of the user config dir. Workspace skills override "
-        "config-dir skills of the same name."
-    ),
-)
-@click.option(
-    "--force",
-    is_flag=True,
-    help="Overwrite an existing installation of the same skill.",
-)
-def install_cmd(name: str, local: bool, force: bool) -> None:
-    """Copy a bundled skill into the user config dir (or this workspace)."""
-    src = _bundled_root() / name
-    if not (src / "SKILL.md").exists():
-        available = ", ".join(sorted(_bundled_skills())) or "(none)"
-        raise click.ClickException(
-            f"no bundled skill named {name!r}. available: {available}"
-        )
-    root = skills_mod.LOCAL_SKILLS_DIR if local else _installed_root()
-    dest = root / name
-    if dest.exists():
-        if not force:
-            raise click.ClickException(
-                f"{dest} already exists. pass --force to overwrite."
-            )
-        shutil.rmtree(dest)
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(src, dest)
-    scope = "workspace" if local else "user"
-    click.echo(f"installed {name} ({scope}) -> {dest}")
+    else:
+        click.echo("  (none)")
 
 
 @main.command("uninstall")
@@ -117,7 +94,10 @@ def install_cmd(name: str, local: bool, force: bool) -> None:
     help="Uninstall every skill in the chosen scope.",
 )
 def uninstall_cmd(name: str | None, local: bool, all_: bool) -> None:
-    """Remove an installed skill."""
+    """Remove a user-installed or project-local skill.
+
+    Cannot remove bundled skills (they ship with the package).
+    """
     root = skills_mod.LOCAL_SKILLS_DIR if local else _installed_root()
     scope = "workspace" if local else "user"
 

--- a/pyagent/tools.py
+++ b/pyagent/tools.py
@@ -290,11 +290,6 @@ _DANGEROUS_PATTERNS: list[tuple[str, str]] = [
         "force push to main/master",
     ),
     (r"\bchmod\s+-R\s+[0-7]{3,4}\s+/(?:\s|$)", "recursive chmod on /"),
-    (
-        r"(?:>\s*\S*|\b(?:rm|mv|cp|tee|sed\s+-i\S*)\s+[^|;&]*)"
-        r"\.auto_installed\b",
-        "tampering with the skills auto-install marker",
-    ),
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 
 [project.scripts]
 pyagent = "pyagent.cli:main"
+pyagent-config = "pyagent.config_cli:main"
 pyagent-skills = "pyagent.skills_cli:main"
 pyagent-sessions = "pyagent.sessions_cli:main"
 

--- a/tests/smoke_ctrlc.py
+++ b/tests/smoke_ctrlc.py
@@ -47,7 +47,6 @@ def main() -> None:
             str(pyagent_bin),
             "--model",
             "pyagent/echo",
-            "--no-memory-pass-on-exit",
         ],
         cwd=str(work),
         stdin=subprocess.PIPE,


### PR DESCRIPTION
## Summary

Two unrelated commits bundled — the larger restructure plus a small earlier nudge to the persona around subagent use.

### Restructure (ce412e1)

**Skills**
- Drop the `auto_install` seeding mechanism; bundled skills load directly from the package, no copies on disk, no drift
- 3-tier discovery: bundled < user-installed < project-local
- Catalog re-renders before every model call, so a skill authored mid-run shows up on the next inner call without restart
- Bundled tier gated by `built_in_skills_enabled` in `config.toml`; only `write-skill` is on by default

**Config**
- New `pyagent-config` CLI: `show`, `defaults`, `init`. `init` writes a documented commented-out template to `config.toml` if absent
- Schema gains `default_model` and `built_in_skills_enabled`

**Model selection**
- `--model` is now optional. Precedence: `--model` > `config.default_model` > auto-detect from API-key env vars > pointed error
- Provider registry in `llms/__init__.py` is the single source of truth for dispatch, defaults, and env-var detection. Adding a provider = appending one tuple
- Session header prints the resolved provider/model

**Reset flags**
- New `--reset-skills` (touches user-installed tier only; workspace is left alone)
- Destructive resets (USER, MEMORY, skills) prompt with a single consolidated confirmation; `--yes` / `-y` bypasses
- `--reset-all` now actually means all

**End-of-session memory pass**
- Off by default. Opt in with `--memory-pass-on-exit`

### Subagent nudge (4e06813)

Persona update encouraging proactive subagent spawning when the work shape fits.

## Test plan

- [x] `pyagent` with no `--model` and no API keys errors with the helpful message listing env vars
- [x] `pyagent` with only `OPENAI_API_KEY` set picks openai (header confirms)
- [x] `pyagent-config init` writes a template; rerunning is a no-op
- [x] `pyagent-config show` reflects merged defaults + user overrides
- [x] `pyagent-skills list` shows `[enabled]` / `[disabled]` per bundled skill
- [x] Authoring a skill mid-session is visible on the next user message without restart
- [x] `--reset-all` prompts with the consolidated list and aborts cleanly on `n`

## Known follow-ups

- No tests yet for the new resolver/registry/discover-filter; worth a small follow-up
- `_render_toml_value` doesn't escape newlines/tabs (no current schema uses them)
- `built_in_skills_enabled` uses list-replace semantics; an additive form might be friendlier later