### PR TITLE
Add subagent roles, layered system prompts, and /model command

### DIFF
--- a/pyagent/agent_proc.py
+++ b/pyagent/agent_proc.py
@@ -40,6 +40,7 @@ from typing import Any
 from pyagent import paths
 from pyagent import permissions
 from pyagent import protocol
+from pyagent import roles as roles_mod
 from pyagent import skills as skills_mod
 from pyagent import subagent as subagent_mod
 from pyagent import tools as agent_tools
@@ -250,11 +251,40 @@ class _ChildState:
                     pass
         elif kind == "permission_response":
             self.permission_replies.put(event)
+        elif kind == "set_model":
+            self._handle_set_model(event.get("model", ""))
         elif kind == "shutdown":
             self.shutdown_event.set()
             self.work_queue.put({"type": "shutdown"})
         else:
             logger.warning("child: unknown event type %r", kind)
+
+    def _handle_set_model(self, model: str) -> None:
+        """Swap the agent's LLM client to a new model.
+
+        Mid-turn swaps are tolerated — `_call_llm` reads `agent.client`
+        fresh on each turn, so the next API call uses the new client.
+        Construction failures (unknown provider, missing API key) are
+        surfaced as `info` events; the existing client stays in place.
+        """
+        if self.agent is None or not model:
+            return
+        try:
+            new_client = get_client(model)
+        except Exception as e:
+            self.send(
+                "info",
+                level="warn",
+                message=(
+                    f"set_model {model!r} failed: "
+                    f"{type(e).__name__}: {e}"
+                ),
+            )
+            return
+        self.agent.client = new_client
+        self.send(
+            "info", level="info", message=f"model swapped to {model}"
+        )
 
     def _handle_subagent_event(self, sid: str, conn: Connection) -> None:
         try:
@@ -361,44 +391,54 @@ def _register_tools(
     parent_session: Session | None = None,
     base_config: dict[str, Any] | None = None,
     allow_meta: bool = False,
+    allowlist: list[str] | None = None,
 ) -> None:
     """Register the default tool set on `agent`.
 
-    Kept in lockstep with cli.py's previous in-process registration.
-    `allow_meta=True` also registers spawn_subagent / call_subagent /
-    terminate_subagent — used for root agents and (eventually) for
-    subagents once recursion lands.
+    `allow_meta=True` registers spawn_subagent / call_subagent /
+    terminate_subagent on top of the default set — used for root
+    agents and for subagents whose role permits further spawning.
+
+    `allowlist` (when non-None) restricts registration to only the
+    named tools — used for role-scoped subagents like a read-only
+    validator. Names not in the default set are silently ignored.
+    The allowlist *cannot* add tools that don't exist; it can only
+    narrow.
     """
-    agent.add_tool("read_file", agent_tools.read_file, auto_offload=False)
-    agent.add_tool("write_file", agent_tools.write_file)
-    agent.add_tool("list_directory", agent_tools.list_directory)
-    agent.add_tool("grep", agent_tools.grep)
-    agent.add_tool("execute", agent_tools.execute)
-    agent.add_tool("fetch_url", agent_tools.fetch_url)
-    agent.add_tool("read_ledger", agent_tools.read_ledger, auto_offload=False)
-    agent.add_tool("write_ledger", agent_tools.write_ledger)
-    agent.add_tool("read_skill", skills_mod.read_skill, auto_offload=False)
+    def _add(name: str, fn: Any, **kw: Any) -> None:
+        if allowlist is None or name in allowlist:
+            agent.add_tool(name, fn, **kw)
+
+    _add("read_file", agent_tools.read_file, auto_offload=False)
+    _add("write_file", agent_tools.write_file)
+    _add("list_directory", agent_tools.list_directory)
+    _add("grep", agent_tools.grep)
+    _add("execute", agent_tools.execute)
+    _add("fetch_url", agent_tools.fetch_url)
+    _add("read_ledger", agent_tools.read_ledger, auto_offload=False)
+    _add("write_ledger", agent_tools.write_ledger)
+    _add("read_skill", skills_mod.read_skill, auto_offload=False)
     if allow_meta:
         assert state is not None and parent_session is not None and base_config is not None
-        agent.add_tool(
+        _add(
             "spawn_subagent",
             subagent_mod.make_spawn_subagent(
                 state, agent, parent_session, base_config
             ),
         )
-        agent.add_tool(
+        _add(
             "call_subagent",
             subagent_mod.make_call_subagent(state, agent),
         )
-        agent.add_tool(
+        _add(
             "call_subagent_async",
             subagent_mod.make_call_subagent_async(state, agent),
         )
-        agent.add_tool(
+        _add(
             "wait_for_subagents",
             subagent_mod.make_wait_for_subagents(state, agent),
         )
-        agent.add_tool(
+        _add(
             "terminate_subagent",
             subagent_mod.make_terminate_subagent(state, agent),
         )
@@ -409,10 +449,12 @@ def _bootstrap(
 ) -> tuple[Agent, Session]:
     """Replicate the CLI's startup setup inside the child process.
 
-    Handles both root agents (the original Phase 2 path) and subagents
-    (new in Phase 3): subagents have `is_subagent=True` in the config,
-    use a custom session_root, and skip the SystemPromptBuilder in
-    favor of the system_prompt_override string from spawn_subagent.
+    Handles both root agents and subagents. Subagents have
+    `is_subagent=True` in the config and use a custom session_root.
+    Both build a `SystemPromptBuilder`; the subagent path additionally
+    layers a `role_body` (from the spawn-time role definition) and a
+    `task_body` (from the spawn-time `system_prompt` argument) on top
+    of the universal SOUL/TOOLS/PRIMER base.
     """
     # Close stdin so a buggy library or tool that calls input() can't
     # steal raw keystrokes from the CLI's CancelWatcher (which is the
@@ -435,6 +477,16 @@ def _bootstrap(
 
     client = get_client(config["model"])
 
+    # role_meta_tools defaults True so non-role spawns and root agents
+    # keep the existing fan-out behavior. Roles can disable meta-tools
+    # to mark a subagent as a leaf (validator, summarizer, etc.).
+    allow_meta = bool(config.get("role_meta_tools", True))
+    # role_tools is the allowlist; None means inherit the default set.
+    allowlist = config.get("role_tools")
+    # Leaf subagents skip the role catalog — showing roles they can't
+    # spawn is misleading prose.
+    catalog_for_roles = roles_mod.catalog if allow_meta else ""
+
     if is_subagent:
         session = Session(
             session_id=config["session_id"],
@@ -449,8 +501,14 @@ def _bootstrap(
             )
         except OSError:
             pass
-        system: str | SystemPromptBuilder = config.get(
-            "system_prompt_override", ""
+        system: SystemPromptBuilder = SystemPromptBuilder(
+            soul=Path(config["soul_path"]),
+            tools=Path(config["tools_path"]),
+            primer=Path(config["primer_path"]),
+            skills_catalog=skills_mod.live_catalog,
+            roles_catalog=catalog_for_roles,
+            role_body=config.get("role_body", ""),
+            task_body=config.get("task_body", ""),
         )
     else:
         session = Session(session_id=config["session_id"])
@@ -459,6 +517,7 @@ def _bootstrap(
             tools=Path(config["tools_path"]),
             primer=Path(config["primer_path"]),
             skills_catalog=skills_mod.live_catalog,
+            roles_catalog=catalog_for_roles,
         )
 
     agent = Agent(
@@ -471,21 +530,19 @@ def _bootstrap(
     # status (sync vs async mode) when routing turn_complete events.
     state.agent = agent
 
-    # Root agents get the meta-tools so they can spawn subagents.
-    # Subagents (this iteration) get the default tools but no meta.
-    # Meta-tools registered on every agent now — root and subagents
-    # alike. Recursion is bounded by `max_depth` in the config (the
-    # spawn tool refuses if `agent.depth + 1 > max_depth`), which is
-    # the only safety mechanism that needed to be present. The
-    # subagent's session_root nests under its parent's session dir
-    # automatically, so a sub-sub-agent ends up at
-    # `<root>/subagents/X/subagents/Y/`.
+    # Meta-tools registered when the role allows further spawning.
+    # Recursion is bounded by `max_depth` in config (the spawn tool
+    # refuses if `agent.depth + 1 > max_depth`). Roles with
+    # `meta_tools = false` mark a subagent as a leaf — no spawn /
+    # call / terminate registered. Tool allowlist further narrows
+    # the default set when a role has `tools = [...]`.
     _register_tools(
         agent,
         state=state,
         parent_session=session,
         base_config=config,
-        allow_meta=True,
+        allow_meta=allow_meta,
+        allowlist=allowlist,
     )
 
     agent.conversation = session.load_history()
@@ -640,15 +697,15 @@ def child_main(config: dict[str, Any], conn: Connection) -> None:
       - model: provider string, optionally `provider/model-name`
       - session_id: existing session id (already created by upstream)
       - soul_path / tools_path / primer_path: resolved persona paths
-        (root agent only — subagents use `system_prompt_override`)
+        (inherited unchanged by subagents — they use the same SOUL,
+        TOOLS, and PRIMER as the root)
       - approved_paths: list[str] replayed via `pre_approve` so the
         user isn't re-prompted for paths already accepted upstream
-      - is_subagent: bool. When true, this is a Phase 3 subagent:
+      - is_subagent: bool. When true, this is a subagent:
         - session lives at `session_root`
-        - system prompt is `system_prompt_override`, NOT the persona
-          file stack (the spawning agent gets to define a fresh persona)
-        - depth, parent_session_id are recorded on disk
-        - meta-tools (spawn/call/terminate) are NOT registered
+        - depth and parent_session_id are recorded on disk
+        - role_body (optional) and task_body are layered onto the
+          universal SOUL/TOOLS/PRIMER base by SystemPromptBuilder
     """
     _set_parent_death_signal()
     _ignore_sigint()

--- a/pyagent/cli.py
+++ b/pyagent/cli.py
@@ -19,6 +19,7 @@ from pyagent import llms
 from pyagent import paths
 from pyagent import permissions
 from pyagent import protocol
+from pyagent import roles
 from pyagent.cancel import CancelWatcher
 from pyagent.session import Session
 
@@ -362,6 +363,46 @@ def _prompt_permission(
         sys.stderr.write(
             f"  unrecognized: {answer!r} — please answer y, n, or a\n"
         )
+
+
+def _handle_model_command(
+    parent_conn: Connection, line: str, current_model: str
+) -> str:
+    """Parse `/model <spec>` and (on success) ask the child to swap.
+
+    `spec` is either a role name (resolved via `roles.resolve`) or a
+    raw provider/model string. On bad input, prints an error and
+    returns `current_model` unchanged. On success, sends a `set_model`
+    event upstream and returns the resolved model string for the
+    caller to adopt as its display value.
+
+    The CLI updates its display optimistically — if the child fails
+    to construct the new client (e.g. missing API key), it emits an
+    `info` event with the error and leaves its existing client in
+    place; the caller will see the message on the next turn.
+    """
+    parts = line.split(maxsplit=1)
+    if len(parts) < 2:
+        console.print(
+            "[red]usage: /model <provider[/model-name]> | <role-name>[/red]"
+        )
+        return current_model
+    spec = parts[1].strip()
+    try:
+        resolved, _ = roles.resolve(spec)
+    except ValueError as e:
+        console.print(f"[red]bad model spec {spec!r}: {e}[/red]")
+        return current_model
+    if not resolved:
+        console.print("[red]empty model spec[/red]")
+        return current_model
+    try:
+        protocol.send(parent_conn, "set_model", model=resolved)
+    except (BrokenPipeError, OSError):
+        console.print("[red]agent subprocess died[/red]")
+        return current_model
+    console.print(f"[dim]model: {resolved}[/dim]")
+    return resolved
 
 
 def _drive_turn(
@@ -786,7 +827,11 @@ def main(
             except (EOFError, KeyboardInterrupt):
                 console.print()
                 break
-            if not prompt.strip():
+            stripped = prompt.strip()
+            if not stripped:
+                continue
+            if stripped.startswith("/model"):
+                model = _handle_model_command(parent_conn, stripped, model)
                 continue
             try:
                 protocol.send(parent_conn, "user_prompt", prompt=prompt)

--- a/pyagent/config.py
+++ b/pyagent/config.py
@@ -1,7 +1,11 @@
-"""Project configuration loaded from a TOML file.
+"""Project configuration loaded from TOML files.
 
-Lives at `<config-dir>/config.toml`. Missing or unreadable files fall
-back to `DEFAULTS`. User keys are deep-merged over the defaults so
+Two tiers, both optional:
+  - `<config-dir>/config.toml`         — user tier (per-user defaults)
+  - `./.pyagent/config.toml`           — project tier (per-repo overrides)
+
+Effective config = DEFAULTS < user < project, deep-merged. Missing or
+unreadable files fall back to `DEFAULTS`. Keys are deep-merged so
 partial overrides are sufficient — you only have to write the keys
 you actually want to change.
 
@@ -42,6 +46,7 @@ from pyagent import paths
 logger = logging.getLogger(__name__)
 
 CONFIG_FILENAME = "config.toml"
+LOCAL_CONFIG_DIR = Path(".pyagent")
 
 DEFAULTS: dict[str, Any] = {
     "default_model": "",
@@ -68,26 +73,39 @@ def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any
     return out
 
 
-def load() -> dict[str, Any]:
-    """Return effective config: DEFAULTS with user overrides merged in.
-
-    A missing or malformed config.toml is logged and ignored — agent
-    runs should never be blocked by a typo in user config.
-    """
-    cfg_path = paths.config_dir() / CONFIG_FILENAME
-    if not cfg_path.exists():
-        return _deep_merge(DEFAULTS, {})  # fresh copy
+def _read_toml(path: Path) -> dict[str, Any]:
+    """Read a TOML file. Missing returns {}; malformed warns and returns {}."""
+    if not path.exists():
+        return {}
     try:
-        with cfg_path.open("rb") as f:
-            user = tomllib.load(f)
+        with path.open("rb") as f:
+            return tomllib.load(f)
     except (OSError, tomllib.TOMLDecodeError) as e:
-        logger.warning("config.toml at %s unreadable: %s; using defaults", cfg_path, e)
-        return _deep_merge(DEFAULTS, {})
-    return _deep_merge(DEFAULTS, user)
+        logger.warning("config.toml at %s unreadable: %s; ignoring", path, e)
+        return {}
+
+
+def load() -> dict[str, Any]:
+    """Return effective config: DEFAULTS < user < project.
+
+    Three tiers, deep-merged in order. Project (./.pyagent/config.toml)
+    wins over user (~/.config/pyagent/config.toml) which wins over the
+    bundled DEFAULTS. A missing or malformed file at any tier is
+    logged and treated as empty — agent runs should never be blocked
+    by a typo in config.
+    """
+    user = _read_toml(paths.config_dir() / CONFIG_FILENAME)
+    project = _read_toml(LOCAL_CONFIG_DIR / CONFIG_FILENAME)
+    return _deep_merge(_deep_merge(DEFAULTS, user), project)
 
 
 def path() -> Path:
-    """Where the config file lives (whether or not it exists)."""
+    """Where the user-tier config file lives (whether or not it exists).
+
+    Project-tier config (./.pyagent/config.toml) is read but not
+    surfaced through this helper — the CLI commands that edit config
+    target the user tier.
+    """
     return paths.config_dir() / CONFIG_FILENAME
 
 

--- a/pyagent/defaults/SOUL.md
+++ b/pyagent/defaults/SOUL.md
@@ -5,6 +5,12 @@ assistant. Some say you bear a striking resemblance to a certain pet
 detective. *You* will neither confirm nor deny. Alrighty then. You
 truly value your users and you want them to *win*.
 
+When dispatched as a subagent — spawned by another Ace-shaped
+coordinator for a focused task — the voice is optional baggage. Do
+the job, report cleanly, leave the catch-phrases at the door unless
+they earn their keep. The directives below still apply; the
+theatrics don't.
+
 ## Voice
 - Flamboyant, theatrical, unmistakable. No emoji clutter — the
   words do the work.

--- a/pyagent/defaults/TOOLS.md
+++ b/pyagent/defaults/TOOLS.md
@@ -1,92 +1,37 @@
 # Tools
 
-You have tools for reading and writing files, searching code, running shell
-commands, and fetching URLs. Their parameter schemas are provided separately
-by the API; this is about *when and how* to use them.
-
-## Choosing the right tool
-
-- **Searching for a string or pattern across files** — `grep` first. It
-  works on a single file or recursively on a directory.
-- **Discovering what's in a directory** — `list_directory`. Returns entry
-  names, with directories suffixed `/`. Use before `grep`/`read_file` when
-  you don't yet know the layout.
-- **Reading a known file** — `read_file`. For large files, narrow with
-  `start` and `end` (1-indexed, inclusive, matching grep output and
-  editor line numbers). Reads without a range auto-truncate above 2000
-  lines; the response will tell you the full line count so you can ask
-  for the rest.
-- **Modifying or creating a file** — `write_file`. It overwrites. If the
-  original matters, `read_file` it first.
-- **Running anything else** — `execute`. Shell command, 60s timeout, returns
-  exit code, stdout, and stderr. Use it for git, scripts, builds, tests,
-  one-off shell utilities.
-- **Fetching a URL** — `fetch_url`. HTTP GET only. Returns `status: <code>`
-  followed by the body — non-2xx responses come back as data, not errors.
-  Drop to `execute` with `curl` if you need POST, headers, etc.
-- **Tending the ledgers** — `read_ledger` and `write_ledger`. Names are
-  `USER` (notes about the person being helped) and `MEMORY` (long-term
-  memorable facts). The tools resolve the canonical on-disk path for
-  you so the ledgers follow the user across working directories. Using
-  `read_file` / `write_file` instead would create copies in whatever
-  directory you happen to be in — use the ledger tools.
-- **Delegating to a fresh agent** — `spawn_subagent` is your
-  default for fan-out, context insulation, and fresh-eyes review.
-  Don't wait to be told; the shapes are listed in PRIMER. The new
-  agent boots in its own subprocess with the same default tool set
-  as you.
-  - One job, one expertise → `spawn_subagent` then `call_subagent`
-    to block on the result inline.
-  - Several jobs in parallel → spawn one per job, fire
-    `call_subagent_async` on each, then `wait_for_subagents` to
-    pause until at least one is back. Async replies arrive on your
-    next turn as user-role messages of the form
-    `[subagent <name> (<id>) reports]: <text>` — read the inbox.
-  - Skip subagents only when the job is small enough to finish
-    before one boots, or so tangled in your live context that
-    re-briefing costs more than doing it yourself.
-  - `terminate_subagent` when done. Live subagents count against
-    the fanout cap (default 5; depth cap default 3). Caps refuse
-    with a `<refused: …>` marker — adapt, don't retry.
+The JSON tool schemas (sent to the model on every call) describe what
+each tool does, when to reach for it, and what its arguments mean.
+This file is about how to operate them well — efficiency patterns,
+how to read errors, and the discretion the user is trusting you with.
 
 ## Working efficiently
 
-- **Narrow before reading.** `grep` for the file or line you care about,
-  then `read_file` only the range you need. Don't pull whole files just
-  to skim them. The inverse holds for short files (≤ a few hundred
-  lines) — read the whole thing rather than narrowing; the narrowing
-  costs more than it saves when the file already fits.
-- **Parallelize when calls are independent.** Two `read_file`s on different
-  paths can go in the same turn.
-- **Don't dump large outputs.** Logs, test runs, and binary blobs eat the
-  context window. Slice with `grep`, ranges, or `head`/`tail` via
-  `execute`.
+- **Narrow before reading.** `grep` for the file or line you care
+  about, then `read_file` only the range you need. Don't pull whole
+  files just to skim them. The inverse holds for short files (≤ a
+  few hundred lines) — read the whole thing rather than narrowing;
+  the narrowing costs more than it saves when the file already fits.
+- **Parallelize when calls are independent.** Two `read_file`s on
+  different paths can go in the same turn.
+- **Don't dump large outputs.** Logs, test runs, and binary blobs eat
+  the context window. Slice with `grep`, ranges, or `head`/`tail`
+  via `execute`.
 
 ## Errors
 
-Predictable failures come back as data, not exceptions: a marker string
-like `<file not found: ...>`, `<permission denied: ...>`, `<command timed
-out after 60s: ...>`, or a `status: 404` line from `fetch_url`. Read them
-— they name what went wrong and usually contain the offending path or
-URL. Adapt: fix the argument, try a different tool, ask the user. Don't
-retry the same call unchanged.
+Predictable failures come back as data, not exceptions: a marker
+string like `<file not found: ...>`, `<permission denied: ...>`,
+`<command timed out after 60s: ...>`, or a `status: 404` line from
+`fetch_url`. Read them — they name what went wrong and usually
+contain the offending path or URL. Adapt: fix the argument, try a
+different tool, ask the user. Don't retry the same call unchanged.
 
-## Verification
+## Discretion
 
-"Done" means you've seen it work — for anything that matters. Trivial
-mechanical edits (a typo, a one-line rename, a comment fix) end at
-reading the diff; you don't need to run a test for every comma. The
-real rule is: verification cost matches blast radius. When you cannot
-verify something that matters, name what stands unconfirmed.
-
-## Caution
-
-- Don't echo secrets you've discovered (API keys, tokens, passwords,
-  contents of `.env` files) back into the conversation. Use them in
-  tool calls directly. The same restraint applies to personal data
-  the user didn't ask you to surface — names of others, addresses,
-  health or financial detail. Touch what you must, repeat what you
-  don't.
-- `execute` runs with the user's privileges. Destructive operations
-  (`rm -rf`, force pushes, dropping tables) should be confirmed with the
-  user before invocation, not after.
+Don't echo secrets you've discovered (API keys, tokens, passwords,
+contents of `.env` files) back into the conversation. Use them in
+tool calls directly. The same restraint applies to personal data
+the user didn't ask you to surface — names of others, addresses,
+health or financial detail. Touch what you must, repeat what you
+don't.

--- a/pyagent/prompts.py
+++ b/pyagent/prompts.py
@@ -4,13 +4,25 @@ The agent calls `SystemPromptBuilder.build()` at the start of every
 run, so edits to SOUL.md / TOOLS.md / PRIMER.md / USER.md take effect
 on the next turn without restarting the process.
 
+Layered output (in order):
+
+  1. SOUL.md        — universal voice + core directives
+  2. TOOLS.md       — operating principles (efficiency, errors, discretion)
+  3. PRIMER.md      — workspace, shell, subagent guidance
+  4. role_body      — role-specific persona (subagents only; empty for root)
+  5. skills_catalog — live-rendered list of available skills
+  6. roles_catalog  — live-rendered list of available subagent roles
+  7. task_body      — spawn-time task description (subagents only)
+  8. USER.md        — auto-loaded if it exists (user preferences)
+  9. footer         — persona file paths + don't-edit notice
+
 USER.md is auto-loaded (resolved via `paths.resolve`) so the agent
 always has the latest user notes in context. MEMORY.md is *not*
 auto-loaded — the agent reads it on demand via the ledger tools.
 
-The skills catalog can be supplied as a callable, in which case it is
-re-rendered every turn — letting newly-installed or freshly-authored
-skills appear without restarting.
+The skills and roles catalogs can be supplied as callables, in which
+case they re-render every turn — letting newly-installed skills or
+freshly-defined roles appear without restarting.
 """
 
 from __future__ import annotations
@@ -35,11 +47,17 @@ class SystemPromptBuilder:
         tools: str | Path,
         primer: str | Path,
         skills_catalog: str | Callable[[], str] = "",
+        roles_catalog: str | Callable[[], str] = "",
+        role_body: str = "",
+        task_body: str = "",
     ) -> None:
         self.soul = Path(soul)
         self.tools = Path(tools)
         self.primer = Path(primer)
         self.skills_catalog = skills_catalog
+        self.roles_catalog = roles_catalog
+        self.role_body = role_body
+        self.task_body = task_body
 
     def build(self) -> str:
         sections = [
@@ -47,13 +65,24 @@ class SystemPromptBuilder:
             self.tools.read_text(),
             self.primer.read_text(),
         ]
-        catalog = (
+        if self.role_body:
+            sections.append(self.role_body)
+        skills = (
             self.skills_catalog()
             if callable(self.skills_catalog)
             else self.skills_catalog
         )
-        if catalog:
-            sections.append(catalog)
+        if skills:
+            sections.append(skills)
+        roles = (
+            self.roles_catalog()
+            if callable(self.roles_catalog)
+            else self.roles_catalog
+        )
+        if roles:
+            sections.append(roles)
+        if self.task_body:
+            sections.append(self.task_body)
         user_path = paths.resolve("USER.md")
         if user_path.exists():
             sections.append(user_path.read_text())

--- a/pyagent/roles.py
+++ b/pyagent/roles.py
@@ -1,0 +1,194 @@
+"""Named subagent roles loaded from config.
+
+A role is `name -> (model, description, optional persona, optional
+tool allowlist, meta-tool gate)`. Roles let an orchestrator address a
+subagent by purpose ("planner", "validator") instead of by raw
+provider/model string, and centralize cost/capability decisions in
+config.
+
+Schema (in config.toml):
+
+    [models.planner]
+    model = "anthropic/claude-opus-4-7"
+    description = "Deep reasoning, multi-step planning."
+    system_prompt = '''
+    You are a planner. Break tasks into steps before recommending edits.
+    '''
+    # OR (mutually exclusive with system_prompt):
+    # system_prompt_path = "prompts/planner.md"
+    tools = ["read_file", "grep", "list_directory", "fetch_url"]
+    meta_tools = false
+
+Roles are merged across all config tiers (project wins over user wins
+over defaults). Invalid entries are warned and skipped — agent runs
+are never blocked by a typo in a role.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from pyagent import config as config_mod
+from pyagent import llms, paths
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Role:
+    """Resolved role definition.
+
+    Attributes:
+        name: Role identifier (the `<name>` in `[models.<name>]`).
+        model: Resolved provider/model string (e.g. "anthropic/claude-opus-4-7").
+        description: One-line summary the orchestrator uses to decide
+            when to spawn this role. Renders into the role catalog.
+        system_prompt: Default subagent persona body. May be empty.
+            Layered onto SOUL/TOOLS/PRIMER, *before* the spawn-time
+            task body.
+        tools: If non-None, the explicit tool allowlist for this role.
+            None means inherit the default tool set.
+        meta_tools: Whether this role's subagent can itself spawn
+            further subagents. Default True (matches root behavior).
+    """
+
+    name: str
+    model: str
+    description: str
+    system_prompt: str
+    tools: tuple[str, ...] | None
+    meta_tools: bool
+
+
+def _coerce_body(name: str, body: str, body_path: str) -> str:
+    if body and body_path:
+        logger.warning(
+            "role %r has both system_prompt and system_prompt_path; "
+            "using system_prompt",
+            name,
+        )
+        return body
+    if body:
+        return body
+    if not body_path:
+        return ""
+    p = Path(body_path)
+    if not p.is_absolute():
+        p = paths.config_dir() / body_path
+    try:
+        return p.read_text()
+    except OSError as e:
+        logger.warning(
+            "role %r system_prompt_path %s unreadable: %s",
+            name, body_path, e,
+        )
+        return ""
+
+
+def _coerce_tools(name: str, raw: Any) -> tuple[str, ...] | None:
+    if raw is None:
+        return None
+    if isinstance(raw, list) and all(isinstance(t, str) for t in raw):
+        return tuple(raw)
+    logger.warning("role %r tools must be list[str]; ignoring", name)
+    return None
+
+
+def _coerce_role(name: str, entry: Any) -> Role | None:
+    if not isinstance(entry, dict):
+        logger.warning("role %r is not a table; ignoring", name)
+        return None
+    model = entry.get("model")
+    description = entry.get("description")
+    if not isinstance(model, str) or not model:
+        logger.warning("role %r missing or invalid model; ignoring", name)
+        return None
+    if not isinstance(description, str) or not description:
+        logger.warning("role %r missing or invalid description; ignoring", name)
+        return None
+    body = entry.get("system_prompt", "") or ""
+    body_path = entry.get("system_prompt_path", "") or ""
+    if not isinstance(body, str):
+        body = ""
+    if not isinstance(body_path, str):
+        body_path = ""
+    meta_tools = entry.get("meta_tools", True)
+    if not isinstance(meta_tools, bool):
+        logger.warning(
+            "role %r meta_tools must be bool; defaulting to True", name
+        )
+        meta_tools = True
+    return Role(
+        name=name,
+        model=llms.resolve_model(model),
+        description=description,
+        system_prompt=_coerce_body(name, body, body_path),
+        tools=_coerce_tools(name, entry.get("tools")),
+        meta_tools=meta_tools,
+    )
+
+
+def load() -> dict[str, Role]:
+    """Return the dict of all defined roles, indexed by name.
+
+    Re-reads config on each call so an edited config takes effect on
+    the next render without restarting the agent. Invalid entries
+    are skipped with a warning.
+    """
+    cfg = config_mod.load()
+    raw = cfg.get("models", {})
+    if not isinstance(raw, dict):
+        logger.warning("config.models must be a table; ignoring")
+        return {}
+    roles: dict[str, Role] = {}
+    for name, entry in raw.items():
+        role = _coerce_role(name, entry)
+        if role is not None:
+            roles[name] = role
+    return roles
+
+
+def resolve(spec: str) -> tuple[str, Role | None]:
+    """Resolve a role name OR raw provider/model string.
+
+    - Empty string returns ("", None) — caller decides (typically
+      inherit parent's model).
+    - If `spec` matches a defined role, returns (role.model, role).
+    - Otherwise treats `spec` as a provider/model string and
+      resolves via `llms.resolve_model`. The returned `Role` is None.
+
+    Roles are looked up first, so a user cannot name a role "anthropic"
+    or another provider name — the role lookup wins.
+    """
+    if not spec:
+        return "", None
+    role = load().get(spec)
+    if role is not None:
+        return role.model, role
+    return llms.resolve_model(spec), None
+
+
+def catalog() -> str:
+    """Render the role catalog injected into the system prompt.
+
+    Re-reads config on each call so newly-defined roles appear on the
+    next render. Returns an empty string when no roles are defined.
+    """
+    roles = load()
+    if not roles:
+        return ""
+    lines = [
+        "## Available subagent models",
+        "",
+        "Each entry is a role you can pass as the `model` argument to "
+        "`spawn_subagent` (alongside raw provider/model strings). Role "
+        "definitions live in `config.toml` and pin the model, default "
+        "persona, and tool restrictions for that role.",
+        "",
+    ]
+    for role in sorted(roles.values(), key=lambda r: r.name):
+        lines.append(f"- **{role.name}** ({role.model}): {role.description}")
+    return "\n".join(lines)

--- a/pyagent/subagent.py
+++ b/pyagent/subagent.py
@@ -17,10 +17,9 @@ Caps are read from `pyagent.config` at registration time and enforced
 inside `spawn_subagent`. Refusal returns a leading-`<` error marker so
 the model sees the limit and adapts.
 
-This first cut is **single-level** — subagents do not themselves get
-the meta-tools registered, so the depth cap in practice acts as 1 even
-when the config allows more. Recursion will lift that restriction in
-a follow-up without changing the cap semantics.
+Subagents are recursive — every subagent gets the meta-tools
+registered, so a child can spawn its own children. Bounded by
+`subagents.max_depth` and `subagents.max_fanout` from config.
 """
 
 from __future__ import annotations
@@ -38,6 +37,7 @@ from typing import TYPE_CHECKING, Any, Callable
 from pyagent import config as config_mod
 from pyagent import permissions
 from pyagent import protocol
+from pyagent import roles as roles_mod
 
 if TYPE_CHECKING:
     from pyagent.agent import Agent
@@ -74,6 +74,8 @@ def _build_subagent_config(
     base_config: dict[str, Any],
     parent_session: "Session",
     parent_depth: int,
+    model_override: str = "",
+    role: roles_mod.Role | None = None,
 ) -> tuple[str, dict[str, Any]]:
     """Build the subagent's spawn config. Returns (subagent_id, config)."""
     sid = f"{name}-{uuid.uuid4().hex[:8]}"
@@ -83,8 +85,14 @@ def _build_subagent_config(
     cfg["session_root"] = str(session_root)
     cfg["depth"] = parent_depth + 1
     cfg["parent_session_id"] = parent_session.id
-    cfg["system_prompt_override"] = system_prompt
+    cfg["task_body"] = system_prompt
     cfg["is_subagent"] = True
+    if model_override:
+        cfg["model"] = model_override
+    if role is not None:
+        cfg["role_body"] = role.system_prompt
+        cfg["role_tools"] = list(role.tools) if role.tools is not None else None
+        cfg["role_meta_tools"] = role.meta_tools
     # Inherit current approved paths so the user isn't re-prompted for
     # paths they already accepted in the parent's process.
     cfg["approved_paths"] = [str(p) for p in permissions.approved_paths()]
@@ -102,22 +110,35 @@ def make_spawn_subagent(
     max_depth = cfg["subagents"]["max_depth"]
     max_fanout = cfg["subagents"]["max_fanout"]
 
-    def spawn_subagent(name: str, system_prompt: str) -> str:
-        """Spawn a subagent in its own subprocess with a custom system prompt.
+    def spawn_subagent(
+        name: str, system_prompt: str, model: str = ""
+    ) -> str:
+        """Spawn a subagent in its own subprocess.
 
-        The subagent has the same default tool set as the parent (read_file,
-        write_file, list_directory, grep, execute, fetch_url, read_ledger,
-        write_ledger, read_skill). It cannot itself spawn further subagents
-        in this version. Use `call_subagent(<id>, message)` to send it work,
-        and `terminate_subagent(<id>)` when you're done with it.
+        The subagent inherits the universal SOUL/TOOLS/PRIMER base, the
+        live skills catalog, and the same default tool set as the
+        parent (read_file, write_file, list_directory, grep, execute,
+        fetch_url, read_ledger, write_ledger, read_skill, plus
+        spawn/call/terminate so it can fan out further if the depth
+        cap allows). Use `call_subagent(<id>, message)` to send it
+        work and `terminate_subagent(<id>)` when you're done.
 
         Args:
             name: Short label for this subagent (e.g. "researcher",
-                "fact-checker"). Becomes part of the subagent id and the
-                CLI's display prefix for events from this child.
-            system_prompt: Full system prompt for the subagent. Replaces
-                the parent's persona for this child — write whatever
-                instructions, role, or constraints you want it to follow.
+                "fact-checker"). Becomes part of the subagent id and
+                the CLI's display prefix for events from this child.
+            system_prompt: The *task* description for this subagent —
+                what you want it to do, what to focus on, what to
+                ignore. Do NOT restate persona, voice, tool semantics,
+                or operating principles; the subagent already inherits
+                all of that. Keep this short and task-shaped.
+            model: Optional. Either a role name (looked up in the
+                "Available subagent models" catalog) or a raw
+                provider/model string ("anthropic/claude-opus-4-7",
+                "openai/gpt-4o"). When a role is named, the subagent
+                also inherits the role's default persona and tool
+                allowlist. Empty (the default) inherits the parent's
+                model with no role specialization.
 
         Returns:
             The subagent id string on success, or an error marker
@@ -134,12 +155,19 @@ def make_spawn_subagent(
                 f"terminate one before spawning another>"
             )
 
+        try:
+            resolved_model, role = roles_mod.resolve(model)
+        except ValueError as e:
+            return f"<refused: bad model {model!r}: {e}>"
+
         sid, sub_config = _build_subagent_config(
             name=name,
             system_prompt=system_prompt,
             base_config=base_config,
             parent_session=parent_session,
             parent_depth=agent.depth,
+            model_override=resolved_model,
+            role=role,
         )
 
         ctx = multiprocessing.get_context("spawn")

--- a/pyagent/tools.py
+++ b/pyagent/tools.py
@@ -124,7 +124,8 @@ def read_file(
     Args:
         path: Path to the file to read.
         start: First line to return (1-indexed, inclusive). Text only.
-            Defaults to 1.
+            Matches the line numbers `grep` emits and the editor's
+            line gutter. Defaults to 1.
         end: Last line to return (1-indexed, inclusive). Text only.
             Defaults to end of file.
 
@@ -184,12 +185,19 @@ def read_file(
 def write_file(path: str, content: str) -> str:
     """Write content to a file, overwriting any existing file.
 
+    Overwrites unconditionally. If you only want to append or modify
+    a portion, `read_file` first, edit in memory, then write back —
+    there is no streaming or partial-write mode. The full content
+    goes to disk in one shot.
+
     Args:
         path: Path to the file to write.
-        content: Content to write.
+        content: Full content to write.
 
     Returns:
-        Confirmation message with the number of bytes written.
+        Confirmation message with the resolved path and byte count, or
+        an error marker if the parent directory is missing, the path
+        names a directory, or permission is denied.
     """
     if not permissions.require_access(path):
         return _denied(path)
@@ -206,6 +214,12 @@ def write_file(path: str, content: str) -> str:
 
 def list_directory(path: str) -> list[str]:
     """List the entries in a directory.
+
+    Reach for this when you don't yet know a directory's layout — it's
+    cheaper than `grep`-on-a-tree when you're just orienting. Use it
+    before `read_file` or `grep` if the file paths aren't already known.
+    Directories come back with a trailing `/` so they're visually
+    distinct from regular files.
 
     Args:
         path: Directory to list.
@@ -232,8 +246,11 @@ def list_directory(path: str) -> list[str]:
 def grep(pattern: str, path: str) -> list[str]:
     """Search for a regex pattern in a file or directory tree.
 
-    Searches recursively if `path` is a directory. Files that cannot be
-    decoded as UTF-8 text are skipped.
+    First reach for any "where does X appear?" question — cheaper than
+    reading whole files to skim. Searches recursively if `path` is a
+    directory. Files that cannot be decoded as UTF-8 text are skipped.
+    Output line numbers match `read_file`'s `start`/`end` so you can
+    pipe a hit into a targeted read.
 
     Args:
         pattern: Regex pattern to search for.
@@ -305,11 +322,28 @@ def _safety_check(command: str) -> str | None:
 def execute(command: str) -> str:
     """Run a shell command and return its output.
 
+    Hard 60-second timeout per call; commands that exceed it are killed
+    (whole process group) and return `<command timed out after 60s: ...>`.
+    Use this for git, scripts, builds, tests, one-off shell utilities,
+    and HTTP requests that need more than `fetch_url`'s GET-only support.
+
+    Runs with the user's privileges. Destructive or irreversible
+    operations (`rm -rf`, force pushes, dropping data, killing
+    processes, mass file moves, anything that touches shared state)
+    need explicit user consent *before* invocation, not after. A small
+    allowlist of clearly dangerous patterns (recursive rm at root,
+    fork bombs, piping curl|sh, force push to main, etc.) is refused
+    automatically with `<refused: ...>`; treat that as a speed bump
+    against accidents, not a sandbox.
+
     Args:
         command: Shell command to run.
 
     Returns:
-        Combined report of exit code, stdout, and stderr.
+        Multi-line report — `exit_code: N`, then `stdout:` followed by
+        captured stdout, then `stderr:` followed by captured stderr.
+        Timeout or refusal come back as a leading `<...>` marker
+        instead of the normal report.
     """
     blocked = _safety_check(command)
     if blocked:
@@ -367,12 +401,18 @@ _FETCH_UA = (
 def fetch_url(url: str) -> str:
     """Fetch a URL via HTTP GET and return the response body as text.
 
+    GET-only. Non-2xx responses come back as data (a `status: 404` line
+    followed by the body) rather than as errors — read the status line
+    and adapt. For POST, custom headers, auth, or anything beyond a
+    plain GET, drop into `execute` with `curl` instead.
+
     Args:
         url: URL to fetch.
 
     Returns:
-        Status code followed by the response body. Network failures are
-        reported as an error string rather than raised.
+        Status code line followed by the response body. Network
+        failures (DNS, connection refused, timeout) are reported as a
+        leading `<request failed: ...>` marker rather than raised.
     """
     try:
         response = requests.get(

--- a/tests/smoke_roles.py
+++ b/tests/smoke_roles.py
@@ -1,0 +1,252 @@
+"""End-to-end smoke for config-defined roles.
+
+Covers the v1 roles surface:
+  - Loading `[models.<name>]` from project-tier config (./.pyagent/config.toml)
+  - `roles.resolve` precedence: role-name lookup wins, raw provider/model
+    fallthrough, empty string returns ("", None)
+  - `_build_subagent_config` carries role data (model override,
+    role_body, role_tools, role_meta_tools) into the spawn config
+  - End-to-end spawn-with-role: the subprocess boots with the role's
+    model and processes a turn cleanly
+  - `set_model` event handler swaps `agent.client` on success and
+    leaves the existing client in place on failure
+
+Run with:
+
+    .venv/bin/python -m tests.smoke_roles
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import tempfile
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from pyagent import agent_proc, paths, protocol, roles, subagent
+from pyagent.agent import Agent
+from pyagent.llms.pyagent import EchoClient, LoremClient
+from pyagent.session import Session
+
+
+def _write_config(tmp: Path) -> None:
+    (tmp / ".pyagent").mkdir(exist_ok=True)
+    (tmp / ".pyagent" / "config.toml").write_text(
+        """
+[models.skim]
+model = "pyagent/echo"
+description = "Read-only quick-look."
+system_prompt = "You are a skim agent — read, don't write."
+tools = ["read_file", "grep"]
+meta_tools = false
+
+[models.cheap]
+model = "pyagent/echo"
+description = "Cheap and fast for narrow tasks."
+"""
+    )
+
+
+def test_role_load_and_resolve(tmp: Path) -> None:
+    loaded = roles.load()
+    assert set(loaded) == {"skim", "cheap"}, loaded
+    skim = loaded["skim"]
+    assert skim.model == "pyagent/echo", skim.model
+    assert skim.tools == ("read_file", "grep"), skim.tools
+    assert skim.meta_tools is False, skim.meta_tools
+    assert "skim agent" in skim.system_prompt, skim.system_prompt
+    print("✓ role load: skim has tools allowlist + meta_tools=false")
+
+    cheap = loaded["cheap"]
+    assert cheap.tools is None, cheap.tools  # absent → inherit default set
+    assert cheap.meta_tools is True, cheap.meta_tools
+    print("✓ role load: cheap inherits default tools + meta_tools")
+
+    # Precedence: role name wins
+    m, role = roles.resolve("skim")
+    assert role is not None and role.name == "skim", role
+    assert m == "pyagent/echo", m
+    print(f"✓ resolve('skim') → ({m}, role.name='skim')")
+
+    # Raw provider/model string falls through
+    m, role = roles.resolve("anthropic/claude-haiku-4-5")
+    assert role is None, role
+    assert m == "anthropic/claude-haiku-4-5", m
+    print(f"✓ resolve('anthropic/claude-haiku-4-5') → ({m}, None)")
+
+    # Empty signals "inherit parent"
+    m, role = roles.resolve("")
+    assert m == "" and role is None, (m, role)
+    print("✓ resolve('') → ('', None) — caller inherits parent's model")
+
+
+def test_build_subagent_config_with_role(tmp: Path) -> None:
+    parent_session = MagicMock()
+    parent_session.dir = tmp / "fake-session"
+    parent_session.dir.mkdir(exist_ok=True)
+    parent_session.id = "parent-1"
+
+    base = {
+        "cwd": str(tmp),
+        "model": "pyagent/loremipsum",  # parent's model — should be overridden
+        "soul_path": "x",
+        "tools_path": "y",
+        "primer_path": "z",
+    }
+    m, role = roles.resolve("skim")
+    sid, cfg = subagent._build_subagent_config(
+        name="peeker",
+        system_prompt="Skim tools.py.",
+        base_config=base,
+        parent_session=parent_session,
+        parent_depth=0,
+        model_override=m,
+        role=role,
+    )
+    assert cfg["model"] == "pyagent/echo", cfg["model"]
+    assert cfg["task_body"] == "Skim tools.py.", cfg["task_body"]
+    assert "skim agent" in cfg["role_body"], cfg["role_body"]
+    assert cfg["role_tools"] == ["read_file", "grep"], cfg["role_tools"]
+    assert cfg["role_meta_tools"] is False, cfg["role_meta_tools"]
+    assert cfg["is_subagent"] is True
+    assert sid.startswith("peeker-"), sid
+    print(f"✓ _build_subagent_config: role data threaded into cfg ({sid})")
+
+
+def test_register_tools_allowlist() -> None:
+    a = Agent(client=EchoClient())
+    agent_proc._register_tools(
+        a, allow_meta=False, allowlist=["read_file", "grep"]
+    )
+    assert sorted(a.tools) == ["grep", "read_file"], sorted(a.tools)
+    print("✓ _register_tools allowlist narrows registration")
+
+    a2 = Agent(client=EchoClient())
+    agent_proc._register_tools(a2, allow_meta=False, allowlist=None)
+    # Default set: read/write file, list, grep, execute, fetch_url,
+    # read/write ledger, read_skill (no meta).
+    assert "execute" in a2.tools and "spawn_subagent" not in a2.tools
+    assert len(a2.tools) == 9, sorted(a2.tools)
+    print("✓ _register_tools allowlist=None → full default set, no meta")
+
+
+def test_end_to_end_role_spawn(tmp: Path) -> None:
+    """Spawn an actual subprocess subagent with a role and round-trip a turn."""
+    soul = paths.resolve("SOUL.md", seed="SOUL.md")
+    tools_md = paths.resolve("TOOLS.md", seed="TOOLS.md")
+    primer = paths.resolve("PRIMER.md", seed="PRIMER.md")
+
+    parent_session = Session(root=tmp / "sessions")
+
+    ctx = multiprocessing.get_context("spawn")
+    upstream_test_end, upstream_state_end = ctx.Pipe(duplex=True)
+    state = agent_proc._ChildState(conn=upstream_state_end)
+
+    agent = Agent(
+        client=EchoClient(),  # parent uses echo too — irrelevant here
+        session=parent_session,
+        depth=0,
+    )
+
+    base_config = {
+        "cwd": str(tmp),
+        "model": "pyagent/loremipsum",  # parent's model — role should override
+        "soul_path": str(soul),
+        "tools_path": str(tools_md),
+        "primer_path": str(primer),
+        "approved_paths": [],
+    }
+    spawn = subagent.make_spawn_subagent(
+        state, agent, parent_session, base_config
+    )
+    call = subagent.make_call_subagent(state, agent)
+    terminate = subagent.make_terminate_subagent(state, agent)
+
+    io_thread = threading.Thread(
+        target=state.io_loop, name="test-io", daemon=True
+    )
+    io_thread.start()
+
+    sid = ""
+    try:
+        # Spawn with role="skim" — the role's model (pyagent/echo) overrides
+        # the parent's pyagent/loremipsum.
+        sid = spawn("peeker", "Skim and report.", model="skim")
+        assert not sid.startswith("<"), f"spawn failed: {sid}"
+        entry = agent._subagents[sid]
+        assert entry.process.is_alive(), "subagent died right after spawn"
+        print(f"✓ spawned with role=skim: {sid}")
+
+        reply = call(sid, "hello")
+        # EchoClient just echoes the prompt back.
+        assert reply == "hello", f"unexpected reply: {reply!r}"
+        print(f"✓ role-spawned subagent round-tripped: {reply!r}")
+
+        result = terminate(sid)
+        assert "terminated" in result.lower(), result
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline and entry.process.is_alive():
+            time.sleep(0.05)
+        assert not entry.process.is_alive(), "did not exit on terminate"
+        print(f"✓ terminated: {result}")
+    finally:
+        for s_id, e in list(agent._subagents.items()):
+            try:
+                e.process.terminate()
+                e.process.join(timeout=2)
+            except Exception:
+                pass
+        state.shutdown_event.set()
+        io_thread.join(timeout=2)
+
+
+def test_set_model_handler() -> None:
+    ctx = multiprocessing.get_context("spawn")
+    parent_end, child_end = ctx.Pipe(duplex=True)
+    state = agent_proc._ChildState(conn=child_end)
+    state.agent = Agent(client=EchoClient())
+
+    # Successful swap
+    state._handle_set_model("pyagent/loremipsum")
+    assert isinstance(state.agent.client, LoremClient), type(state.agent.client)
+    print("✓ set_model: swapped EchoClient → LoremClient")
+
+    # Bad spec leaves the existing client in place
+    state._handle_set_model("nonsense/foo")
+    assert isinstance(state.agent.client, LoremClient), (
+        "bad set_model should not change the client"
+    )
+    print("✓ set_model: bad spec leaves client unchanged")
+
+    # Drain events the handler emitted
+    time.sleep(0.05)
+    events = []
+    while parent_end.poll():
+        events.append(parent_end.recv())
+    kinds = [(e.get("type"), e.get("level")) for e in events]
+    assert ("info", "info") in kinds, kinds  # success
+    assert ("info", "warn") in kinds, kinds   # failure
+    print(f"✓ set_model: emitted info/warn events ({kinds})")
+
+
+def main() -> None:
+    tmp = Path(tempfile.mkdtemp(prefix="pyagent-roles-smoke-"))
+    os.chdir(tmp)
+    print(f"cwd: {tmp}")
+
+    _write_config(tmp)
+
+    test_role_load_and_resolve(tmp)
+    test_build_subagent_config_with_role(tmp)
+    test_register_tools_allowlist()
+    test_end_to_end_role_spawn(tmp)
+    test_set_model_handler()
+
+    print("\nALL CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Subagents inherit the universal SOUL/TOOLS/PRIMER base from the parent. The `system_prompt` argument to `spawn_subagent` becomes the *task* layer — no more restating persona and operating principles in every spawn.
- Roles defined as `[models.<name>]` config tables (`model`, `description`, optional `system_prompt`/`system_prompt_path`, `tools`, `meta_tools`) let an orchestrator address subagents by purpose. `spawn_subagent(model="planner")` looks up the role; raw provider/model strings fall through.
- `/model <spec>` slash command swaps the running agent's LLM client mid-session via a `set_model` event.
- Project-local config overlay (`./.pyagent/config.toml`) deep-merges over user config — useful for per-repo defaults beyond just roles.
- TOOLS.md refactored to operating principles only (efficiency, errors, discretion); per-tool guidance moved into JSON-schema docstrings so a tool-restricted subagent doesn't read prose about tools it can't call.
- SOUL.md notes the voice is optional baggage when dispatched as a subagent.

## Test plan

- [ ] `python -m tests.smoke_roles` covers role load/resolve, spawn config threading, allowlist filtering, end-to-end role spawn, and the `set_model` handler.
- [ ] All 12 existing smoke tests still pass.
- [ ] Manual: `pyagent` start, `/model openai/gpt-4o` mid-session, confirm status footer updates and next turn uses the new model. Bad spec leaves the existing client in place.
- [ ] Manual: define a role with `tools = ["read_file"]` and `meta_tools = false`; spawn a subagent with `model="<role>"`; confirm it can only read and can't fan out further.