### PR TITLE
Document roles + /model and surface them via pyagent-config init

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,22 @@ what was picked.
 Make sure the matching API key from the table above is set in your
 environment before launching.
 
+### Switching models mid-session
+
+At the prompt, type `/model <spec>` to swap the running agent's LLM
+client without restarting:
+
+```
+> /model openai/gpt-4o
+> /model anthropic
+> /model planner          # role name (see Roles section)
+```
+
+The swap takes effect on the next API call. The status footer updates
+to reflect the new model. A bad spec leaves the existing client in
+place and prints a warning. Subagents are not affected — each child
+keeps the model it was spawned with.
+
 ## Design
 
 ### The agent loop
@@ -249,9 +265,14 @@ one out of the catalog, just leave it out of `built_in_skills_enabled`.
 
 ## Configuration
 
-Pyagent reads its config from `<config-dir>/config.toml`. A missing file is
-fine — bundled defaults apply. The `pyagent-config` CLI inspects and
-initializes the file:
+Pyagent reads config from two tiers, both optional:
+
+- `<config-dir>/config.toml` — user tier (per-user defaults)
+- `./.pyagent/config.toml` — project tier (per-repo overrides)
+
+Effective config is `defaults < user < project`, deep-merged. A missing
+file at any tier is fine — bundled defaults apply. The `pyagent-config`
+CLI inspects and initializes the user-tier file:
 
 ```
 pyagent-config show          # effective merged config (defaults + overrides)
@@ -262,6 +283,38 @@ pyagent-config init          # write the template to config.toml if absent
 `init` never overwrites; pass `--force` if you really want to start over.
 The written template is fully commented out, so the file's presence does
 not change behavior — uncomment lines to override defaults.
+
+### Roles (named subagent models)
+
+Define `[models.<name>]` tables in `config.toml` to give the
+orchestrator addressable subagent presets. The orchestrator then calls
+`spawn_subagent(model="planner")` (or any other defined role name)
+instead of repeating raw provider strings in every spawn. Roles also
+appear as targets for the `/model` slash command.
+
+```toml
+[models.planner]
+model = "anthropic/claude-opus-4-7"
+description = "Deep reasoning, multi-step planning."
+system_prompt = """
+You are a planner. Break tasks into steps before recommending edits.
+"""
+tools = ["read_file", "grep", "list_directory"]   # optional allowlist
+meta_tools = false                                # leaf role, can't fan out
+```
+
+| Field | Required | Purpose |
+| --- | --- | --- |
+| `model` | yes | provider/model string in the same form as `--model`. |
+| `description` | yes | One-line summary; the orchestrator uses this to decide when to spawn this role. |
+| `system_prompt` | no | Default subagent persona body, layered onto SOUL/TOOLS/PRIMER (use `system_prompt_path` instead for longer prose; mutually exclusive). |
+| `tools` | no | Allowlist that narrows the default tool set. Absent = full default. |
+| `meta_tools` | no | Default `true`. Set `false` for leaves that should not themselves spawn subagents. |
+
+Roles render into a live "Available subagent models" catalog that the
+orchestrator sees in its system prompt. `/model <role-name>` and
+`spawn_subagent(model=...)` use the same lookup — role names win over
+raw provider strings.
 
 ## Managing sessions
 

--- a/pyagent/config.py
+++ b/pyagent/config.py
@@ -133,7 +133,10 @@ def _render_toml_value(v: Any) -> str:
 
 def render_toml(data: dict[str, Any], commented: bool = False) -> str:
     """Render a config dict as TOML text. Top-level scalars/lists first,
-    then tables — the order TOML requires.
+    then tables — the order TOML requires. Tables containing nested
+    tables (e.g. `models.<name>` role definitions) render each child
+    as its own `[parent.child]` section so `pyagent-config show` works
+    with role-defining configs.
 
     If `commented`, every value line is prefixed with `# ` so the file
     serves as documentation: the user uncomments lines they want to
@@ -146,11 +149,49 @@ def render_toml(data: dict[str, Any], commented: bool = False) -> str:
     for k, v in flat:
         lines.append(f"{prefix}{k} = {_render_toml_value(v)}")
     for k, v in tables:
-        lines.append("")
-        lines.append(f"{prefix}[{k}]")
-        for k2, v2 in v.items():
-            lines.append(f"{prefix}{k2} = {_render_toml_value(v2)}")
+        scalars = {kk: vv for kk, vv in v.items() if not isinstance(vv, dict)}
+        sub_tables = {kk: vv for kk, vv in v.items() if isinstance(vv, dict)}
+        if scalars:
+            lines.append("")
+            lines.append(f"{prefix}[{k}]")
+            for k2, v2 in scalars.items():
+                lines.append(f"{prefix}{k2} = {_render_toml_value(v2)}")
+        for k2, v2 in sub_tables.items():
+            lines.append("")
+            lines.append(f"{prefix}[{k}.{k2}]")
+            for k3, v3 in v2.items():
+                if isinstance(v3, dict):
+                    continue  # three-deep nesting not supported
+                lines.append(f"{prefix}{k3} = {_render_toml_value(v3)}")
     return "\n".join(lines) + "\n"
+
+
+_ROLE_EXAMPLE_BLOCK = """
+# Roles — named subagent models the orchestrator can address by name.
+#
+# Each [models.<name>] table defines a preset that `spawn_subagent`
+# resolves via its `model` argument. Required: model, description.
+# Optional: system_prompt / system_prompt_path (default subagent
+# persona body, layered onto SOUL/TOOLS/PRIMER), tools (allowlist
+# narrowing the default tool set), meta_tools (default true; set
+# false to make a leaf role that can't fan out further).
+#
+# [models.planner]
+# model = "anthropic/claude-opus-4-7"
+# description = "Deep reasoning, multi-step planning."
+# system_prompt = "You are a planner. Break tasks into steps before recommending edits."
+# tools = ["read_file", "grep", "list_directory", "fetch_url"]
+# meta_tools = false
+"""
+
+
+def commented_template() -> str:
+    """Render the full commented-out template: documented defaults
+    plus a commented role example so users can discover the
+    `[models.<name>]` schema from `pyagent-config defaults` and the
+    file written by `pyagent-config init`.
+    """
+    return render_toml(DEFAULTS, commented=True) + _ROLE_EXAMPLE_BLOCK
 
 
 def init_default(force: bool = False) -> tuple[Path, bool]:
@@ -163,5 +204,5 @@ def init_default(force: bool = False) -> tuple[Path, bool]:
     if target.exists() and not force:
         return target, False
     target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(render_toml(DEFAULTS, commented=True))
+    target.write_text(commented_template())
     return target, True

--- a/pyagent/config_cli.py
+++ b/pyagent/config_cli.py
@@ -41,7 +41,7 @@ def defaults_cmd() -> None:
 
     Pipe to a file, or use `pyagent-config init` to drop it in place.
     """
-    click.echo(config.render_toml(config.DEFAULTS, commented=True), nl=False)
+    click.echo(config.commented_template(), nl=False)
 
 
 @main.command("init")


### PR DESCRIPTION
## Summary

Two discoverability gaps from #2:

- **README.md** now documents the `/model` mid-session swap, the project-local config overlay (`./.pyagent/config.toml`), and the `[models.<name>]` role schema with a worked example.
- **`pyagent-config init` / `defaults`** now append a commented role example after the rendered defaults, so users can discover the schema in the file the CLI drops on disk.
- **Fixed a latent bug in `render_toml`**: it could only handle one level of nesting, so `pyagent-config show` would crash for users with roles defined. Now renders nested tables as `[parent.child]` sections.

## Test plan

- [ ] `pyagent-config defaults` includes the role example block.
- [ ] `pyagent-config show` works with a `config.toml` that defines `[models.planner]`.
- [ ] All existing smoke tests still pass (verified locally).