### PR TITLE
Discourage attachment re-reads; raise default max_tokens to 16384

### DIFF
--- a/pyagent/agent.py
+++ b/pyagent/agent.py
@@ -142,8 +142,11 @@ class Agent:
     @staticmethod
     def _format_offload_ref(path: Any, size: int, preview: str) -> str:
         header = (
-            f"[output saved to {path} ({size} chars) — "
-            f"call read_file on this path to view the full output]"
+            f"[output saved to {path} ({size} chars) — preview below. "
+            f"Do NOT read_file the whole attachment; that pulls every "
+            f"byte back into context permanently. If you need more, "
+            f"grep for what you want or read_file with start/end to "
+            f"slice a specific range.]"
         )
         if preview:
             return f"{header}\n\n--- preview ---\n{preview}"

--- a/pyagent/llms/anthropic.py
+++ b/pyagent/llms/anthropic.py
@@ -17,7 +17,7 @@ class AnthropicClient:
     def __init__(
         self,
         model: str = "claude-sonnet-4-6",
-        max_tokens: int = 4096,
+        max_tokens: int = 16384,
         api_key: str | None = None,
         cache: bool = True,
     ) -> None:

--- a/pyagent/llms/openai.py
+++ b/pyagent/llms/openai.py
@@ -23,7 +23,7 @@ class OpenAIClient:
     def __init__(
         self,
         model: str = "gpt-4o",
-        max_tokens: int = 4096,
+        max_tokens: int = 16384,
         api_key: str | None = None,
     ) -> None:
         self.model = model


### PR DESCRIPTION
## Summary
- Reword the offload stub in \`Agent._format_offload_ref\` so it tells the agent **not** to re-read the full attachment; current wording (\"call read_file on this path to view the full output\") was actively prompting the bug in #4.
- Raise default \`max_tokens\` on both LLM clients from 4096 → 16384. The 4096 cap was the root cause of the heredoc fallback in #4 — large \`write_file\` tool calls were truncated mid-emission, and the agent's recovery path embedded the file content in shell strings.

Addresses the two highest-leverage levers in #4. Both are one-line config/copy changes.

## Why 16384
- Sonnet 4.x and Opus 4.x support 64K+ output tokens.
- gpt-4o's \`max_completion_tokens\` ceiling is 16384, so this is the largest universally-safe default.
- Every artifact in the linked session was under 4K tokens; 16384 gives ~5× headroom.
- Still constructor-overridable for callers who want lower (cost) or higher (large-output Anthropic models).

## Test plan
- [ ] Run a session that previously triggered the offload bug; confirm the agent no longer calls \`read_file\` on the attachment path after seeing the new stub.
- [ ] Run a session that writes a large (~10KB) file; confirm the \`write_file\` tool call completes in one emission and the agent does not fall back to \`execute\` heredocs.
- [ ] Sanity-check that a normal short response still works under the higher cap (no behavioral change expected — \`max_tokens\` is a ceiling, not a target).

## Out of scope
The longer-term context-management concerns from #4 (eviction of stale tool results, persistence-replay edge cases, structural \`write_file\` chunking) are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)