### PR TITLE
html-tools plugin + fetch_url restructure (closes #11, #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,14 @@ The following is a table of the built-in tools.
 | `list_directory` | List the entries in a directory; directories are suffixed `/`. |
 | `grep` | Search for a regex pattern in a file or recursively across a directory. |
 | `execute` | Run a shell command (60s timeout). A small regex blocklist refuses obviously dangerous patterns. |
-| `fetch_url` | HTTP GET a URL and return status + body. |
+| `fetch_url` | HTTP GET a URL. Always saves the raw body to a session attachment; by default also returns markdown of the article body inline. `format="void"` skips the inline conversion for triage / batch fetches. |
 | `list_plugins` | List the plugins currently loaded. Self-improvement helper. |
 
-Memory tools (`read_ledger` / `write_ledger`) come from the bundled
-`memory-markdown` plugin, not core. See "Plugins" below.
+HTML tools (`html_to_md` / `html_select`) come from the bundled
+`html-tools` plugin and operate on saved attachments (or any local
+HTML file). Memory tools (`read_ledger` / `write_ledger`) come from
+the bundled `memory-markdown` plugin. Both ship default-enabled. See
+"Plugins" below.
 
 File tools resolve paths and refuse anything outside the workspace unless the
 human approves at a prompt. See `pyagent/permissions.py`. The user's pyagent

--- a/pyagent/config.py
+++ b/pyagent/config.py
@@ -51,7 +51,7 @@ LOCAL_CONFIG_DIR = Path(".pyagent")
 DEFAULTS: dict[str, Any] = {
     "default_model": "",
     "built_in_skills_enabled": ["write-skill", "write-plugin"],
-    "built_in_plugins_enabled": ["memory-markdown"],
+    "built_in_plugins_enabled": ["memory-markdown", "html-tools"],
     "subagents": {
         "max_depth": 3,
         "max_fanout": 5,

--- a/pyagent/defaults/TOOLS.md
+++ b/pyagent/defaults/TOOLS.md
@@ -28,6 +28,27 @@ how to read errors, and the discretion the user is trusting you with.
   into the conversation forever. `append=True` creates the file
   if missing, so the first chunk can use it too.
 
+## Web pages and HTML
+
+- **Don't write your own HTML scrub.** `fetch_url` saves the raw page
+  to a session attachment and returns markdown of the article body
+  inline. That's one tool call instead of fetch → grep → re-write a
+  regex stripper across multiple turns.
+- **Reach for `html_select` when structure matters.** Tables, lists at
+  a specific selector, links inside a sidebar — markdown of the whole
+  page flattens these. `html_select(path, "table.wikitable tr")`
+  preserves rows. The path comes from the attachment `fetch_url`
+  saved.
+- **Use `format="void"` for triage.** When you're fetching several
+  candidate URLs to assess relevance later, `fetch_url(url,
+  format="void")` skips the inline markdown so you don't pay for
+  previews you won't read. The raw is still saved; come back with
+  `html_to_md` / `html_select` on the ones you want.
+- **`main_content=False`** when the page *is* a document and the
+  boilerplate is part of it (Wikipedia, docs, reference pages). The
+  default `True` is right for news / blogs / articles where chrome
+  dwarfs the body.
+
 ## Errors
 
 Predictable failures come back as data, not exceptions: a marker

--- a/pyagent/plugins/html_tools/__init__.py
+++ b/pyagent/plugins/html_tools/__init__.py
@@ -1,0 +1,107 @@
+"""html-tools — bundled plugin for interrogating HTML attachments.
+
+Two tools, both operating on local HTML files (typically session
+attachments produced by `fetch_url`). The conversion code lives in
+`extraction.py` and is also imported by core's `fetch_url` so the
+default-clean fetch path and the agent-facing tools share one
+implementation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pyagent import permissions
+from pyagent.plugins.html_tools import extraction
+
+
+def register(api):
+    def _read_html(path: str) -> tuple[bool, str]:
+        """Returns (ok, payload). On error, ok=False and payload is a
+        leading-`<>`-marker error string the tool returns directly."""
+        if not permissions.require_access(path):
+            return (
+                False,
+                f"<permission denied (outside workspace): {path}>",
+            )
+        p = Path(path)
+        try:
+            return (True, p.read_text())
+        except FileNotFoundError:
+            return (False, f"<file not found: {path}>")
+        except IsADirectoryError:
+            return (False, f"<is a directory, not a file: {path}>")
+        except PermissionError:
+            return (False, f"<permission denied: {path}>")
+        except UnicodeDecodeError:
+            return (
+                False,
+                f"<cannot decode {path} as UTF-8 — not an HTML file?>",
+            )
+
+    def html_to_md(path: str, main_content: bool = True) -> str:
+        """Render an HTML file as markdown.
+
+        Reach for this on a saved attachment from `fetch_url` (or any
+        local `.html` file) when you want clean, LLM-readable text:
+        headings as `#`, lists as `-`, tables as pipes, links as
+        `[text](url)`. Tables and structure survive — a flat tag-strip
+        would lose them.
+
+        Args:
+            path: Path to the HTML file.
+            main_content: If True (default), reduce to the article body
+                first by stripping nav/aside/footer/header and preferring
+                a `<main>` / `<article>` / known content wrapper. Set
+                False for reference pages (Wikipedia, docs) where the
+                whole document is the content.
+
+        Returns:
+            Markdown text. Large outputs auto-offload via the standard
+            attachment path.
+        """
+        ok, payload = _read_html(path)
+        if not ok:
+            return payload
+        return extraction.html_to_markdown(payload, main_content=main_content)
+
+    def html_select(path: str, css: str, limit: int = 50) -> str:
+        """Run a CSS selector against an HTML file; return matches as
+        markdown.
+
+        The structured-extraction escape hatch when `html_to_md` would
+        lose the shape you care about — table rows, list items at a
+        specific selector, links inside a sidebar, etc. Each match is
+        rendered as a markdown block separated by `---`.
+
+        Args:
+            path: Path to the HTML file.
+            css: CSS selector. Examples: `"table.wikitable tr"`,
+                `"div.article a[href]"`, `"h2"`.
+            limit: Maximum matches to return. Defaults to 50; raise it
+                deliberately when you know the page has many small
+                matches and you want them all.
+
+        Returns:
+            Markdown of the matched elements, joined by horizontal
+            rules. A trailing note mentions the truncation if more
+            matches exist than `limit`.
+        """
+        ok, payload = _read_html(path)
+        if not ok:
+            return payload
+        md, total, returned = extraction.html_select_to_markdown(
+            payload, css, limit=limit
+        )
+        if total == 0:
+            return f"<no matches for selector {css!r} in {path}>"
+        if returned < total:
+            md = (
+                md
+                + f"\n[matched {total}; showing first {returned}. "
+                f"Re-run with a tighter selector or higher `limit` to see more.]\n"
+            )
+        return md
+
+    api.register_tool("html_to_md", html_to_md)
+    api.register_tool("html_select", html_select)

--- a/pyagent/plugins/html_tools/extraction.py
+++ b/pyagent/plugins/html_tools/extraction.py
@@ -1,0 +1,121 @@
+"""HTML parsing and markdown rendering — shared between this plugin's
+tools and core's `fetch_url`.
+
+Lives inside the plugin package so disabling the plugin removes the
+tool surface; core soft-imports from here, so when the plugin is
+disabled, `fetch_url` falls back to raw-attachment-only and skips
+markdown conversion. When the plugin is enabled (the default), both
+the plugin tools and `fetch_url` share one implementation.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from bs4 import BeautifulSoup
+from markdownify import markdownify
+
+
+# Tags whose presence almost always means boilerplate, not content. We
+# strip these unconditionally — even when main_content=False — because
+# they break markdown rendering (script/style content embedded in the
+# converter output is noise, not signal).
+_ALWAYS_STRIP = ("script", "style", "noscript", "template")
+
+# Tags that frame the page chrome rather than the content. Stripped
+# only when `main_content=True`.
+_BOILERPLATE = ("nav", "aside", "footer", "header", "form")
+
+# Selectors we try in order to find the article body when the page
+# doesn't use a single <main> or <article> wrapper.
+_MAIN_CANDIDATES = (
+    "main",
+    "article",
+    "[role='main']",
+    "#content",
+    "#main-content",
+    ".main-content",
+    ".article-body",
+    ".post-content",
+    ".entry-content",
+)
+
+
+def _strip_tags(soup: BeautifulSoup, names: Iterable[str]) -> None:
+    for tag_name in names:
+        for tag in soup.find_all(tag_name):
+            tag.decompose()
+
+
+def _find_main(soup: BeautifulSoup):
+    """Best-effort article-body locator. Returns the matched element or
+    None if no candidate selector hits."""
+    for selector in _MAIN_CANDIDATES:
+        match = soup.select_one(selector)
+        if match is not None:
+            return match
+    return None
+
+
+def html_to_markdown(html: str, *, main_content: bool = True) -> str:
+    """Render `html` as markdown.
+
+    With `main_content=True`, attempts a readability-style reduction
+    first: remove obvious boilerplate (nav/aside/footer/etc.) and prefer
+    a `<main>` / `<article>` / known content-wrapper region if one
+    exists. With `main_content=False`, converts the whole document
+    after stripping only `<script>` / `<style>` noise.
+
+    Returns markdown text. Whitespace is normalized; the markdown is
+    safe to embed in conversation history.
+    """
+    soup = BeautifulSoup(html or "", "html.parser")
+    _strip_tags(soup, _ALWAYS_STRIP)
+
+    target = soup
+    if main_content:
+        _strip_tags(soup, _BOILERPLATE)
+        main = _find_main(soup)
+        if main is not None:
+            target = main
+
+    md = markdownify(str(target), heading_style="ATX")
+    # Markdownify can leave long runs of blank lines from divs/spans;
+    # collapse runs of >2 blank lines down to 2 so the markdown reads
+    # cleanly without changing the structural meaning.
+    lines = md.splitlines()
+    out: list[str] = []
+    blanks = 0
+    for line in lines:
+        if line.strip() == "":
+            blanks += 1
+            if blanks > 2:
+                continue
+        else:
+            blanks = 0
+        out.append(line.rstrip())
+    return "\n".join(out).strip() + "\n"
+
+
+def html_select_to_markdown(
+    html: str, css: str, *, limit: int = 50
+) -> tuple[str, int, int]:
+    """Run a CSS selector against `html` and render matches as markdown.
+
+    Returns `(markdown, matched_count, returned_count)`. When matches
+    exceed `limit`, the markdown is truncated to the first `limit`
+    items and the caller can mention the gap in its result message.
+    Each returned match is separated by a horizontal rule so the agent
+    can scan record boundaries without ambiguity.
+    """
+    soup = BeautifulSoup(html or "", "html.parser")
+    _strip_tags(soup, _ALWAYS_STRIP)
+    matches = soup.select(css)
+    total = len(matches)
+    kept = matches[:limit] if limit > 0 else matches
+    rendered: list[str] = []
+    for el in kept:
+        chunk = markdownify(str(el), heading_style="ATX").strip()
+        if chunk:
+            rendered.append(chunk)
+    return ("\n\n---\n\n".join(rendered) + "\n", total, len(kept))

--- a/pyagent/plugins/html_tools/manifest.toml
+++ b/pyagent/plugins/html_tools/manifest.toml
@@ -1,0 +1,17 @@
+name = "html-tools"
+version = "0.1.0"
+description = "Interrogate saved HTML attachments — convert to markdown, select by CSS."
+api_version = "1"
+
+# These tools operate on saved attachments produced by fetch_url (or any
+# local HTML file the agent has access to). fetch_url itself also calls
+# into this plugin's extraction module as a convenience for its default
+# format="md" path; if the plugin is disabled, fetch_url falls back to
+# raw-attachment-only and the agent loses the markdown convenience but
+# can still grep / read_file the saved HTML.
+[provides]
+tools = ["html_to_md", "html_select"]
+
+# Stateless and read-only — safe to load in subagents.
+[load]
+in_subagents = true

--- a/pyagent/tools.py
+++ b/pyagent/tools.py
@@ -436,22 +436,88 @@ _FETCH_UA = (
     "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
 )
 
+# Cap the inline markdown so a giant page can't blow the conversation.
+# Past this size we truncate the inline body and tell the agent to call
+# html_to_md(path, ...) on the saved raw attachment for the full output.
+_FETCH_INLINE_MD_CEILING = 8000
 
-def fetch_url(url: str) -> str:
-    """Fetch a URL via HTTP GET and return the response body as text.
+# Soft import: when the html-tools plugin is enabled (the default),
+# fetch_url uses its conversion as a convenience. When the plugin is
+# disabled or its deps are missing, we fall back to raw-attachment-only.
+try:
+    from pyagent.plugins.html_tools import extraction as _html_extraction
+except ImportError:
+    _html_extraction = None
 
-    GET-only. Non-2xx responses come back as data (a `status: 404` line
-    followed by the body) rather than as errors — read the status line
-    and adapt. For POST, custom headers, auth, or anything beyond a
-    plain GET, drop into `execute` with `curl` instead.
+
+def _detect_content_type(headers: dict, body: str) -> tuple[str, bool]:
+    """Return (content_type, is_html). content_type is the mime portion
+    of the Content-Type header, lowercased; is_html is True for HTML
+    responses (used to decide whether markdown conversion applies)."""
+    raw = (headers.get("Content-Type") or headers.get("content-type") or "")
+    ctype = raw.split(";", 1)[0].strip().lower()
+    if not ctype:
+        # Cheap content sniff for hosts that don't set Content-Type.
+        head = body[:512].lstrip().lower()
+        if head.startswith("<!doctype html") or head.startswith("<html"):
+            ctype = "text/html"
+        elif head.startswith(("{", "[")):
+            ctype = "application/json"
+        else:
+            ctype = "text/plain"
+    is_html = "html" in ctype
+    return ctype, is_html
+
+
+def _suffix_for_content_type(ctype: str) -> str:
+    if "html" in ctype:
+        return ".html"
+    if "json" in ctype:
+        return ".json"
+    if "xml" in ctype:
+        return ".xml"
+    return ".txt"
+
+
+def fetch_url(
+    url: str,
+    format: str = "md",
+    main_content: bool = True,
+) -> "str | Attachment":
+    """Fetch a URL via HTTP GET; save the raw response and return a
+    convenience preview.
+
+    The raw response body is *always* saved to a session attachment.
+    The returned tool result names that path so you can follow up with
+    `html_to_md`, `html_select`, `grep`, or `read_file` against the
+    saved file — no need to re-fetch.
+
+    GET-only. Non-2xx responses still save and report normally; the
+    HTTP status appears in the result. For POST, custom headers, auth,
+    or anything beyond a plain GET, drop into `execute` with `curl`.
 
     Args:
         url: URL to fetch.
+        format: Output format. `"md"` (default) converts HTML responses
+            to markdown and includes it inline alongside the saved-path
+            stub — one tool call covers article-body extraction.
+            `"void"` skips conversion and returns only the path stub
+            with no inline body — use when you'll interrogate the page
+            with `html_select` / `grep` and don't want to pay tokens
+            for a markdown preview you won't read, or when fetching
+            multiple URLs to triage cheaply.
+        main_content: When `format="md"` and the response is HTML, run
+            a readability-style reduction first (drop nav/aside/footer
+            and prefer `<main>` / `<article>`). Default `True` matches
+            the news/blog/article majority. Set False for reference
+            pages (Wikipedia, docs) where the whole document is the
+            content.
 
     Returns:
-        Status code line followed by the response body. Network
-        failures (DNS, connection refused, timeout) are reported as a
-        leading `<request failed: ...>` marker rather than raised.
+        An attachment-style stub naming the saved path, the response
+        status and content type, and — when applicable — the converted
+        markdown inline. Network failures (DNS, connection refused,
+        timeout) come back as `<request failed: ...>` instead.
     """
     try:
         response = requests.get(
@@ -459,4 +525,70 @@ def fetch_url(url: str) -> str:
         )
     except requests.RequestException as e:
         return f"<request failed: {e}>"
-    return f"status: {response.status_code}\n{response.text}"
+
+    body = response.text
+    ctype, is_html = _detect_content_type(dict(response.headers), body)
+    suffix = _suffix_for_content_type(ctype)
+    size = len(body)
+
+    header_lines = [
+        f"Fetched {url} (status {response.status_code}, "
+        f"{size} chars, {ctype}).",
+    ]
+
+    if format == "void":
+        header_lines.append(
+            "No content returned (format=\"void\"). Use `html_to_md`, "
+            "`html_select`, `grep`, or `read_file` on the saved path "
+            "to interrogate."
+        )
+        preview = "\n".join(header_lines)
+        return Attachment(content=body, preview=preview, suffix=suffix)
+
+    if not is_html or _html_extraction is None:
+        if not is_html:
+            header_lines.append(
+                f"Non-HTML response. Use `read_file` / `grep` on the "
+                f"saved path to extract."
+            )
+        else:
+            header_lines.append(
+                "html-tools plugin not available; markdown conversion "
+                "skipped. Use `read_file` / `grep` on the saved path."
+            )
+        preview = "\n".join(header_lines)
+        return Attachment(content=body, preview=preview, suffix=suffix)
+
+    try:
+        md = _html_extraction.html_to_markdown(
+            body, main_content=main_content
+        )
+    except Exception as e:
+        header_lines.append(
+            f"Markdown conversion failed ({type(e).__name__}: {e}). "
+            f"Use `html_to_md` directly on the saved path or fall back "
+            f"to `read_file` / `grep`."
+        )
+        preview = "\n".join(header_lines)
+        return Attachment(content=body, preview=preview, suffix=suffix)
+
+    md_size = len(md)
+    truncated = md_size > _FETCH_INLINE_MD_CEILING
+    if truncated:
+        md_inline = (
+            md[:_FETCH_INLINE_MD_CEILING]
+            + "\n\n[markdown truncated; call "
+            "`html_to_md(<saved path>, main_content="
+            f"{main_content})` for the full output.]"
+        )
+    else:
+        md_inline = md
+
+    label = "main-content markdown" if main_content else "full-document markdown"
+    header_lines.append(
+        f"{label} ({md_size} chars{', truncated inline' if truncated else ''}). "
+        f"For CSS extraction or raw search, use `html_select` / "
+        f"`grep` / `read_file` on the saved path."
+    )
+    preview = "\n".join(header_lines) + "\n\n" + md_inline
+    return Attachment(content=body, preview=preview, suffix=suffix)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,11 @@ version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
     "anthropic>=0.40",
+    "beautifulsoup4>=4.12",
     "click>=8.1",
     "docstring_parser>=0.16",
     "google-genai>=0.8",
+    "markdownify>=0.11",
     "openai>=1.50",
     "petname>=2.6",
     "platformdirs>=4",

--- a/tests/smoke_html_tools.py
+++ b/tests/smoke_html_tools.py
@@ -1,0 +1,252 @@
+"""End-to-end smoke for the html-tools plugin and the restructured
+fetch_url.
+
+Three concerns:
+
+  1. **Plugin loads, registers expected tools.** With "html-tools" in
+     built_in_plugins_enabled, `discover()` and `load()` produce the
+     two tools (`html_to_md`, `html_select`).
+
+  2. **Conversion behaves.** `html_to_markdown` produces clean markdown
+     (headings, lists, links survive); `html_to_markdown(...,
+     main_content=True)` strips boilerplate (nav/footer); selector
+     extraction returns matched markdown chunks.
+
+  3. **fetch_url returns an Attachment with raw content saved + the
+     right preview shape.** The preview carries inline markdown for
+     `format="md"` and a content-type-aware stub for `format="void"` /
+     non-HTML / plugin-disabled paths. The Attachment's content holds
+     the full raw response so html_select / grep / read_file can run
+     against the saved path.
+
+Run with:
+
+    .venv/bin/python -m tests.smoke_html_tools
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+from pyagent import config as config_mod, paths as paths_mod, plugins, tools
+from pyagent.plugins.html_tools import extraction
+from pyagent.session import Attachment
+
+
+_NEWS_HTML = """
+<!doctype html>
+<html><head><title>headline</title></head>
+<body>
+  <header><nav>home / about / contact</nav></header>
+  <aside class="sidebar">related: a, b, c</aside>
+  <main>
+    <h1>The Real Story</h1>
+    <p>First paragraph with a <a href="https://example.com">link</a>.</p>
+    <ul><li>one</li><li>two</li></ul>
+  </main>
+  <footer>copyright 2026</footer>
+</body></html>
+"""
+
+_TABLE_HTML = """
+<!doctype html>
+<html><body>
+  <h1>Books</h1>
+  <table class="wikitable">
+    <tr><th>Title</th><th>Year</th></tr>
+    <tr><td>The Gunslinger</td><td>1982</td></tr>
+    <tr><td>The Drawing of the Three</td><td>1987</td></tr>
+  </table>
+</body></html>
+"""
+
+
+def _check_extraction_main_content() -> None:
+    md = extraction.html_to_markdown(_NEWS_HTML, main_content=True)
+    # Boilerplate stripped.
+    assert "home / about / contact" not in md, md
+    assert "related:" not in md, md
+    assert "copyright 2026" not in md, md
+    # Real content kept, structure preserved.
+    assert "The Real Story" in md, md
+    assert "[link](https://example.com)" in md, md
+    # List survives as bullets.
+    assert "- one" in md or "* one" in md, md
+    print(f"✓ extraction.main_content drops boilerplate, keeps structure")
+
+
+def _check_extraction_full_document() -> None:
+    md = extraction.html_to_markdown(_NEWS_HTML, main_content=False)
+    # With main_content=False, boilerplate stays.
+    assert "home / about / contact" in md or "home" in md, md
+    assert "The Real Story" in md, md
+    print(f"✓ extraction.main_content=False preserves the whole document")
+
+
+def _check_extraction_select_table() -> None:
+    md, total, returned = extraction.html_select_to_markdown(
+        _TABLE_HTML, "table.wikitable tr", limit=10
+    )
+    assert total == 3, total
+    assert returned == 3, returned
+    assert "The Gunslinger" in md, md
+    assert "1982" in md, md
+    assert "The Drawing of the Three" in md, md
+    # Records separated by horizontal rules.
+    assert md.count("---") >= 2, md
+    print(f"✓ extraction.select returns matched markdown, {total} matches")
+
+
+def _check_extraction_select_limit() -> None:
+    md, total, returned = extraction.html_select_to_markdown(
+        _TABLE_HTML, "tr", limit=2
+    )
+    assert total == 3, total
+    assert returned == 2, returned
+    print(f"✓ extraction.select honors limit (matched {total}, kept {returned})")
+
+
+def _check_plugin_loads_under_default_config() -> None:
+    """With the default config, html-tools is in built_in_plugins_enabled
+    and load() exposes both tools."""
+    tmp = Path(tempfile.mkdtemp(prefix="pyagent-smoke-htmltools-"))
+    # Point config_dir at an empty temp dir so user/project config can't
+    # mask the bundled defaults (e.g. an existing user config that hasn't
+    # added "html-tools" yet).
+    with mock.patch.object(paths_mod, "config_dir", return_value=tmp):
+        with mock.patch.object(
+            plugins, "LOCAL_PLUGINS_DIR", Path(tmp / "no_local_plugins")
+        ):
+            cfg = config_mod.load()
+            assert "html-tools" in cfg["built_in_plugins_enabled"], (
+                cfg["built_in_plugins_enabled"]
+            )
+            loaded = plugins.load()
+            tool_names = set(loaded.tools().keys())
+    assert "html_to_md" in tool_names, tool_names
+    assert "html_select" in tool_names, tool_names
+    print(f"✓ plugin loads by default; tools = {sorted(tool_names)}")
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        text: str,
+        *,
+        status_code: int = 200,
+        content_type: str = "text/html; charset=utf-8",
+    ) -> None:
+        self.text = text
+        self.status_code = status_code
+        self.headers = {"Content-Type": content_type}
+
+
+def _check_fetch_url_md_default() -> None:
+    """fetch_url returns an Attachment whose content is the raw body
+    and whose preview includes the converted markdown."""
+    with mock.patch.object(
+        tools.requests, "get", return_value=_FakeResponse(_NEWS_HTML)
+    ):
+        result = tools.fetch_url("https://example.com/news")
+    assert isinstance(result, Attachment), type(result)
+    assert result.content == _NEWS_HTML, "raw content should be saved verbatim"
+    assert result.suffix == ".html", result.suffix
+    # Preview should mention the URL/status, the content type, and
+    # contain the converted markdown.
+    assert "https://example.com/news" in result.preview, result.preview
+    assert "status 200" in result.preview, result.preview
+    assert "text/html" in result.preview, result.preview
+    assert "The Real Story" in result.preview, result.preview
+    assert "[link](https://example.com)" in result.preview, result.preview
+    # Boilerplate must not survive the main-content extraction.
+    assert "home / about / contact" not in result.preview, result.preview
+    print(f"✓ fetch_url(format='md') saves raw + inlines markdown")
+
+
+def _check_fetch_url_void() -> None:
+    """format='void' returns only the stub — no markdown body."""
+    with mock.patch.object(
+        tools.requests, "get", return_value=_FakeResponse(_NEWS_HTML)
+    ):
+        result = tools.fetch_url(
+            "https://example.com/x", format="void"
+        )
+    assert isinstance(result, Attachment), type(result)
+    assert result.content == _NEWS_HTML, "raw still saved"
+    assert "format=\"void\"" in result.preview, result.preview
+    # Markdown body must NOT appear in preview.
+    assert "The Real Story" not in result.preview, result.preview
+    assert "[link]" not in result.preview, result.preview
+    print(f"✓ fetch_url(format='void') saves raw, omits markdown body")
+
+
+def _check_fetch_url_non_html() -> None:
+    """JSON / non-HTML responses skip conversion regardless of format."""
+    body = '{"ok": true, "items": [1, 2, 3]}'
+    with mock.patch.object(
+        tools.requests,
+        "get",
+        return_value=_FakeResponse(
+            body, content_type="application/json"
+        ),
+    ):
+        result = tools.fetch_url("https://api.example.com/x")
+    assert isinstance(result, Attachment), type(result)
+    assert result.content == body, result.content
+    assert result.suffix == ".json", result.suffix
+    assert "application/json" in result.preview, result.preview
+    assert "Non-HTML" in result.preview, result.preview
+    print(f"✓ fetch_url skips conversion for non-HTML responses")
+
+
+def _check_fetch_url_large_md_truncates() -> None:
+    """When converted markdown exceeds the inline ceiling, the preview
+    is truncated and points at html_to_md on the saved path."""
+    big_html = (
+        "<html><body><main>"
+        + "".join(f"<p>line {i} " + "x " * 200 + "</p>" for i in range(60))
+        + "</main></body></html>"
+    )
+    with mock.patch.object(
+        tools.requests, "get", return_value=_FakeResponse(big_html)
+    ):
+        result = tools.fetch_url("https://example.com/big")
+    assert isinstance(result, Attachment), type(result)
+    assert "markdown truncated" in result.preview, result.preview
+    assert "html_to_md" in result.preview, result.preview
+    # Raw still saved untouched.
+    assert result.content == big_html
+    print(f"✓ fetch_url truncates oversized markdown with a recovery hint")
+
+
+def _check_fetch_url_request_failure() -> None:
+    import requests as _real_requests
+
+    def _boom(*a, **kw):
+        raise _real_requests.ConnectionError("boom")
+
+    with mock.patch.object(tools.requests, "get", side_effect=_boom):
+        result = tools.fetch_url("https://nope.invalid")
+    assert isinstance(result, str), type(result)
+    assert result.startswith("<request failed:"), result
+    print(f"✓ fetch_url surfaces network failures as <request failed: ...>")
+
+
+def main() -> None:
+    _check_extraction_main_content()
+    _check_extraction_full_document()
+    _check_extraction_select_table()
+    _check_extraction_select_limit()
+    _check_plugin_loads_under_default_config()
+    _check_fetch_url_md_default()
+    _check_fetch_url_void()
+    _check_fetch_url_non_html()
+    _check_fetch_url_large_md_truncates()
+    _check_fetch_url_request_failure()
+    print("smoke_html_tools: all checks passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Two coupled changes that replace the multi-turn HTML scrub choreography observed in the `2026-04-30-well-mako` session (#8):

- **New bundled `html-tools` plugin** providing `html_to_md` (markdown conversion) and `html_select` (CSS selector → markdown). Operates on saved HTML attachments.
- **`fetch_url` restructure** — always saves raw response to a session attachment, plus a new `format` parameter (`"md"` default, `"void"` for triage) and `main_content` toggle.

The plugin's `extraction` module is the single implementation; `fetch_url` soft-imports it as a convenience for the default-clean path. Disabling the plugin (or missing deps) gracefully degrades `fetch_url` to raw-attachment-only.

## Behavior changes

| Call | Before | After |
|------|--------|-------|
| `fetch_url(url)` | Returns raw HTML inline (≤8K) or offload stub (>8K) | Always saves raw to attachment; returns markdown of the article body inline alongside the path stub |
| `fetch_url(url, format="void")` | n/a | Saves raw, returns path stub only — for triage / batch fetches |
| `fetch_url(url, main_content=False)` | n/a | Converts the whole document instead of reducing to article body — for Wikipedia-style reference pages |
| `html_to_md(path)` | n/a | Renders saved HTML as markdown |
| `html_select(path, css, limit=50)` | n/a | CSS-selector extraction returning matched markdown blocks |

## Why this fixes the well-mako pattern

The session spent 7 turns iterating a `re.sub('<[^>]+>', ' ', ...)` HTML stripper across `python3 -c` calls, with progressively patched entity escapes. ~10K chars of conversation churn for what is now a single `fetch_url(url)` call returning clean markdown. Structured cases (Wikipedia book table) become `fetch_url(url, format="void")` → `html_select(path, "table.wikitable tr")` — two calls instead of seven, with table structure preserved as markdown rows.

## Default-enabled

`html-tools` is added to `built_in_plugins_enabled` defaults alongside `memory-markdown`. Stateless and read-only — `[load] in_subagents = true`, so subagents inherit the surface.

**Note for existing users:** anyone with an explicit `built_in_plugins_enabled` in their config.toml needs to add `"html-tools"` manually; the bundled defaults only apply when the key isn't set in user config.

## Implementation

- `pyagent/plugins/html_tools/{manifest.toml, __init__.py, extraction.py}` — the plugin.
- `pyagent/tools.py::fetch_url` — restructured. Soft-imports `pyagent.plugins.html_tools.extraction`; falls back to raw-only if unavailable.
- `pyagent/config.py` — `"html-tools"` added to defaults.
- `pyproject.toml` — adds `beautifulsoup4>=4.12` and `markdownify>=0.11`.
- Markdown conversion uses BeautifulSoup for parsing (also drives `html_select`) and markdownify for rendering. Main-content extraction is a heuristic: strip `<script>` / `<style>` always; with `main_content=True` also strip `<nav>` / `<aside>` / `<footer>` / `<header>` / `<form>` and prefer `<main>` / `<article>` / common content wrappers.

## Test plan

- [x] `tests/smoke_html_tools.py` — 10 checks covering extraction quality, selector limits, plugin discovery under default config, fetch_url path stub shape for `md` / `void` / non-HTML / oversized-md / network-failure.
- [x] Full smoke suite — all pass except `smoke_token_meter` which fails identically on `main` (pre-existing, unrelated `StubClientWithUsage.respond()` signature mismatch).
- [ ] Manual: drive the agent through a real research task (the well-mako scenario) and verify the conversation shape.

## Out of scope

- Eviction of saved attachments after they're no longer needed (#10).
- `read_file` ranged-read char ceiling (#9).
- Cache token logging (#8).
- Saving a sibling `.md` attachment when conversion runs — agent re-runs `html_to_md` on the saved HTML if it needs the full markdown (open question in #12, deferred).

Closes #11. Closes #12.