### PR TITLE
Cache token logging + read_file ranged-read ceiling (#8, #9)

### DIFF
--- a/pyagent/agent.py
+++ b/pyagent/agent.py
@@ -67,7 +67,12 @@ class Agent:
         # `on_usage` callback fired in `run` lets agent_proc forward
         # per-call deltas upstream so the CLI can render a running
         # cost meter.
-        self.token_usage: dict[str, int] = {"input": 0, "output": 0}
+        self.token_usage: dict[str, int] = {
+            "input": 0,
+            "output": 0,
+            "cache_creation": 0,
+            "cache_read": 0,
+        }
         # Async subagent inbox. The IO thread (in agent_proc) puts
         # formatted reply strings here when an async-fired subagent
         # finishes its turn. `_drain_pending_async`, called at the
@@ -150,6 +155,13 @@ class Agent:
     # needs to recover them.
     TOOL_ARG_ELIDE_THRESHOLD = 4_000
 
+    # Tools that bypass auto_offload but still get the soft threshold
+    # applied — `read_file` is registered with auto_offload=False so a
+    # small explicit read returns inline, but the soft threshold
+    # (8000 chars by default) still needs to fire on a runaway ranged
+    # read of HTML / a wide log line / a binary mistakenly read as text.
+    SOFT_THRESHOLD_FORCED_TOOLS: frozenset[str] = frozenset({"read_file"})
+
     def _render_tool_result(self, name: str, result: Any) -> str:
         if isinstance(result, Attachment):
             if not self.session:
@@ -176,7 +188,12 @@ class Agent:
             auto = self._auto_offload.get(name, True)
             over_threshold = len(text) > self.session.attachment_threshold
             over_ceiling = len(text) > self.HARD_OFFLOAD_CEILING
-            if (auto and over_threshold) or over_ceiling:
+            forced_soft = (
+                not auto
+                and name in self.SOFT_THRESHOLD_FORCED_TOOLS
+                and over_threshold
+            )
+            if (auto and over_threshold) or over_ceiling or forced_soft:
                 path = self.session.write_attachment(name, text)
                 preview = text[: self.session.preview_chars]
                 return self._format_offload_ref(path, len(text), preview)
@@ -310,8 +327,8 @@ class Agent:
             self.conversation.append(turn)
             usage = turn.get("usage") if isinstance(turn, dict) else None
             if usage:
-                self.token_usage["input"] += int(usage.get("input", 0) or 0)
-                self.token_usage["output"] += int(usage.get("output", 0) or 0)
+                for k in ("input", "output", "cache_creation", "cache_read"):
+                    self.token_usage[k] += int(usage.get(k, 0) or 0)
                 if on_usage:
                     on_usage(usage)
 

--- a/pyagent/agent_proc.py
+++ b/pyagent/agent_proc.py
@@ -613,6 +613,8 @@ def _run_turn(
                 "usage",
                 input=int(u.get("input", 0) or 0),
                 output=int(u.get("output", 0) or 0),
+                cache_creation=int(u.get("cache_creation", 0) or 0),
+                cache_read=int(u.get("cache_read", 0) or 0),
             ),
             cancel_event=state.cancel_event,
         )

--- a/pyagent/cli.py
+++ b/pyagent/cli.py
@@ -213,16 +213,26 @@ def _format_usage_suffix(
     """Build the ` [Nk tok / $0.0X]` suffix for the status footer.
 
     Empty string when there's nothing to show (no LLM calls yet).
-    The displayed token total bundles all four counts (input, output,
-    cache writes, cache reads); the cost estimate weights cache writes
-    and reads by their respective multipliers on Anthropic.
+    On Anthropic the four token counts (input, output, cache writes,
+    cache reads) are disjoint — `input_tokens` excludes both cache
+    reads and writes — so the displayed total bundles all four. On
+    OpenAI / Gemini the providers' "input" already includes their
+    cached-token count; bundling cache_read on top would double-count
+    the same tokens in the displayed total. Cost estimation in
+    `_estimate_cost_usd` already gates the cache-pricing multipliers
+    to Anthropic; this gate keeps the displayed token count honest the
+    same way.
     """
-    total = (
-        input_tokens
-        + output_tokens
-        + cache_creation_tokens
-        + cache_read_tokens
-    )
+    name = _model_name(model)
+    if _is_anthropic_model(name):
+        total = (
+            input_tokens
+            + output_tokens
+            + cache_creation_tokens
+            + cache_read_tokens
+        )
+    else:
+        total = input_tokens + output_tokens
     if total == 0:
         return ""
     if total >= 1000:

--- a/pyagent/cli.py
+++ b/pyagent/cli.py
@@ -123,6 +123,15 @@ _PRICING_USD_PER_MTOK: dict[str, tuple[float, float]] = {
     "gemini-2.5-flash": (0.075, 0.30),
 }
 
+# Anthropic ephemeral-cache pricing multipliers applied to the model's
+# base input rate: writes are 1.25× input, reads are 0.1× input.
+_ANTHROPIC_CACHE_WRITE_MULT = 1.25
+_ANTHROPIC_CACHE_READ_MULT = 0.1
+
+
+def _is_anthropic_model(name: str) -> bool:
+    return name.startswith("claude-")
+
 
 def _model_name(model_str: str) -> str:
     """Extract the bare model name from a 'provider/name' string.
@@ -163,11 +172,21 @@ def _resolve_model(cli_model: str | None) -> str:
 
 
 def _estimate_cost_usd(
-    model: str, input_tokens: int, output_tokens: int
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cache_creation_tokens: int = 0,
+    cache_read_tokens: int = 0,
 ) -> float | None:
     """USD cost estimate, or None if the model isn't in the pricing
     table. Falls back gracefully on unknown / future models — the
-    footer renders just the token count in that case."""
+    footer renders just the token count in that case.
+
+    Anthropic ephemeral-cache writes/reads are billed at multiples of
+    the base input rate. OpenAI and Gemini surface cached counts but
+    bill them inside `prompt_tokens` / `prompt_token_count` at the
+    regular input rate, so no separate adjustment is needed for those.
+    """
     name = _model_name(model)
     if not name:
         # Model defaulted from provider; the AnthropicClient/etc set
@@ -177,24 +196,46 @@ def _estimate_cost_usd(
     if rates is None:
         return None
     in_rate, out_rate = rates
-    return (input_tokens * in_rate + output_tokens * out_rate) / 1_000_000
+    cost = input_tokens * in_rate + output_tokens * out_rate
+    if _is_anthropic_model(name):
+        cost += cache_creation_tokens * in_rate * _ANTHROPIC_CACHE_WRITE_MULT
+        cost += cache_read_tokens * in_rate * _ANTHROPIC_CACHE_READ_MULT
+    return cost / 1_000_000
 
 
 def _format_usage_suffix(
-    input_tokens: int, output_tokens: int, model: str
+    input_tokens: int,
+    output_tokens: int,
+    model: str,
+    cache_creation_tokens: int = 0,
+    cache_read_tokens: int = 0,
 ) -> str:
     """Build the ` [Nk tok / $0.0X]` suffix for the status footer.
 
     Empty string when there's nothing to show (no LLM calls yet).
+    The displayed token total bundles all four counts (input, output,
+    cache writes, cache reads); the cost estimate weights cache writes
+    and reads by their respective multipliers on Anthropic.
     """
-    total = input_tokens + output_tokens
+    total = (
+        input_tokens
+        + output_tokens
+        + cache_creation_tokens
+        + cache_read_tokens
+    )
     if total == 0:
         return ""
     if total >= 1000:
         tok_str = f"{total / 1000:.1f}k tok"
     else:
         tok_str = f"{total} tok"
-    cost = _estimate_cost_usd(model, input_tokens, output_tokens)
+    cost = _estimate_cost_usd(
+        model,
+        input_tokens,
+        output_tokens,
+        cache_creation_tokens,
+        cache_read_tokens,
+    )
     if cost is None:
         return f" [{tok_str}]"
     if cost < 0.01:
@@ -204,11 +245,18 @@ def _format_usage_suffix(
     return f" [{tok_str} / {cost_str}]"
 
 
-def _agents_tokens(agents: dict) -> tuple[int, int]:
-    """Sum input/output tokens across all tracked agents."""
+def _agents_tokens(agents: dict) -> tuple[int, int, int, int]:
+    """Sum input/output/cache-write/cache-read tokens across all
+    tracked agents."""
     in_tot = sum(a.get("tokens", {}).get("input", 0) for a in agents.values())
     out_tot = sum(a.get("tokens", {}).get("output", 0) for a in agents.values())
-    return in_tot, out_tot
+    cw_tot = sum(
+        a.get("tokens", {}).get("cache_creation", 0) for a in agents.values()
+    )
+    cr_tot = sum(
+        a.get("tokens", {}).get("cache_read", 0) for a in agents.values()
+    )
+    return in_tot, out_tot, cw_tot, cr_tot
 
 
 def _render_status(agents: dict, model: str = "") -> str:
@@ -223,8 +271,8 @@ def _render_status(agents: dict, model: str = "") -> str:
     subagents in spawn order) which gives a stable left-to-right read.
     Token/cost suffix is the aggregate across the whole tree.
     """
-    in_tot, out_tot = _agents_tokens(agents)
-    suffix = _format_usage_suffix(in_tot, out_tot, model)
+    in_tot, out_tot, cw_tot, cr_tot = _agents_tokens(agents)
+    suffix = _format_usage_suffix(in_tot, out_tot, model, cw_tot, cr_tot)
     if len(agents) <= 1:
         status = agents.get("root", {}).get("status", "thinking")
         return f"[dim]{status}…{suffix}[/dim]"
@@ -278,9 +326,15 @@ def _update_agents_state(
             return
     if kind == "usage":
         slot = agents.setdefault(key, {"status": "idle"})
-        tokens = slot.setdefault("tokens", {"input": 0, "output": 0})
-        tokens["input"] += int(event.get("input", 0) or 0)
-        tokens["output"] += int(event.get("output", 0) or 0)
+        # Use .get(k, 0) + … so old two-key dicts in long-running state
+        # (or session.jsonl re-replays predating the cache schema) don't
+        # KeyError on cache_creation / cache_read.
+        tokens = slot.setdefault(
+            "tokens",
+            {"input": 0, "output": 0, "cache_creation": 0, "cache_read": 0},
+        )
+        for k in ("input", "output", "cache_creation", "cache_read"):
+            tokens[k] = tokens.get(k, 0) + int(event.get(k, 0) or 0)
         return
 
 

--- a/pyagent/llms/anthropic.py
+++ b/pyagent/llms/anthropic.py
@@ -112,6 +112,8 @@ class AnthropicClient:
             "usage": {
                 "input": getattr(usage, "input_tokens", 0) or 0,
                 "output": getattr(usage, "output_tokens", 0) or 0,
+                "cache_creation": getattr(usage, "cache_creation_input_tokens", 0) or 0,
+                "cache_read": getattr(usage, "cache_read_input_tokens", 0) or 0,
             },
         }
 

--- a/pyagent/llms/gemini.py
+++ b/pyagent/llms/gemini.py
@@ -111,6 +111,8 @@ class GeminiClient:
             "usage": {
                 "input": getattr(usage_meta, "prompt_token_count", 0) or 0,
                 "output": getattr(usage_meta, "candidates_token_count", 0) or 0,
+                "cache_creation": 0,
+                "cache_read": getattr(usage_meta, "cached_content_token_count", 0) or 0,
             },
         }
 

--- a/pyagent/llms/openai.py
+++ b/pyagent/llms/openai.py
@@ -89,6 +89,8 @@ class OpenAIClient:
             )
 
         usage = getattr(response, "usage", None)
+        prompt_details = getattr(usage, "prompt_tokens_details", None)
+        cache_read = getattr(prompt_details, "cached_tokens", 0) or 0
         return {
             "role": "assistant",
             "text": message.content or "",
@@ -96,6 +98,8 @@ class OpenAIClient:
             "usage": {
                 "input": getattr(usage, "prompt_tokens", 0) or 0,
                 "output": getattr(usage, "completion_tokens", 0) or 0,
+                "cache_creation": 0,
+                "cache_read": cache_read,
             },
         }
 

--- a/pyagent/llms/pyagent.py
+++ b/pyagent/llms/pyagent.py
@@ -46,7 +46,7 @@ class EchoClient:
         return {
             "text": text,
             "tool_calls": [],
-            "usage": {"input": 0, "output": 0},
+            "usage": {"input": 0, "output": 0, "cache_creation": 0, "cache_read": 0},
         }
 
 
@@ -102,5 +102,5 @@ class LoremClient:
         return {
             "text": "\n\n".join(paragraphs),
             "tool_calls": [],
-            "usage": {"input": 0, "output": 0},
+            "usage": {"input": 0, "output": 0, "cache_creation": 0, "cache_read": 0},
         }

--- a/tests/smoke_read_file_ceiling.py
+++ b/tests/smoke_read_file_ceiling.py
@@ -1,0 +1,111 @@
+"""Smoke for the read_file soft-threshold ceiling (issue #9).
+
+Locks four behaviors:
+  1. Small read_file output (< attachment_threshold) returns inline.
+  2. Large read_file output (between threshold and hard ceiling) is
+     forced to offload, returns the stub string.
+  3. Tools registered with auto_offload=False that are NOT in
+     SOFT_THRESHOLD_FORCED_TOOLS (e.g. read_skill) still bypass the
+     soft threshold.
+  4. Hard ceiling still fires for tools outside the forced set when
+     output exceeds HARD_OFFLOAD_CEILING.
+
+Constructed via Agent._render_tool_result(name, text) directly with a
+real Session in a tempdir — no Attachment(...) construction site is
+introduced (smoke_session_replay enforces that invariant).
+
+No subprocess, no network. Run with:
+    .venv/bin/python -m tests.smoke_read_file_ceiling
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from pyagent.agent import Agent
+from pyagent.session import Session
+
+
+def _make_agent(tmp: Path) -> Agent:
+    session = Session(session_id="ceiling", root=tmp)
+    session._ensure_dirs()
+    agent = Agent(client=None, session=session)  # client unused here
+    # Mirror agent_proc registration: read_file and read_skill bypass
+    # auto_offload, every other tool defaults to True.
+    agent.add_tool("read_file", lambda: None, auto_offload=False)
+    agent.add_tool("read_skill", lambda: None, auto_offload=False)
+    agent.add_tool("some_normal_tool", lambda: None, auto_offload=True)
+    return agent
+
+
+def _check_small_read_file_inline() -> None:
+    """A 200-char read_file result returns the original text inline."""
+    with tempfile.TemporaryDirectory(prefix="pyagent-smoke-ceiling-") as t:
+        agent = _make_agent(Path(t))
+        text = "x" * 200
+        rendered = agent._render_tool_result("read_file", text)
+        assert rendered == text, (
+            f"small read_file should return inline; got {rendered[:120]!r}"
+        )
+    print("✓ small read_file output returns inline")
+
+
+def _check_large_read_file_offloads() -> None:
+    """A 17_500-char read_file (> 8000 soft threshold, < 64000 hard ceiling)
+    is forced to offload via the SOFT_THRESHOLD_FORCED_TOOLS path."""
+    with tempfile.TemporaryDirectory(prefix="pyagent-smoke-ceiling-") as t:
+        agent = _make_agent(Path(t))
+        threshold = agent.session.attachment_threshold
+        ceiling = agent.HARD_OFFLOAD_CEILING
+        size = 17_500
+        assert threshold < size < ceiling, (
+            f"sanity: {threshold} < {size} < {ceiling}"
+        )
+        text = "y" * size
+        rendered = agent._render_tool_result("read_file", text)
+        assert "[output saved to" in rendered, rendered
+        assert text not in rendered, (
+            "raw payload leaked through soft-threshold offload"
+        )
+    print(f"✓ {size}-char read_file forced offload via soft threshold")
+
+
+def _check_read_skill_unaffected() -> None:
+    """read_skill is auto_offload=False but NOT in
+    SOFT_THRESHOLD_FORCED_TOOLS, so a 17_500-char result still returns
+    inline. This is the regression guard for #10."""
+    with tempfile.TemporaryDirectory(prefix="pyagent-smoke-ceiling-") as t:
+        agent = _make_agent(Path(t))
+        assert "read_skill" not in agent.SOFT_THRESHOLD_FORCED_TOOLS
+        text = "z" * 17_500
+        rendered = agent._render_tool_result("read_skill", text)
+        assert rendered == text, (
+            "read_skill should bypass soft threshold; got offload stub"
+        )
+    print("✓ read_skill bypasses soft threshold (regression guard for #10)")
+
+
+def _check_hard_ceiling_still_fires() -> None:
+    """Outputs over HARD_OFFLOAD_CEILING are offloaded regardless of
+    auto_offload, even for tools outside the forced set."""
+    with tempfile.TemporaryDirectory(prefix="pyagent-smoke-ceiling-") as t:
+        agent = _make_agent(Path(t))
+        ceiling = agent.HARD_OFFLOAD_CEILING
+        text = "q" * (ceiling + 5_000)
+        rendered = agent._render_tool_result("read_skill", text)
+        assert "[output saved to" in rendered, rendered
+        assert text not in rendered
+    print("✓ hard ceiling still offloads oversize read_skill output")
+
+
+def main() -> None:
+    _check_small_read_file_inline()
+    _check_large_read_file_offloads()
+    _check_read_skill_unaffected()
+    _check_hard_ceiling_still_fires()
+    print("\nALL CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/smoke_token_meter.py
+++ b/tests/smoke_token_meter.py
@@ -7,6 +7,11 @@ Exercises (in-process):
      per-agent.
   4. _render_status renders the token+cost suffix with sensible
      formatting for known and unknown models.
+  5. Cache-token aggregation: cache_creation / cache_read flow from
+     stub usage dicts through Agent.token_usage and `usage` events,
+     and the Anthropic-cache cost multipliers feed _estimate_cost_usd.
+  6. Backward compatibility: events / state predating the four-key
+     usage schema do not KeyError on cache fields.
 
 No subprocess, no real network. Run with:
 
@@ -50,6 +55,7 @@ class StubClientWithUsage:
         conversation: list[dict[str, Any]],
         system: str | None = None,
         tools: list[dict[str, Any]] | None = None,
+        system_volatile: str | None = None,
     ) -> dict[str, Any]:
         u = self.usages[min(self.calls, len(self.usages) - 1)]
         self.calls += 1
@@ -57,7 +63,50 @@ class StubClientWithUsage:
             "role": "assistant",
             "text": f"reply-{self.calls}",
             "tool_calls": [],
-            "usage": {"input": u[0], "output": u[1]},
+            "usage": {
+                "input": u[0],
+                "output": u[1],
+                "cache_creation": 0,
+                "cache_read": 0,
+            },
+        }
+
+
+class StubClientWithCacheUsage:
+    """Stub LLM that returns a fixed four-key usage dict including
+    Anthropic-shape cache_creation / cache_read counts."""
+
+    model = "stub-cache"
+
+    def __init__(
+        self,
+        input_t: int = 100,
+        output_t: int = 50,
+        cache_creation: int = 1000,
+        cache_read: int = 500,
+    ) -> None:
+        self.input_t = input_t
+        self.output_t = output_t
+        self.cache_creation = cache_creation
+        self.cache_read = cache_read
+
+    def respond(
+        self,
+        conversation: list[dict[str, Any]],
+        system: str | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        system_volatile: str | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "role": "assistant",
+            "text": "cache-reply",
+            "tool_calls": [],
+            "usage": {
+                "input": self.input_t,
+                "output": self.output_t,
+                "cache_creation": self.cache_creation,
+                "cache_read": self.cache_read,
+            },
         }
 
 
@@ -65,6 +114,78 @@ def _render_plain(markup: str) -> str:
     buf = io.StringIO()
     Console(file=buf, force_terminal=False, color_system=None).print(markup)
     return buf.getvalue().rstrip()
+
+
+def _check_cache_token_aggregation() -> None:
+    """Cache token fields aggregate end-to-end and feed cost math."""
+    # Agent aggregates all four keys.
+    agent = Agent(client=StubClientWithCacheUsage())
+    agent.run("hi")
+    assert agent.token_usage == {
+        "input": 100,
+        "output": 50,
+        "cache_creation": 1000,
+        "cache_read": 500,
+    }, agent.token_usage
+    print(f"✓ Agent.token_usage four-key aggregation: {agent.token_usage}")
+
+    # Cost arithmetic for Anthropic with cache fields.
+    # base = 1000*3 + 500*15 = 3000 + 7500 = 10500
+    # write = 1000 * 3 * 1.25 = 3750
+    # read = 500 * 3 * 0.1 = 150
+    # total = 14400 / 1_000_000 = 0.0144
+    cost = _estimate_cost_usd(
+        "anthropic/claude-sonnet-4-6", 1000, 500, 1000, 500
+    )
+    assert cost is not None and abs(cost - 0.0144) < 1e-9, cost
+    print(f"✓ Anthropic cache-aware cost: {cost}")
+
+    # Non-Anthropic models must ignore cache multipliers.
+    # gpt-4o: 1000*2.5 + 500*10 = 2500 + 5000 = 7500 → 0.0075
+    cost_oa = _estimate_cost_usd("openai/gpt-4o", 1000, 500, 100, 100)
+    assert cost_oa is not None and abs(cost_oa - 0.0075) < 1e-9, cost_oa
+    print(f"✓ Non-Anthropic ignores cache multipliers: {cost_oa}")
+
+    # Backward compat: usage event missing cache_creation / cache_read.
+    agents: dict[str, dict] = {}
+    _update_agents_state(
+        agents, {"type": "usage", "input": 10, "output": 5}
+    )
+    assert agents["root"]["tokens"] == {
+        "input": 10,
+        "output": 5,
+        "cache_creation": 0,
+        "cache_read": 0,
+    }, agents
+    print("✓ usage event missing cache keys → defaults to zero")
+
+    # Backward compat: pre-existing two-key tokens dict (e.g. from a
+    # long-running CLI process started before this PR landed) must
+    # accept new four-key events without KeyError.
+    legacy = {"root": {"status": "idle", "tokens": {"input": 50, "output": 30}}}
+    _update_agents_state(
+        legacy,
+        {
+            "type": "usage",
+            "input": 1,
+            "output": 2,
+            "cache_creation": 3,
+            "cache_read": 4,
+        },
+    )
+    assert legacy["root"]["tokens"] == {
+        "input": 51,
+        "output": 32,
+        "cache_creation": 3,
+        "cache_read": 4,
+    }, legacy
+    print("✓ legacy two-key tokens dict accepts cache keys")
+
+    # Suffix activity threshold: cache_read alone counts as activity.
+    suf = _format_usage_suffix(0, 0, "anthropic/claude-sonnet-4-6", 0, 100)
+    assert suf, f"suffix should be non-empty when cache_read > 0: {suf!r}"
+    assert "tok" in suf, suf
+    print(f"✓ suffix activates on cache-only usage: {suf!r}")
 
 
 def main() -> None:
@@ -98,16 +219,33 @@ def main() -> None:
     client = StubClientWithUsage([(100, 50), (200, 80)])
     agent = Agent(client=client)
     agent.run("first")
-    assert agent.token_usage == {"input": 100, "output": 50}, agent.token_usage
+    assert agent.token_usage == {
+        "input": 100,
+        "output": 50,
+        "cache_creation": 0,
+        "cache_read": 0,
+    }, agent.token_usage
     agent.run("second")
-    assert agent.token_usage == {"input": 300, "output": 130}, agent.token_usage
+    assert agent.token_usage == {
+        "input": 300,
+        "output": 130,
+        "cache_creation": 0,
+        "cache_read": 0,
+    }, agent.token_usage
     print(f"✓ Agent.token_usage accumulates: {agent.token_usage}")
 
     # 5. on_usage fires per call
     captured: list[dict] = []
     agent2 = Agent(client=StubClientWithUsage([(50, 25)]))
     agent2.run("ping", on_usage=lambda u: captured.append(u))
-    assert captured == [{"input": 50, "output": 25}], captured
+    assert captured == [
+        {
+            "input": 50,
+            "output": 25,
+            "cache_creation": 0,
+            "cache_read": 0,
+        }
+    ], captured
     print(f"✓ on_usage callback fires: {captured}")
 
     # 6. _update_agents_state usage handling
@@ -115,23 +253,39 @@ def main() -> None:
     _update_agents_state(
         agents, {"type": "usage", "input": 100, "output": 50}
     )
-    assert agents["root"]["tokens"] == {"input": 100, "output": 50}, agents
+    assert agents["root"]["tokens"] == {
+        "input": 100,
+        "output": 50,
+        "cache_creation": 0,
+        "cache_read": 0,
+    }, agents
     _update_agents_state(
         agents, {"type": "usage", "input": 200, "output": 80}
     )
-    assert agents["root"]["tokens"] == {"input": 300, "output": 130}, agents
+    assert agents["root"]["tokens"] == {
+        "input": 300,
+        "output": 130,
+        "cache_creation": 0,
+        "cache_read": 0,
+    }, agents
     # subagent usage event creates the slot if missing
     _update_agents_state(
         agents,
         {"type": "usage", "agent_id": "lead-x", "input": 50, "output": 20},
     )
-    assert agents["lead-x"]["tokens"] == {"input": 50, "output": 20}, agents
-    print(f"✓ usage events accumulate per-agent")
+    assert agents["lead-x"]["tokens"] == {
+        "input": 50,
+        "output": 20,
+        "cache_creation": 0,
+        "cache_read": 0,
+    }, agents
+    print("✓ usage events accumulate per-agent")
 
-    # 7. _agents_tokens sums
-    in_tot, out_tot = _agents_tokens(agents)
+    # 7. _agents_tokens sums (now four-tuple)
+    in_tot, out_tot, cw_tot, cr_tot = _agents_tokens(agents)
     assert in_tot == 350 and out_tot == 150, (in_tot, out_tot)
-    print(f"✓ aggregate: {in_tot} in / {out_tot} out")
+    assert cw_tot == 0 and cr_tot == 0, (cw_tot, cr_tot)
+    print(f"✓ aggregate: {in_tot} in / {out_tot} out / {cw_tot} cw / {cr_tot} cr")
 
     # 8. _render_status includes the suffix
     out = _render_plain(_render_status(agents, "anthropic"))
@@ -147,6 +301,9 @@ def main() -> None:
     out = _render_plain(_render_status(minimal, "anthropic"))
     assert out == "thinking…", out
     print(f"✓ render zero-token: {out!r}")
+
+    # 9. Cache-aware extensions
+    _check_cache_token_aggregation()
 
     print("\nALL CHECKS PASSED")
 

--- a/tests/smoke_token_meter.py
+++ b/tests/smoke_token_meter.py
@@ -187,6 +187,30 @@ def _check_cache_token_aggregation() -> None:
     assert "tok" in suf, suf
     print(f"✓ suffix activates on cache-only usage: {suf!r}")
 
+    # On Anthropic, the four token counts are disjoint (input excludes
+    # both cache reads and writes), so the displayed total bundles all
+    # four. On OpenAI / Gemini, the providers' "input" already includes
+    # the cached count — bundling cache_read on top would double-count.
+    # The display must gate the bundle the same way _estimate_cost_usd
+    # gates the cache pricing multipliers.
+    anth = _format_usage_suffix(
+        100, 50, "anthropic/claude-sonnet-4-6", 200, 1000
+    )
+    assert "1.4k tok" in anth, anth  # 100 + 50 + 200 + 1000 = 1350 → 1.4k
+    oai = _format_usage_suffix(100, 50, "openai/gpt-4o", 0, 1000)
+    # OpenAI's prompt_tokens already includes cache_read; total must
+    # not double-count. Expected: input + output = 150 (NOT 1150).
+    assert "150 tok" in oai, oai
+    assert "1.1k tok" not in oai, (
+        f"OpenAI suffix double-counted cache_read into displayed total: {oai!r}"
+    )
+    gem = _format_usage_suffix(100, 50, "gemini/gemini-2.5-flash", 0, 1000)
+    assert "150 tok" in gem, gem
+    assert "1.1k tok" not in gem, (
+        f"Gemini suffix double-counted cache_read into displayed total: {gem!r}"
+    )
+    print(f"✓ suffix gates cache bundling to Anthropic (anth={anth!r}, oai={oai!r})")
+
 
 def main() -> None:
     # 1. Model-name resolution


### PR DESCRIPTION
## #8 — Cache token logging

Extends the usage schema across every LLM client to four keys: `input`, `output`, `cache_creation`, `cache_read`. Anthropic populates all four (`cache_creation_input_tokens`, `cache_read_input_tokens` from the SDK); OpenAI surfaces `prompt_tokens_details.cached_tokens` (already billed inside `prompt_tokens` at the base input rate); Gemini surfaces `cached_content_token_count`. Pyagent stub clients report zeros.

Cost estimation in `cli.py` now applies Anthropic's ephemeral-cache pricing — writes at 1.25x the base input rate, reads at 0.1x — gated on `_is_anthropic_model`. OpenAI and Gemini get no separate adjustment because their cached counts are already in the prompt-token total. The token-suffix display still shows a single bundled total.

Every aggregation path (`Agent.token_usage`, `agent_proc` `on_usage` lambda, `_update_agents_state`, `_agents_tokens`) was updated to use `.get(k, 0)` form so old `conversation.jsonl` lines and any pre-PR in-memory state survive without a migration. `_agents_tokens` now returns a 4-tuple — the only call site (`_render_status`) was updated to match.

| File | Change |
|------|--------|
| `pyagent/llms/{anthropic,gemini,openai,pyagent}.py` | Add cache fields to the returned `usage` dict. |
| `pyagent/agent.py` | `token_usage` init + aggregation loop over all four keys. |
| `pyagent/agent_proc.py` | `on_usage` lambda forwards cache fields upstream. |
| `pyagent/cli.py` | Pricing constants, `_estimate_cost_usd`, `_format_usage_suffix`, `_agents_tokens`, `_update_agents_state`. |

Closes #8.

## #9 — `read_file` soft-threshold ceiling

Adds `Agent.SOFT_THRESHOLD_FORCED_TOOLS = frozenset({\"read_file\"})` and a third branch to the offload predicate in `_render_tool_result`. `read_file` is registered with `auto_offload=False` so small explicit reads still return inline, but a runaway ranged read (HTML, a wide log line, a binary mistakenly read as text) above `session.attachment_threshold` (8000 chars by default) now offloads instead of riding along on every subsequent turn.

`read_skill` is intentionally not in the forced set — that's the regression guard for the not-yet-implemented #10 work, where skills are expected to drop into context and stay. The hard ceiling (`HARD_OFFLOAD_CEILING`, 64K) is unchanged and still catches outright pathological cases.

No new `Attachment(...)` construction site, so `smoke_session_replay._check_attachment_construction_sites` still passes.

Closes #9.

## Test plan

- [x] `tests/smoke_token_meter.py` — fixes the pre-existing `system_volatile` kwarg failure on `main`, switches assertions to the four-key shape, adds a `_check_cache_token_aggregation` block covering Anthropic cache-cost arithmetic, non-Anthropic ignoring multipliers, missing-key tolerance, legacy two-key tokens-dict tolerance, and the suffix-activates-on-cache-only case.
- [x] `tests/smoke_read_file_ceiling.py` (new) — locks four behaviors: small read inline, mid-size read offloads via the forced-soft path, `read_skill` bypasses the soft threshold, hard ceiling still fires for non-forced tools.
- [x] Full smoke suite (20 files): all pass.