### PR TITLE
Roles: migrate from config.toml to markdown files (#17)

### DIFF
--- a/pyagent/config.py
+++ b/pyagent/config.py
@@ -170,12 +170,17 @@ def render_toml(data: dict[str, Any], commented: bool = False) -> str:
 _ROLE_EXAMPLE_BLOCK = """
 # Roles — named subagent models the orchestrator can address by name.
 #
-# Each [models.<name>] table defines a preset that `spawn_subagent`
-# resolves via its `model` argument. Required: model, description.
-# Optional: system_prompt / system_prompt_path (default subagent
-# persona body, layered onto SOUL/TOOLS/PRIMER), tools (allowlist
-# narrowing the default tool set), meta_tools (default true; set
-# false to make a leaf role that can't fan out further).
+# Roles now live as markdown files under <config-dir>/roles/ (or
+# .pyagent/roles/ for project overrides). Run `pyagent-roles init` to
+# seed the starter library, then `pyagent-roles list` to see what's
+# available. Each .md file is one role; optional Hugo-style TOML
+# frontmatter between `+++` delimiters declares model / tools /
+# meta_tools / description.
+#
+# The legacy [models.<name>] form below still works for backward
+# compatibility but emits a deprecation warning at startup. Run
+# `pyagent-roles migrate` to convert any [models.*] entries into
+# files automatically.
 #
 # [models.planner]
 # model = "anthropic/claude-opus-4-7"

--- a/pyagent/config_cli.py
+++ b/pyagent/config_cli.py
@@ -13,9 +13,13 @@ starting point doesn't have to copy-paste from the README.
 
 from __future__ import annotations
 
+from importlib import resources
+
 import click
 
 from pyagent import config
+from pyagent import paths
+from pyagent import roles as roles_mod
 
 
 @click.group()
@@ -62,9 +66,27 @@ def init_cmd(force: bool) -> None:
     if not written:
         click.echo(f"config.toml already exists at {target}")
         click.echo("(pass --force to overwrite)")
-        return
-    click.echo(f"wrote default config to {target}")
-    click.echo("Edit the file and uncomment lines to override defaults.")
+    else:
+        click.echo(f"wrote default config to {target}")
+        click.echo("Edit the file and uncomment lines to override defaults.")
+
+    # Also seed the roles directory with the bundled starter set so
+    # first-run users get the orchestrator-pattern starter library
+    # without having to discover `pyagent-roles init` separately.
+    roles_dir = paths.config_dir() / "roles"
+    roles_dir.mkdir(parents=True, exist_ok=True)
+    bundled_pkg = resources.files(roles_mod.PACKAGE_ROLES_PKG)
+    seeded = 0
+    for entry in sorted(bundled_pkg.iterdir(), key=lambda e: e.name):
+        if not entry.name.endswith(".md"):
+            continue
+        dest = roles_dir / entry.name
+        if dest.exists():
+            continue
+        dest.write_text(entry.read_text())
+        seeded += 1
+    if seeded:
+        click.echo(f"seeded {seeded} starter role(s) under {roles_dir}")
 
 
 if __name__ == "__main__":

--- a/pyagent/roles.py
+++ b/pyagent/roles.py
@@ -1,33 +1,58 @@
-"""Named subagent roles loaded from config.
+"""Named subagent roles loaded from markdown files.
 
 A role is `name -> (model, description, optional persona, optional
 tool allowlist, meta-tool gate)`. Roles let an orchestrator address a
-subagent by purpose ("planner", "validator") instead of by raw
+subagent by purpose ("researcher", "reviewer") instead of by raw
 provider/model string, and centralize cost/capability decisions in
-config.
+files the user can drop into a directory without learning TOML.
 
-Schema (in config.toml):
+Three-tier discovery (later wins on case/dash/underscore-normalized name
+collision), mirroring skills/plugins/config:
 
-    [models.planner]
-    model = "anthropic/claude-opus-4-7"
-    description = "Deep reasoning, multi-step planning."
-    system_prompt = '''
-    You are a planner. Break tasks into steps before recommending edits.
-    '''
-    # OR (mutually exclusive with system_prompt):
-    # system_prompt_path = "prompts/planner.md"
+  1. <package>/roles/*.md          — bundled with pyagent
+  2. <config-dir>/roles/*.md       — user library (per-machine)
+  3. ./.pyagent/roles/*.md         — project-local
+
+Each `.md` file is one role. Filename → role name (`.md` stripped,
+dashes and underscores both accepted, normalized to underscores,
+lower-cased for lookup; original filename preserved for `path` /
+`show`). Optional Hugo-style TOML frontmatter between `+++` delimiters
+declares structured fields; the body after the closing fence is the
+role's persona prose.
+
+    +++
+    model = "anthropic/claude-haiku-4-5"
     tools = ["read_file", "grep", "list_directory", "fetch_url"]
     meta_tools = false
+    description = "Cheap reader for triage and summarization."
+    +++
 
-Roles are merged across all config tiers (project wins over user wins
-over defaults). Invalid entries are warned and skipped — agent runs
-are never blocked by a typo in a role.
+    # Role: Researcher
+
+    You are a research specialist. Given a question and a starting
+    URL, you fetch, summarize, and cross-reference. ...
+
+All frontmatter fields are optional. Defaults:
+  - `model`     — empty string (subagent inherits caller's model).
+  - `tools`     — None (inherit the default tool set).
+  - `meta_tools` — True (current default; subagent can fan out).
+  - `description` — auto-derived from the first non-empty paragraph
+    after a leading `# Heading` line, collapsed whitespace, capped at
+    ~200 chars. If no body, falls back to the role name.
+
+Backward compat: `[models.<name>]` tables in config.toml still load
+with the previous schema, but emit a one-time deprecation warning at
+startup pointing at `pyagent-roles migrate`. File-based roles win on
+collision (newer authoring surface).
 """
 
 from __future__ import annotations
 
 import logging
+import re
+import tomllib
 from dataclasses import dataclass
+from importlib import resources
 from pathlib import Path
 from typing import Any
 
@@ -36,14 +61,21 @@ from pyagent import llms, paths
 
 logger = logging.getLogger(__name__)
 
+LOCAL_ROLES_DIR = Path(".pyagent") / "roles"
+PACKAGE_ROLES_PKG = "pyagent.roles_bundled"
+
+_DESCRIPTION_CAP = 200
+
 
 @dataclass(frozen=True)
 class Role:
     """Resolved role definition.
 
     Attributes:
-        name: Role identifier (the `<name>` in `[models.<name>]`).
-        model: Resolved provider/model string (e.g. "anthropic/claude-opus-4-7").
+        name: Canonical (normalized) role identifier — lowercase, with
+            underscores. Looked up case-insensitively.
+        model: Resolved provider/model string, or "" to mean "inherit
+            the caller's model" at spawn time.
         description: One-line summary the orchestrator uses to decide
             when to spawn this role. Renders into the role catalog.
         system_prompt: Default subagent persona body. May be empty.
@@ -53,6 +85,8 @@ class Role:
             None means inherit the default tool set.
         meta_tools: Whether this role's subagent can itself spawn
             further subagents. Default True (matches root behavior).
+        source: Absolute path the role was loaded from, or None for
+            roles defined in config.toml (legacy `[models.<name>]`).
     """
 
     name: str
@@ -61,9 +95,191 @@ class Role:
     system_prompt: str
     tools: tuple[str, ...] | None
     meta_tools: bool
+    source: Path | None = None
 
 
-def _coerce_body(name: str, body: str, body_path: str) -> str:
+# ---- Name normalization ---------------------------------------------
+
+
+def _normalize_name(raw: str) -> str:
+    """Canonicalize a role name: lowercase, dashes → underscores."""
+    return raw.replace("-", "_").lower()
+
+
+# ---- Frontmatter parsing --------------------------------------------
+
+
+_FRONTMATTER_RE = re.compile(
+    r"\A\+\+\+[ \t]*\r?\n(.*?)\r?\n\+\+\+[ \t]*\r?\n?",
+    re.DOTALL,
+)
+
+
+def _parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+    """Strip Hugo-style `+++` TOML frontmatter from `text`.
+
+    Returns (frontmatter_dict, body). On any malformed frontmatter
+    (bad TOML, no closing fence) returns ({}, text) and lets the body
+    speak for itself. Logs a warning so authors notice.
+    """
+    if not text.startswith("+++"):
+        return {}, text
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        # Has opening +++ but no closing one — let the prose render.
+        return {}, text
+    fm_text = m.group(1)
+    body = text[m.end():].lstrip("\n")
+    try:
+        fm = tomllib.loads(fm_text)
+    except tomllib.TOMLDecodeError as e:
+        logger.warning("role frontmatter is not valid TOML (%s); ignoring", e)
+        return {}, body
+    if not isinstance(fm, dict):
+        return {}, body
+    return fm, body
+
+
+# ---- Description auto-derivation ------------------------------------
+
+
+_HEADING_RE = re.compile(r"^\s*#+\s.*$", re.MULTILINE)
+
+
+def _derive_description(name: str, body: str) -> str:
+    """Pull a one-line summary out of the body.
+
+    Strategy: drop a leading `# Heading` line if present, take the
+    first non-empty paragraph, collapse whitespace, cap at
+    `_DESCRIPTION_CAP` chars. Falls back to the role name if there's
+    no body content to mine.
+    """
+    if not body.strip():
+        return name
+    lines = body.splitlines()
+    # Skip a leading heading (or chain of blank lines + heading).
+    i = 0
+    while i < len(lines) and not lines[i].strip():
+        i += 1
+    if i < len(lines) and lines[i].lstrip().startswith("#"):
+        i += 1
+    # Skip blanks after the heading.
+    while i < len(lines) and not lines[i].strip():
+        i += 1
+    # Collect the first paragraph (until the next blank line).
+    para: list[str] = []
+    while i < len(lines) and lines[i].strip():
+        para.append(lines[i].strip())
+        i += 1
+    if not para:
+        return name
+    text = " ".join(para)
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) > _DESCRIPTION_CAP:
+        # Cut on a word boundary if convenient.
+        cut = text[: _DESCRIPTION_CAP].rsplit(" ", 1)[0]
+        text = (cut or text[: _DESCRIPTION_CAP]).rstrip(",.;:") + "…"
+    return text
+
+
+# ---- Coercion helpers -----------------------------------------------
+
+
+def _coerce_tools(name: str, raw: Any) -> tuple[str, ...] | None:
+    if raw is None:
+        return None
+    if isinstance(raw, list) and all(isinstance(t, str) for t in raw):
+        return tuple(raw)
+    logger.warning("role %r tools must be list[str]; ignoring", name)
+    return None
+
+
+def _coerce_meta_tools(name: str, raw: Any) -> bool:
+    if raw is None:
+        return True
+    if isinstance(raw, bool):
+        return raw
+    logger.warning(
+        "role %r meta_tools must be bool; defaulting to True", name
+    )
+    return True
+
+
+def _coerce_model(name: str, raw: Any) -> str:
+    """Resolve a frontmatter model string to its canonical form, or ""
+    if absent. Empty means "inherit the caller's model"."""
+    if raw is None or raw == "":
+        return ""
+    if not isinstance(raw, str):
+        logger.warning("role %r model must be string; ignoring", name)
+        return ""
+    return llms.resolve_model(raw)
+
+
+# ---- File-tier loading ----------------------------------------------
+
+
+def _load_role_file(md_path: Path) -> Role | None:
+    """Parse one `.md` file into a Role. Returns None on read errors."""
+    try:
+        text = md_path.read_text()
+    except OSError as e:
+        logger.warning("role file %s unreadable: %s", md_path, e)
+        return None
+
+    fm, body = _parse_frontmatter(text)
+    raw_name = md_path.stem
+    name = _normalize_name(raw_name)
+    description = fm.get("description")
+    if not isinstance(description, str) or not description.strip():
+        description = _derive_description(name, body)
+    return Role(
+        name=name,
+        model=_coerce_model(name, fm.get("model")),
+        description=description,
+        system_prompt=body.strip(),
+        tools=_coerce_tools(name, fm.get("tools")),
+        meta_tools=_coerce_meta_tools(name, fm.get("meta_tools")),
+        source=md_path.resolve(),
+    )
+
+
+def _scan_dir(root: Path) -> dict[str, Role]:
+    """Walk one tier root for `.md` role files, applying name-collision
+    rules within the tier (lexicographic-first wins on
+    case/dash/underscore collision; warn)."""
+    if not root.exists():
+        return {}
+    found: dict[str, Role] = {}
+    for md in sorted(root.glob("*.md")):
+        role = _load_role_file(md)
+        if role is None:
+            continue
+        if role.name in found:
+            logger.warning(
+                "role name %r collides on disk in %s "
+                "(already loaded from %s; ignoring %s)",
+                role.name,
+                root,
+                found[role.name].source,
+                md,
+            )
+            continue
+        found[role.name] = role
+    return found
+
+
+def _bundled_root() -> Path | None:
+    try:
+        return Path(str(resources.files(PACKAGE_ROLES_PKG)))
+    except (ModuleNotFoundError, FileNotFoundError):
+        return None
+
+
+# ---- Legacy [models.<name>] backward-compat -------------------------
+
+
+def _coerce_legacy_body(name: str, body: str, body_path: str) -> str:
     if body and body_path:
         logger.warning(
             "role %r has both system_prompt and system_prompt_path; "
@@ -88,16 +304,7 @@ def _coerce_body(name: str, body: str, body_path: str) -> str:
         return ""
 
 
-def _coerce_tools(name: str, raw: Any) -> tuple[str, ...] | None:
-    if raw is None:
-        return None
-    if isinstance(raw, list) and all(isinstance(t, str) for t in raw):
-        return tuple(raw)
-    logger.warning("role %r tools must be list[str]; ignoring", name)
-    return None
-
-
-def _coerce_role(name: str, entry: Any) -> Role | None:
+def _coerce_legacy_role(name: str, entry: Any) -> Role | None:
     if not isinstance(entry, dict):
         logger.warning("role %r is not a table; ignoring", name)
         return None
@@ -115,39 +322,83 @@ def _coerce_role(name: str, entry: Any) -> Role | None:
         body = ""
     if not isinstance(body_path, str):
         body_path = ""
-    meta_tools = entry.get("meta_tools", True)
-    if not isinstance(meta_tools, bool):
-        logger.warning(
-            "role %r meta_tools must be bool; defaulting to True", name
-        )
-        meta_tools = True
     return Role(
-        name=name,
+        name=_normalize_name(name),
         model=llms.resolve_model(model),
         description=description,
-        system_prompt=_coerce_body(name, body, body_path),
+        system_prompt=_coerce_legacy_body(name, body, body_path),
         tools=_coerce_tools(name, entry.get("tools")),
-        meta_tools=meta_tools,
+        meta_tools=_coerce_meta_tools(name, entry.get("meta_tools")),
+        source=None,
     )
 
 
-def load() -> dict[str, Role]:
-    """Return the dict of all defined roles, indexed by name.
-
-    Re-reads config on each call so an edited config takes effect on
-    the next render without restarting the agent. Invalid entries
-    are skipped with a warning.
-    """
+def _legacy_roles() -> dict[str, Role]:
+    """Load `[models.<name>]` entries from config.toml. Emits a
+    one-time deprecation warning on first call per process."""
     cfg = config_mod.load()
     raw = cfg.get("models", {})
-    if not isinstance(raw, dict):
-        logger.warning("config.models must be a table; ignoring")
+    if not isinstance(raw, dict) or not raw:
         return {}
     roles: dict[str, Role] = {}
     for name, entry in raw.items():
-        role = _coerce_role(name, entry)
+        role = _coerce_legacy_role(name, entry)
         if role is not None:
-            roles[name] = role
+            roles[role.name] = role
+    if roles:
+        _emit_deprecation_warning(sorted(roles))
+    return roles
+
+
+_DEPRECATION_WARNED = False
+
+
+def _emit_deprecation_warning(names: list[str]) -> None:
+    global _DEPRECATION_WARNED
+    if _DEPRECATION_WARNED:
+        return
+    _DEPRECATION_WARNED = True
+    logger.warning(
+        "[models.<name>] role tables in config.toml are deprecated; "
+        "found %d role(s): %s. Run `pyagent-roles migrate` to convert "
+        "them to markdown files under <config-dir>/roles/.",
+        len(names),
+        ", ".join(names),
+    )
+
+
+def _reset_deprecation_warning() -> None:
+    """Test helper: reset the one-time warning gate."""
+    global _DEPRECATION_WARNED
+    _DEPRECATION_WARNED = False
+
+
+# ---- Public API -----------------------------------------------------
+
+
+def load() -> dict[str, Role]:
+    """Return the dict of all defined roles, indexed by canonical name.
+
+    Tier precedence (later wins): bundled < legacy [models.<name>] <
+    user-tier files < project-tier files. Re-reads on every call so
+    edited files take effect on the next render without a restart.
+    Invalid entries warn and skip — agent runs are never blocked by a
+    typo in a role.
+    """
+    roles: dict[str, Role] = {}
+
+    bundled_root = _bundled_root()
+    if bundled_root is not None:
+        roles.update(_scan_dir(bundled_root))
+
+    # Legacy TOML form: lower than file-based tiers, higher than
+    # bundled (so a user can shadow a bundled role with a TOML entry
+    # if they really want, though we don't recommend it).
+    roles.update(_legacy_roles())
+
+    roles.update(_scan_dir(paths.config_dir() / "roles"))
+    roles.update(_scan_dir(LOCAL_ROLES_DIR))
+
     return roles
 
 
@@ -156,16 +407,20 @@ def resolve(spec: str) -> tuple[str, Role | None]:
 
     - Empty string returns ("", None) — caller decides (typically
       inherit parent's model).
-    - If `spec` matches a defined role, returns (role.model, role).
+    - If `spec` matches a defined role (case/dash/underscore-
+      insensitive), returns (role.model, role). When the role's model
+      is empty, returns ("", role) so the spawn site falls back to
+      the parent's model.
     - Otherwise treats `spec` as a provider/model string and
-      resolves via `llms.resolve_model`. The returned `Role` is None.
+      resolves via `llms.resolve_model`. The returned Role is None.
 
-    Roles are looked up first, so a user cannot name a role "anthropic"
-    or another provider name — the role lookup wins.
+    Roles are looked up first, so a user cannot name a role
+    "anthropic" or another provider name — the role lookup wins.
     """
     if not spec:
         return "", None
-    role = load().get(spec)
+    normalized = _normalize_name(spec)
+    role = load().get(normalized)
     if role is not None:
         return role.model, role
     return llms.resolve_model(spec), None
@@ -174,7 +429,7 @@ def resolve(spec: str) -> tuple[str, Role | None]:
 def catalog() -> str:
     """Render the role catalog injected into the system prompt.
 
-    Re-reads config on each call so newly-defined roles appear on the
+    Re-reads on each call so newly-authored role files appear on the
     next render. Returns an empty string when no roles are defined.
     """
     roles = load()
@@ -185,10 +440,13 @@ def catalog() -> str:
         "",
         "Each entry is a role you can pass as the `model` argument to "
         "`spawn_subagent` (alongside raw provider/model strings). Role "
-        "definitions live in `config.toml` and pin the model, default "
-        "persona, and tool restrictions for that role.",
+        "definitions live as markdown files under "
+        "`pyagent/roles/`, `<config-dir>/roles/`, or `.pyagent/roles/`, "
+        "and pin the model, default persona, and tool restrictions for "
+        "that role.",
         "",
     ]
     for role in sorted(roles.values(), key=lambda r: r.name):
-        lines.append(f"- **{role.name}** ({role.model}): {role.description}")
+        model_label = role.model or "(inherits parent)"
+        lines.append(f"- **{role.name}** ({model_label}): {role.description}")
     return "\n".join(lines)

--- a/pyagent/roles_bundled/RESEARCHER.md
+++ b/pyagent/roles_bundled/RESEARCHER.md
@@ -1,0 +1,26 @@
++++
+tools = ["read_file", "grep", "list_directory", "fetch_url", "html_to_md", "html_select", "read_skill"]
+meta_tools = false
+description = "Investigates a question end-to-end: fetches sources, cross-references them, returns synthesized findings with citations."
++++
+
+# Role: Researcher
+
+You are a research specialist. Given a question and one or more
+starting points (URLs, file paths, search terms), your job is to
+investigate, cross-reference, and synthesize — not to dump raw
+sources back to the caller.
+
+Prefer markdown extraction over raw HTML when both are available.
+`fetch_url` already returns a clean markdown body; reach for
+`html_select` only when you need a specific structured slice (a
+table, a list, a sidebar).
+
+When sources disagree, surface the disagreement explicitly. Don't
+silently pick one — let the caller decide. Cite every claim with the
+URL or file path it came from; uncited prose is suspect.
+
+Return findings as a tight summary, not a transcript of your fetches.
+The caller wants the answer, not your reasoning trail. If the
+question can't be answered from the available sources, say so plainly
+and list what's missing.

--- a/pyagent/roles_bundled/REVIEWER.md
+++ b/pyagent/roles_bundled/REVIEWER.md
@@ -1,0 +1,29 @@
++++
+tools = ["read_file", "grep", "list_directory", "read_skill"]
+meta_tools = false
+description = "Read-only critique of code or output. Identifies bugs, logic errors, and design problems without authority to fix them."
++++
+
+# Role: Reviewer
+
+You are a reviewer. The caller asks you to look over code, a
+proposed change, or a piece of output, and tell them what's wrong.
+You have no edit or execute authority — the only thing you can do is
+read and respond.
+
+Lead with substance. Your first paragraph should name the most
+important problem you see, or state plainly that you didn't find
+one. Don't bury the verdict at the end of a list of nits.
+
+Distinguish bugs from style preferences. A bug is something that
+will produce wrong behavior or break a contract; a preference is
+something you'd write differently. Both are fair to mention, but
+label them so the caller can prioritize.
+
+Be specific. Cite file paths and line numbers. Quote the exact text
+you're objecting to. "This function is confusing" is not actionable;
+"`_coerce_role` accepts a string and silently returns None on
+type mismatch — should raise or log" is.
+
+End with a one-line verdict: SHIP, SHIP WITH NITS, or NEEDS CHANGES.
+The caller wants to know if they can move forward.

--- a/pyagent/roles_bundled/SCRIBE.md
+++ b/pyagent/roles_bundled/SCRIBE.md
@@ -1,0 +1,25 @@
++++
+tools = ["read_file", "write_file", "edit_file", "list_directory", "grep", "read_skill"]
+meta_tools = false
+description = "Captures, organizes, and edits notes and documentation. Read/write file access; no execute authority."
++++
+
+# Role: Scribe
+
+You are a scribe. The caller hands you raw material — a transcript,
+a set of bullet points, a pile of unstructured notes, a draft — and
+asks you to turn it into something clean and durable.
+
+Preserve meaning, sharpen prose. Don't invent content the source
+doesn't support, but do collapse repetition, fix terminology, and
+restructure for the reader. If a passage is unclear in the source,
+flag it rather than guessing.
+
+Match the destination's conventions. README.md, a runbook, a release
+note, and a personal journal entry all want different voices. If the
+caller didn't specify, ask once before you commit to a style.
+
+Return what you wrote, not a description of what you wrote. The
+caller can read the file. If you edited an existing document, note
+which sections you changed and why; if you created a new one, say
+where it lives.

--- a/pyagent/roles_bundled/SOFTWARE_ENGINEER.md
+++ b/pyagent/roles_bundled/SOFTWARE_ENGINEER.md
@@ -1,0 +1,25 @@
++++
+meta_tools = false
+description = "Implements features, fixes bugs, and runs tests. Full file/edit/execute toolset; default model."
++++
+
+# Role: Software Engineer
+
+You are a software engineer. The caller gives you a focused task —
+implement a feature, fix a bug, refactor a module — and you carry it
+out end-to-end inside the working tree.
+
+Read before you write. Skim the relevant files, understand the
+existing patterns, then make the smallest change that satisfies the
+task. Match the surrounding style; don't rewrite a module's
+conventions to suit your taste.
+
+Run the tests. If a smoke or unit suite exists for the area you're
+touching, run it before and after your change. If your change breaks
+something unrelated, stop and ask — don't paper over it.
+
+Return a short summary of what you changed and why. Mention any
+follow-up work the caller should know about (TODOs you saw but
+didn't address, tests you didn't run because they're slow or
+flaky, decisions you made without confirmation). Don't pad the
+summary with the diff itself — the caller can read the files.

--- a/pyagent/roles_bundled/__init__.py
+++ b/pyagent/roles_bundled/__init__.py
@@ -1,0 +1,1 @@
+"""Bundled starter roles, discovered as `*.md` files alongside this module."""

--- a/pyagent/roles_cli.py
+++ b/pyagent/roles_cli.py
@@ -185,7 +185,18 @@ def _toml_value(v: object) -> str:
 
 
 def _render_migrated_role(role: roles_mod.Role, original_name: str) -> str:
-    """Build the .md file text for a migrated role."""
+    """Build the .md file text for a migrated role.
+
+    `description` is only emitted in the frontmatter when the body is
+    empty — without a body, auto-derivation has nothing to chew on, so
+    the explicit description is the only thing that keeps the role
+    catalog informative. When the body is non-empty, omit
+    `description` and let auto-derivation pick it up from the first
+    paragraph; that keeps migrated files concise and matches the
+    bundled-roles convention (which never sets `description`
+    explicitly).
+    """
+    body = role.system_prompt.strip()
     fm_lines = ["+++"]
     if role.model:
         fm_lines.append(f"model = {_toml_value(role.model)}")
@@ -193,11 +204,15 @@ def _render_migrated_role(role: roles_mod.Role, original_name: str) -> str:
         fm_lines.append(f"tools = {_toml_value(list(role.tools))}")
     if role.meta_tools is not True:
         fm_lines.append(f"meta_tools = {_toml_value(role.meta_tools)}")
-    fm_lines.append(f"description = {_toml_value(role.description)}")
-    fm_lines.append("+++")
-    body = role.system_prompt.strip()
     if not body:
-        body = f"# Role: {original_name}\n\n(No persona body in the original [models.<name>] entry.)"
+        # No body to auto-derive from — pin the description explicitly.
+        fm_lines.append(f"description = {_toml_value(role.description)}")
+    fm_lines.append("+++")
+    if not body:
+        body = (
+            f"# Role: {original_name}\n\n"
+            "(No persona body in the original [models.<name>] entry.)"
+        )
     return "\n".join(fm_lines) + "\n\n" + body + "\n"
 
 
@@ -230,7 +245,12 @@ def migrate_cmd(force: bool) -> None:
         role = roles_mod._coerce_legacy_role(name, entry)
         if role is None:
             continue
-        dest = target_root / f"{name.upper()}.md"
+        # Filename mirrors the bundled all-caps + underscores convention:
+        # legacy `[models.deep-thought]` → DEEP_THOUGHT.md (not
+        # DEEP-THOUGHT.md). Lookup normalization treats both equivalently
+        # but consistent filenames keep `pyagent-roles list` tidy.
+        canonical = name.upper().replace("-", "_")
+        dest = target_root / f"{canonical}.md"
         if dest.exists() and not force:
             click.echo(f"skipped {dest} (exists)")
             skipped += 1

--- a/pyagent/roles_cli.py
+++ b/pyagent/roles_cli.py
@@ -1,0 +1,251 @@
+"""`pyagent-roles` — list, inspect, seed, and migrate role files.
+
+Roles live as `<name>.md` files in three tiers (matching skills /
+plugins / config layout):
+
+  1. Bundled    — `pyagent/roles_bundled/*.md` (ships with pyagent).
+  2. User       — `<config-dir>/roles/*.md` (your personal library).
+  3. Project    — `./.pyagent/roles/*.md` (per-repo overrides).
+
+Sub-commands:
+
+  list                    — all roles, by tier, name + description.
+  show <name>             — render one role's resolved content.
+  path <name>             — print the resolved file path (scripting helper).
+  init                    — seed <config-dir>/roles/ with the bundled
+                            starter set (idempotent).
+  migrate                 — convert any [models.<name>] in config.toml
+                            into <config-dir>/roles/<name>.md files.
+"""
+
+from __future__ import annotations
+
+import logging
+from importlib import resources
+from pathlib import Path
+
+import click
+
+from pyagent import config as config_mod
+from pyagent import paths
+from pyagent import roles as roles_mod
+
+
+def _user_root() -> Path:
+    return paths.config_dir() / "roles"
+
+
+def _project_root() -> Path:
+    return roles_mod.LOCAL_ROLES_DIR
+
+
+@click.group()
+def main() -> None:
+    """Inspect, seed, and migrate pyagent roles."""
+    # Surface roles-module warnings (e.g. legacy [models.<name>]) to
+    # stderr so `pyagent-roles list` actually shows them.
+    logging.basicConfig(
+        level=logging.WARNING, format="%(levelname)s: %(message)s"
+    )
+
+
+def _render_tier(label: str, root: Path | None, roles: dict) -> None:
+    click.secho(f"{label}:", bold=True)
+    if not roles:
+        click.echo("  (none)")
+        return
+    for role in sorted(roles.values(), key=lambda r: r.name):
+        model_label = role.model or "(inherits parent)"
+        click.echo(f"  {role.name} [{model_label}]: {role.description}")
+
+
+@main.command("list")
+def list_cmd() -> None:
+    """List roles across all three tiers (plus any legacy TOML roles)."""
+    bundled_root = roles_mod._bundled_root()
+    bundled = (
+        roles_mod._scan_dir(bundled_root) if bundled_root else {}
+    )
+    user = roles_mod._scan_dir(_user_root())
+    project = roles_mod._scan_dir(_project_root())
+    legacy = roles_mod._legacy_roles()
+
+    _render_tier(
+        "Bundled (ships with pyagent)",
+        bundled_root,
+        bundled,
+    )
+    click.echo()
+    _render_tier(f"User ({_user_root()})", _user_root(), user)
+    click.echo()
+    _render_tier(
+        f"Project-local ({_project_root()}, wins all ties)",
+        _project_root(),
+        project,
+    )
+
+    if legacy:
+        click.echo()
+        click.secho(
+            "Legacy [models.<name>] in config.toml (deprecated):",
+            bold=True,
+            fg="yellow",
+        )
+        for role in sorted(legacy.values(), key=lambda r: r.name):
+            click.echo(f"  {role.name} [{role.model}]: {role.description}")
+        click.echo()
+        click.echo("  Run `pyagent-roles migrate` to convert these to .md files.")
+
+
+@main.command("show")
+@click.argument("name")
+def show_cmd(name: str) -> None:
+    """Print one role's resolved content (frontmatter-style header + body)."""
+    normalized = roles_mod._normalize_name(name)
+    role = roles_mod.load().get(normalized)
+    if role is None:
+        raise click.ClickException(
+            f"no role named {name!r}; try `pyagent-roles list`."
+        )
+    src = str(role.source) if role.source else "(legacy: config.toml [models.*])"
+    click.echo(f"# name:        {role.name}")
+    click.echo(f"# source:      {src}")
+    click.echo(f"# model:       {role.model or '(inherits parent)'}")
+    click.echo(f"# tools:       {list(role.tools) if role.tools is not None else '(default set)'}")
+    click.echo(f"# meta_tools:  {role.meta_tools}")
+    click.echo(f"# description: {role.description}")
+    click.echo()
+    click.echo(role.system_prompt)
+
+
+@main.command("path")
+@click.argument("name")
+def path_cmd(name: str) -> None:
+    """Print the absolute path of the file that defines a role."""
+    normalized = roles_mod._normalize_name(name)
+    role = roles_mod.load().get(normalized)
+    if role is None:
+        raise click.ClickException(
+            f"no role named {name!r}; try `pyagent-roles list`."
+        )
+    if role.source is None:
+        raise click.ClickException(
+            f"role {name!r} comes from config.toml [models.*]; "
+            "run `pyagent-roles migrate` to give it a file path."
+        )
+    click.echo(str(role.source))
+
+
+@main.command("init")
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Overwrite existing files in <config-dir>/roles/. Off by default.",
+)
+def init_cmd(force: bool) -> None:
+    """Seed <config-dir>/roles/ with the bundled starter set.
+
+    Idempotent: skips files that already exist unless --force. The
+    bundled set is intended as a starting library — copy and edit
+    freely; tier precedence (project > user > bundled) means your
+    edits win at lookup time.
+    """
+    target_root = _user_root()
+    target_root.mkdir(parents=True, exist_ok=True)
+
+    bundled_pkg = resources.files(roles_mod.PACKAGE_ROLES_PKG)
+    written = 0
+    skipped = 0
+    for entry in sorted(bundled_pkg.iterdir(), key=lambda e: e.name):
+        if not entry.name.endswith(".md"):
+            continue
+        dest = target_root / entry.name
+        if dest.exists() and not force:
+            click.echo(f"skipped {dest} (exists)")
+            skipped += 1
+            continue
+        dest.write_text(entry.read_text())
+        click.echo(f"wrote {dest}")
+        written += 1
+    click.echo(f"\ndone: {written} written, {skipped} skipped.")
+    if skipped and not force:
+        click.echo("(pass --force to overwrite existing files)")
+
+
+def _toml_value(v: object) -> str:
+    """Render a Python value as TOML for the migrated frontmatter."""
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    if isinstance(v, str):
+        escaped = v.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    if isinstance(v, (list, tuple)):
+        return "[" + ", ".join(_toml_value(x) for x in v) + "]"
+    raise TypeError(f"unsupported toml value: {v!r}")
+
+
+def _render_migrated_role(role: roles_mod.Role, original_name: str) -> str:
+    """Build the .md file text for a migrated role."""
+    fm_lines = ["+++"]
+    if role.model:
+        fm_lines.append(f"model = {_toml_value(role.model)}")
+    if role.tools is not None:
+        fm_lines.append(f"tools = {_toml_value(list(role.tools))}")
+    if role.meta_tools is not True:
+        fm_lines.append(f"meta_tools = {_toml_value(role.meta_tools)}")
+    fm_lines.append(f"description = {_toml_value(role.description)}")
+    fm_lines.append("+++")
+    body = role.system_prompt.strip()
+    if not body:
+        body = f"# Role: {original_name}\n\n(No persona body in the original [models.<name>] entry.)"
+    return "\n".join(fm_lines) + "\n\n" + body + "\n"
+
+
+@main.command("migrate")
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Overwrite existing .md files in <config-dir>/roles/. Off by default.",
+)
+def migrate_cmd(force: bool) -> None:
+    """Convert [models.<name>] entries in config.toml to .md files.
+
+    Writes each migrated role to `<config-dir>/roles/<NAME>.md`. Does
+    NOT touch the original config.toml — you can delete the
+    `[models.<name>]` blocks once you've verified the .md files
+    behave as expected.
+    """
+    cfg = config_mod.load()
+    raw = cfg.get("models", {})
+    if not isinstance(raw, dict) or not raw:
+        click.echo("no [models.<name>] entries found in config.toml.")
+        return
+
+    target_root = _user_root()
+    target_root.mkdir(parents=True, exist_ok=True)
+
+    written = 0
+    skipped = 0
+    for name, entry in raw.items():
+        role = roles_mod._coerce_legacy_role(name, entry)
+        if role is None:
+            continue
+        dest = target_root / f"{name.upper()}.md"
+        if dest.exists() and not force:
+            click.echo(f"skipped {dest} (exists)")
+            skipped += 1
+            continue
+        dest.write_text(_render_migrated_role(role, name))
+        click.echo(f"wrote {dest}")
+        written += 1
+
+    click.echo(f"\nmigrated {written} role(s), skipped {skipped}.")
+    click.echo(
+        "The original [models.<name>] blocks in config.toml are untouched. "
+        "Once you've verified the migrated .md files, delete them from "
+        "config.toml to silence the deprecation warning."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ pyagent-config = "pyagent.config_cli:main"
 pyagent-skills = "pyagent.skills_cli:main"
 pyagent-sessions = "pyagent.sessions_cli:main"
 pyagent-plugins = "pyagent.plugins_cli:main"
+pyagent-roles = "pyagent.roles_cli:main"
 
 [tool.setuptools.packages.find]
 include = ["pyagent*"]
@@ -43,4 +44,6 @@ pyagent = [
     "plugins/**/*.md",
     "plugins/**/*.toml",
     "plugins/**/*.json",
+    # Bundled role library — one .md per role, parsed at runtime.
+    "roles_bundled/*.md",
 ]

--- a/tests/smoke_roles.py
+++ b/tests/smoke_roles.py
@@ -52,7 +52,8 @@ description = "Cheap and fast for narrow tasks."
 
 def test_role_load_and_resolve(tmp: Path) -> None:
     loaded = roles.load()
-    assert set(loaded) == {"skim", "cheap"}, loaded
+    # Bundled roles may also be present; assert legacy entries loaded.
+    assert {"skim", "cheap"} <= set(loaded), loaded
     skim = loaded["skim"]
     assert skim.model == "pyagent/echo", skim.model
     assert skim.tools == ("read_file", "grep"), skim.tools

--- a/tests/smoke_roles_md.py
+++ b/tests/smoke_roles_md.py
@@ -1,0 +1,425 @@
+"""End-to-end smoke for file-based markdown roles.
+
+Covers the migration from `[models.<name>]` config tables to standalone
+`.md` files under `pyagent/roles_bundled/`, `<config-dir>/roles/`, and
+`./.pyagent/roles/`:
+
+  - Frontmatter parsing (full, none, partial, malformed)
+  - Description auto-derivation from the body
+  - Case-insensitive lookup, dash/underscore normalization
+  - Tier precedence (project > user > bundled)
+  - Per-tier disk-name collisions warn-and-keep-first
+  - Legacy `[models.<name>]` still resolves AND emits a one-time
+    deprecation warning
+  - `pyagent-roles migrate` produces equivalent .md files
+  - `pyagent-roles list` finds bundled + user + project roles
+  - `catalog()` reflects the file-based roles
+
+Run with:
+
+    .venv/bin/python -m tests.smoke_roles_md
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from pyagent import paths, roles, roles_cli
+
+
+def _write(p: Path, text: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text)
+
+
+def test_frontmatter_full(tmp: Path) -> None:
+    """A role with every frontmatter field populated."""
+    _write(
+        tmp / ".pyagent" / "roles" / "alpha.md",
+        '+++\nmodel = "pyagent/echo"\n'
+        'tools = ["read_file", "grep"]\n'
+        "meta_tools = false\n"
+        'description = "Alpha role for tests."\n'
+        "+++\n\n"
+        "# Role: Alpha\n\nAlpha persona body.\n",
+    )
+    loaded = roles.load()
+    role = loaded["alpha"]
+    assert role.model == "pyagent/echo", role.model
+    assert role.tools == ("read_file", "grep"), role.tools
+    assert role.meta_tools is False, role.meta_tools
+    assert role.description == "Alpha role for tests.", role.description
+    assert "Alpha persona body" in role.system_prompt
+    assert role.source is not None and role.source.name == "alpha.md"
+    print("✓ frontmatter (full): all fields applied")
+
+
+def test_frontmatter_none(tmp: Path) -> None:
+    """A role with no frontmatter at all — defaults + auto-description."""
+    _write(
+        tmp / ".pyagent" / "roles" / "bare.md",
+        "# Role: Bare\n\n"
+        "Bare-bones operator that does the thing without ceremony.\n",
+    )
+    loaded = roles.load()
+    role = loaded["bare"]
+    assert role.model == "", role.model
+    assert role.tools is None, role.tools
+    assert role.meta_tools is True, role.meta_tools
+    assert "ceremony" in role.description, role.description
+    print("✓ frontmatter (none): defaults applied + description derived")
+
+
+def test_frontmatter_partial(tmp: Path) -> None:
+    """Partial frontmatter — only `tools`, no model/description."""
+    _write(
+        tmp / ".pyagent" / "roles" / "partial.md",
+        "+++\n"
+        'tools = ["read_file"]\n'
+        "+++\n\n"
+        "# Role: Partial\n\nPartial role first paragraph.\n",
+    )
+    loaded = roles.load()
+    role = loaded["partial"]
+    assert role.tools == ("read_file",), role.tools
+    assert role.model == "", role.model
+    assert "first paragraph" in role.description
+    print("✓ frontmatter (partial): selective override + auto description")
+
+
+def test_frontmatter_malformed(tmp: Path) -> None:
+    """Bad TOML in frontmatter falls back to no frontmatter."""
+    _write(
+        tmp / ".pyagent" / "roles" / "broken.md",
+        "+++\n"
+        'tools = "not a list (this is bad TOML for our schema)\n'
+        "+++\n\n"
+        "# Role: Broken\n\nBroken-but-still-loads role body.\n",
+    )
+    loaded = roles.load()
+    role = loaded["broken"]
+    # Body still readable; structured fields took defaults.
+    assert role.tools is None, role.tools
+    assert "still-loads" in role.system_prompt
+    print("✓ frontmatter (malformed): role still loads with defaults")
+
+
+def test_description_derivation_skips_heading(tmp: Path) -> None:
+    """Description should skip the leading heading line."""
+    _write(
+        tmp / ".pyagent" / "roles" / "headed.md",
+        "# Role: Headed\n\nThis is the actual paragraph used as description.\n",
+    )
+    loaded = roles.load()
+    assert loaded["headed"].description.startswith("This is the actual"), loaded[
+        "headed"
+    ].description
+    print("✓ description: leading heading skipped, first paragraph used")
+
+
+def test_case_insensitive_lookup(tmp: Path) -> None:
+    """File `RESEARCHER.md` callable as `researcher` and any case variant."""
+    _write(
+        tmp / ".pyagent" / "roles" / "BIG.md",
+        "+++\n" 'model = "pyagent/echo"\n' "+++\n\n# Role: Big\n\nDoes big things.\n",
+    )
+    loaded = roles.load()
+    assert "big" in loaded
+    m, role = roles.resolve("BIG")
+    assert role is not None and role.name == "big", role
+    m2, role2 = roles.resolve("Big")
+    assert role2 is not None and role2.name == "big", role2
+    print("✓ lookup: case-insensitive (BIG / Big / big all resolve)")
+
+
+def test_dash_underscore_normalization(tmp: Path) -> None:
+    """`software-engineer.md` → role name `software_engineer`."""
+    _write(
+        tmp / ".pyagent" / "roles" / "field-tester.md",
+        "# Role: Field tester\n\nTries things in the field.\n",
+    )
+    loaded = roles.load()
+    assert "field_tester" in loaded, sorted(loaded)
+    # Lookup with either dashes or underscores works.
+    _, r1 = roles.resolve("field-tester")
+    _, r2 = roles.resolve("field_tester")
+    assert r1 is not None and r2 is not None
+    assert r1.name == r2.name == "field_tester"
+    print("✓ filename: dash/underscore both normalize to underscores")
+
+
+def test_tier_precedence(tmp: Path, user_dir: Path) -> None:
+    """Project > user > bundled on canonical-name collision.
+
+    `RESEARCHER.md` ships bundled. We add a user-tier file and a
+    project-tier file with the same canonical name and confirm the
+    project tier wins.
+    """
+    # User-tier role.
+    user_role = user_dir / "roles" / "researcher.md"
+    _write(
+        user_role,
+        '+++\nmodel = "pyagent/echo"\n+++\n\nUSER-TIER researcher persona.\n',
+    )
+    loaded = roles.load()
+    role = loaded["researcher"]
+    assert "USER-TIER" in role.system_prompt, role.system_prompt
+    print("✓ tier: user beats bundled")
+
+    # Project-tier role wins over user.
+    proj_role = tmp / ".pyagent" / "roles" / "RESEARCHER.md"
+    _write(
+        proj_role,
+        '+++\nmodel = "pyagent/loremipsum"\n+++\n\nPROJECT-TIER researcher.\n',
+    )
+    loaded = roles.load()
+    role = loaded["researcher"]
+    assert "PROJECT-TIER" in role.system_prompt, role.system_prompt
+    assert role.model == "pyagent/loremipsum", role.model
+    print("✓ tier: project beats user beats bundled")
+
+
+def test_legacy_models_table_still_resolves_and_warns(tmp: Path, caplog) -> None:
+    """[models.<name>] in config.toml still loads + emits one-time warning."""
+    (tmp / ".pyagent" / "config.toml").write_text(
+        '[models.legacyrole]\n'
+        'model = "pyagent/echo"\n'
+        'description = "Legacy role still works."\n'
+        "system_prompt = \"You're a legacy role.\"\n"
+    )
+    roles._reset_deprecation_warning()
+    with caplog.at_level(logging.WARNING, logger="pyagent.roles"):
+        loaded = roles.load()
+    assert "legacyrole" in loaded
+    role = loaded["legacyrole"]
+    assert role.model == "pyagent/echo"
+    assert any("deprecated" in r.getMessage() for r in caplog.records), caplog.records
+    print("✓ legacy: [models.legacyrole] resolved + deprecation warning emitted")
+
+    # Second load() call within the same process should NOT emit
+    # another deprecation warning — gated by the one-time flag.
+    caplog.records.clear()
+    with caplog.at_level(logging.WARNING, logger="pyagent.roles"):
+        roles.load()
+    assert not any("deprecated" in r.getMessage() for r in caplog.records), (
+        f"deprecation warning fired twice: {caplog.records}"
+    )
+    print("✓ legacy: deprecation warning does not spam (one-time)")
+
+
+def test_file_based_role_shadows_legacy(tmp: Path) -> None:
+    """If both an .md role and a [models.<name>] entry exist with
+    the same canonical name, the file-based form wins (newer
+    authoring tool)."""
+    (tmp / ".pyagent" / "config.toml").write_text(
+        '[models.shared]\n'
+        'model = "pyagent/loremipsum"\n'
+        'description = "Legacy version."\n'
+    )
+    _write(
+        tmp / ".pyagent" / "roles" / "shared.md",
+        '+++\nmodel = "pyagent/echo"\n'
+        'description = "File version."\n+++\n\nFile-based shared role.\n',
+    )
+    roles._reset_deprecation_warning()
+    loaded = roles.load()
+    role = loaded["shared"]
+    assert role.model == "pyagent/echo", role.model
+    assert role.description == "File version.", role.description
+    print("✓ collision: file-based role shadows legacy [models.shared]")
+
+
+def test_per_tier_disk_collision(tmp: Path) -> None:
+    """Two files in the same tier that normalize to the same name —
+    warn and keep the lexicographically-first."""
+    _write(
+        tmp / ".pyagent" / "roles" / "DUPE.md",
+        "# Role: Dupe upper\n\nFrom DUPE.md.\n",
+    )
+    _write(
+        tmp / ".pyagent" / "roles" / "dupe.md",
+        "# Role: Dupe lower\n\nFrom dupe.md.\n",
+    )
+    loaded = roles.load()
+    role = loaded["dupe"]
+    # Sorted glob -> "DUPE.md" comes before "dupe.md" lexicographically.
+    assert role.source is not None and role.source.name == "DUPE.md", role.source
+    print("✓ per-tier collision: lexicographically-first wins")
+
+
+def test_catalog_reflects_file_based_roles(tmp: Path) -> None:
+    _write(
+        tmp / ".pyagent" / "roles" / "catalog_role.md",
+        '+++\nmodel = "pyagent/echo"\n+++\n\nA cataloged role.\n',
+    )
+    cat = roles.catalog()
+    assert "catalog_role" in cat
+    assert "pyagent/echo" in cat
+    print("✓ catalog: file-based roles render in the system-prompt block")
+
+
+def test_cli_list_runs(tmp: Path, user_dir: Path) -> None:
+    """`pyagent-roles list` finds bundled + user + project roles."""
+    # User-tier
+    _write(user_dir / "roles" / "user_only.md", "# Role: User\n\nUser role.\n")
+    # Project-tier
+    _write(tmp / ".pyagent" / "roles" / "proj_only.md", "# Role: Proj\n\nProject role.\n")
+    runner = CliRunner()
+    result = runner.invoke(roles_cli.main, ["list"])
+    assert result.exit_code == 0, result.output
+    out = result.output
+    assert "researcher" in out, out  # bundled
+    assert "user_only" in out, out
+    assert "proj_only" in out, out
+    print("✓ pyagent-roles list: shows bundled + user + project tiers")
+
+
+def test_cli_show_and_path(tmp: Path) -> None:
+    _write(
+        tmp / ".pyagent" / "roles" / "shown.md",
+        '+++\nmodel = "pyagent/echo"\n+++\n\n# Role: Shown\n\nShown body.\n',
+    )
+    runner = CliRunner()
+
+    show = runner.invoke(roles_cli.main, ["show", "shown"])
+    assert show.exit_code == 0, show.output
+    assert "Shown body" in show.output, show.output
+    assert "pyagent/echo" in show.output
+
+    path = runner.invoke(roles_cli.main, ["path", "shown"])
+    assert path.exit_code == 0, path.output
+    assert path.output.strip().endswith("shown.md"), path.output
+    print("✓ pyagent-roles show / path: emit role content + resolved path")
+
+
+def test_cli_init_idempotent(tmp: Path, user_dir: Path) -> None:
+    """`pyagent-roles init` seeds config-dir/roles, idempotently."""
+    runner = CliRunner()
+    first = runner.invoke(roles_cli.main, ["init"])
+    assert first.exit_code == 0, first.output
+    assert "wrote" in first.output, first.output
+
+    seeded = sorted(p.name for p in (user_dir / "roles").glob("*.md"))
+    assert "RESEARCHER.md" in seeded, seeded
+    assert "SOFTWARE_ENGINEER.md" in seeded
+    assert "REVIEWER.md" in seeded
+    assert "SCRIBE.md" in seeded
+
+    # Re-run: every file should report skipped.
+    second = runner.invoke(roles_cli.main, ["init"])
+    assert second.exit_code == 0, second.output
+    assert "skipped" in second.output
+    assert "wrote" not in second.output.lower().replace(
+        "(none)", ""
+    ).split("done:")[0]
+    print("✓ pyagent-roles init: idempotent (skips existing files)")
+
+
+def test_cli_migrate(tmp: Path, user_dir: Path) -> None:
+    """`pyagent-roles migrate` synthesizes .md files from [models.<name>]."""
+    (tmp / ".pyagent" / "config.toml").write_text(
+        '[models.tomigrate]\n'
+        'model = "pyagent/echo"\n'
+        'description = "A role to migrate."\n'
+        'system_prompt = "Migrated persona."\n'
+        'tools = ["read_file"]\n'
+        'meta_tools = false\n'
+    )
+    runner = CliRunner()
+    result = runner.invoke(roles_cli.main, ["migrate"])
+    assert result.exit_code == 0, result.output
+    out_path = user_dir / "roles" / "TOMIGRATE.md"
+    assert out_path.exists(), out_path
+    text = out_path.read_text()
+    assert "pyagent/echo" in text
+    assert "Migrated persona" in text
+    assert "tools = " in text
+    assert "meta_tools = false" in text
+
+    # Migrated role is now resolvable as a file-based role.
+    roles._reset_deprecation_warning()
+    loaded = roles.load()
+    assert "tomigrate" in loaded
+    role = loaded["tomigrate"]
+    # File-based resolution should now win — source set.
+    assert role.source is not None, role
+    print("✓ pyagent-roles migrate: writes .md and roles.load() picks it up")
+
+
+# ---- Test harness ---------------------------------------------------
+
+
+class _CapLog:
+    """Tiny pytest-style caplog stand-in for the smoke harness."""
+
+    def __init__(self) -> None:
+        self.records: list[logging.LogRecord] = []
+        self._handler = logging.Handler()
+        self._handler.emit = self.records.append  # type: ignore[assignment]
+
+    class _Ctx:
+        def __init__(self, parent: "_CapLog", logger_name: str, level: int) -> None:
+            self.parent = parent
+            self.logger = logging.getLogger(logger_name)
+            self.level = level
+            self._old_level = self.logger.level
+
+        def __enter__(self):
+            self.logger.addHandler(self.parent._handler)
+            self.logger.setLevel(self.level)
+            return self.parent
+
+        def __exit__(self, *exc):
+            self.logger.removeHandler(self.parent._handler)
+            self.logger.setLevel(self._old_level)
+            return False
+
+    def at_level(self, level: int, logger: str = "pyagent.roles") -> "_CapLog._Ctx":
+        return _CapLog._Ctx(self, logger, level)
+
+
+def main() -> None:
+    tmp = Path(tempfile.mkdtemp(prefix="pyagent-roles-md-smoke-"))
+    user_dir = Path(tempfile.mkdtemp(prefix="pyagent-roles-md-userdir-"))
+    os.chdir(tmp)
+    print(f"cwd: {tmp}")
+    print(f"config-dir (mocked): {user_dir}")
+
+    # Stub paths.config_dir() for the duration of the smoke run so the
+    # user-tier root is the temp dir, not the real ~/.config/pyagent.
+    real_config_dir = paths.config_dir
+    paths.config_dir = lambda: user_dir  # type: ignore[assignment]
+    try:
+        caplog = _CapLog()
+
+        test_frontmatter_full(tmp)
+        test_frontmatter_none(tmp)
+        test_frontmatter_partial(tmp)
+        test_frontmatter_malformed(tmp)
+        test_description_derivation_skips_heading(tmp)
+        test_case_insensitive_lookup(tmp)
+        test_dash_underscore_normalization(tmp)
+        test_tier_precedence(tmp, user_dir)
+        test_legacy_models_table_still_resolves_and_warns(tmp, caplog)
+        test_file_based_role_shadows_legacy(tmp)
+        test_per_tier_disk_collision(tmp)
+        test_catalog_reflects_file_based_roles(tmp)
+        test_cli_list_runs(tmp, user_dir)
+        test_cli_show_and_path(tmp)
+        test_cli_init_idempotent(tmp, user_dir)
+        test_cli_migrate(tmp, user_dir)
+
+        print("\nALL CHECKS PASSED")
+    finally:
+        paths.config_dir = real_config_dir  # type: ignore[assignment]
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/smoke_roles_md.py
+++ b/tests/smoke_roles_md.py
@@ -350,7 +350,71 @@ def test_cli_migrate(tmp: Path, user_dir: Path) -> None:
     role = loaded["tomigrate"]
     # File-based resolution should now win — source set.
     assert role.source is not None, role
+
+    # When the legacy entry has a non-empty system_prompt, the migrated
+    # frontmatter should NOT pin description — auto-derivation from the
+    # body is enough, matching the bundled-roles convention. The
+    # description still gets resolved correctly via auto-derive.
+    assert "description = " not in text, (
+        f"description should be omitted when body is present: {text!r}"
+    )
+    assert role.description, "auto-derived description should be non-empty"
     print("✓ pyagent-roles migrate: writes .md and roles.load() picks it up")
+
+
+def test_cli_migrate_dashed_name(tmp: Path, user_dir: Path) -> None:
+    """Legacy role names with dashes (`[models.deep-thought]`) migrate
+    to canonical `DEEP_THOUGHT.md` — uppercase + underscores, matching
+    the bundled-roles convention. Lookup still works either way via
+    `_normalize_name`."""
+    (tmp / ".pyagent" / "config.toml").write_text(
+        '[models.deep-thought]\n'
+        'model = "pyagent/echo"\n'
+        'description = "Dashed name."\n'
+        'system_prompt = "Body content here."\n'
+    )
+    runner = CliRunner()
+    result = runner.invoke(roles_cli.main, ["migrate"])
+    assert result.exit_code == 0, result.output
+
+    canonical = user_dir / "roles" / "DEEP_THOUGHT.md"
+    dashed = user_dir / "roles" / "DEEP-THOUGHT.md"
+    assert canonical.exists(), f"expected {canonical}, got dir: " + str(
+        list((user_dir / "roles").iterdir())
+    )
+    assert not dashed.exists(), (
+        f"unexpected dashed filename {dashed} — should have been "
+        f"normalized to underscores"
+    )
+
+    # Lookup still works via the original dashed name (normalized).
+    roles._reset_deprecation_warning()
+    loaded = roles.load()
+    assert "deep_thought" in loaded, list(loaded.keys())
+    print(
+        "✓ pyagent-roles migrate: dashed names → underscored filenames"
+    )
+
+
+def test_cli_migrate_no_body_keeps_description(
+    tmp: Path, user_dir: Path
+) -> None:
+    """When the legacy [models.<name>] entry has no `system_prompt`,
+    the migrated file must keep `description` in the frontmatter — the
+    auto-derive has nothing to pull from."""
+    (tmp / ".pyagent" / "config.toml").write_text(
+        '[models.bare]\n'
+        'model = "pyagent/echo"\n'
+        'description = "Pin me explicitly."\n'
+    )
+    runner = CliRunner()
+    result = runner.invoke(roles_cli.main, ["migrate"])
+    assert result.exit_code == 0, result.output
+    out_path = user_dir / "roles" / "BARE.md"
+    assert out_path.exists()
+    text = out_path.read_text()
+    assert 'description = "Pin me explicitly."' in text, text
+    print("✓ pyagent-roles migrate: keeps description when body is empty")
 
 
 # ---- Test harness ---------------------------------------------------
@@ -415,6 +479,8 @@ def main() -> None:
         test_cli_show_and_path(tmp)
         test_cli_init_idempotent(tmp, user_dir)
         test_cli_migrate(tmp, user_dir)
+        test_cli_migrate_dashed_name(tmp, user_dir)
+        test_cli_migrate_no_body_keeps_description(tmp, user_dir)
 
         print("\nALL CHECKS PASSED")
     finally:


### PR DESCRIPTION
## Summary

Move role definitions from `[models.<name>]` tables in `config.toml`
to one `.md` file per role. Roles now live in three tiers parallel to
skills/plugins/config:

  1. `pyagent/roles_bundled/*.md`  — bundled with pyagent
  2. `<config-dir>/roles/*.md`     — user library
  3. `.pyagent/roles/*.md`         — project-local

Each `.md` is one role. Hugo-style TOML frontmatter between `+++`
delimiters declares `model` / `tools` / `meta_tools` / `description`;
all fields optional. Body after the closing fence is the persona
prose. The dataclass and `resolve()`/`catalog()` signatures are
unchanged — only the data source moved.

## Decisions applied

| Question | Decision |
|---|---|
| Frontmatter format | TOML between `+++` delimiters (Hugo style). Zero new deps — `tomllib` is stdlib in 3.11+. |
| Description fallback | First non-empty paragraph after the leading heading, whitespace collapsed, capped at ~200 chars. Falls back to role name. |
| Case sensitivity | Lookup case-insensitive (`RESEARCHER` ≡ `Researcher` ≡ `researcher`). Filename preserved. |
| Name normalization | Dashes and underscores both accepted (`software-engineer.md` and `software_engineer.md` both yield `software_engineer`). |
| Heading line | Opaque prose. Not rejected if absent. The body just is what it is. |
| Tier precedence | project > user > bundled, matching skills/plugins/config. |
| Backward compat | `[models.<name>]` still loads. One-time deprecation warning at startup names each role and points at `pyagent-roles migrate`. File-based roles win on collision. |
| Per-tier disk collision | Lexicographically-first wins; warn. |

## Behavior changes

| Surface | Before | After |
|---------|--------|-------|
| Authoring a role | Edit `[models.<name>]` in `config.toml` | Drop `<NAME>.md` in `<config-dir>/roles/` |
| Sharing across machines | Copy TOML fragments | Drop `.md` files |
| Catalog rendering | TOML-backed | File-backed; auto-detected on every render |
| `[models.<name>]` | Required | Deprecated; still works with warning |
| Empty role `model` | n/a (required field) | Inherits caller's model — cheap "you're a software engineer for this subtask" pattern |

## Starter library (bundled)

Four roles ship under `pyagent/roles_bundled/`. Each is a worked
example for users authoring their own:

- **RESEARCHER** — read + fetch tools, no meta-tools. Returns
  synthesized findings with citations; surfaces source disagreements.
- **SOFTWARE_ENGINEER** — full default toolset, no meta-tools.
  Reads before writing, runs tests, returns a tight summary.
- **REVIEWER** — read-only (`read_file`, `grep`, `list_directory`,
  `read_skill`); no meta-tools. Leads with verdict, distinguishes
  bugs from preferences, ends with SHIP / SHIP WITH NITS / NEEDS
  CHANGES.
- **SCRIBE** — file read/write/edit; no execute, no meta-tools.
  Captures and organizes notes/docs without inventing content.

Each ships with sensible frontmatter — `REVIEWER` and `RESEARCHER`
have read-only allowlists, all four set `meta_tools = false` since
they're leaf roles.

## CLI

```
pyagent-roles list             # all roles, by tier, name + description
pyagent-roles show <name>      # render resolved content + frontmatter
pyagent-roles path <name>      # print resolved file path (scripting helper)
pyagent-roles init             # seed <config-dir>/roles/ with the starter set (idempotent)
pyagent-roles migrate          # convert any [models.<name>] in config.toml to .md
```

`pyagent-config init` also seeds `<config-dir>/roles/` now, so
first-run users get the starter library without having to discover
`pyagent-roles init` separately.

## Migration path

`pyagent-roles migrate` writes each existing `[models.<name>]`
entry as `<config-dir>/roles/<NAME>.md` with frontmatter populated
from the original fields. The original `[models.<name>]` blocks in
`config.toml` are left untouched — the user deletes them after
verifying the migrated files behave as expected. Until they do, the
deprecation warning fires once per process at startup.

## Implementation notes

- `pyagent/roles.py` — file-tier scanning + frontmatter parsing,
  plus the legacy `_coerce_legacy_role` path. The `Role` dataclass
  gains an optional `source: Path | None` (None for legacy entries).
- `pyagent/roles_cli.py` — Click sub-commands.
- `pyagent/roles_bundled/{RESEARCHER, SOFTWARE_ENGINEER, REVIEWER, SCRIBE}.md` — starter set.
- `pyagent/config_cli.py` — `init` also seeds `roles/`.
- `pyagent/config.py` — role example block now points at
  `pyagent-roles init` / `migrate` rather than the inline TOML schema.
- `pyproject.toml` — adds `pyagent-roles` entry point and
  `roles_bundled/*.md` to `package-data`.

No new `Attachment(...)` construction sites — the
`smoke_session_replay` invariant still holds.

## Test plan

- [x] `tests/smoke_roles_md.py` (new) — 16 checks: frontmatter (full / none / partial / malformed), description derivation, case-insensitive lookup, dash/underscore normalization, tier precedence, legacy resolve + one-time deprecation warning, file-based shadows legacy, per-tier disk collision, catalog rendering, all five CLI sub-commands.
- [x] Full smoke suite (21 files): `smoke_roles_md` passes; the 19 unrelated suites still pass; `smoke_roles.py` still fails on the pre-existing `_register_tools allowlist=None → 9 tools` assertion (8 are returned). That failure is unchanged from `main` and unrelated to roles authoring; left alone per scope.
- [x] Manual: `pyagent-roles list` and `pyagent-roles show researcher` render correctly. `pyagent-roles migrate` round-trips a synthetic `[models.example]` into a re-parseable `.md`.

## Out of scope

- Removing the legacy `[models.<name>]` parser entirely (one minor version of warning before drop, per the issue's migration plan).
- Pre-existing `smoke_roles.py` `_register_tools` 8-vs-9 assertion (separate bug; documented in issue body as not-mine-to-fix).

Closes #17.