### PR TITLE
read_skill body eviction with evict_after_use flag (#10)

### DIFF
--- a/pyagent/agent.py
+++ b/pyagent/agent.py
@@ -54,6 +54,15 @@ class Agent:
         self.session = session
         self.tools: dict[str, Callable[..., Any]] = {}
         self._auto_offload: dict[str, bool] = {}
+        # Tools opted into post-consumption eviction. After an
+        # assistant turn produces output, any earlier tool_result for
+        # one of these tools is replaced in-memory by a one-line stub
+        # — the data was single-shot reference content, the model
+        # already extracted what it needed from it, and recovery is
+        # one tool call away. JSONL on disk keeps the full content
+        # (round-trip invariant); eviction is in-memory only.
+        # See issue #10.
+        self._evict_after_use: dict[str, bool] = {}
         self.conversation: list[Any] = []
         self.plugins = plugins
         # Subagent registry: id -> opaque entry (shape owned by the
@@ -88,9 +97,21 @@ class Agent:
         name: str,
         fn: Callable[..., Any],
         auto_offload: bool = True,
+        *,
+        evict_after_use: bool = False,
     ) -> None:
+        """Register a tool.
+
+        `evict_after_use=True` opts the tool into post-consumption
+        eviction: once an assistant turn has produced output that
+        followed the tool_result, the result's `content` field is
+        replaced in-memory by a short stub (see `_apply_eviction`).
+        Use for single-shot reference content (skill bodies, etc.) —
+        not for tools whose results the model may want to revisit.
+        """
         self.tools[name] = fn
         self._auto_offload[name] = auto_offload
+        self._evict_after_use[name] = evict_after_use
 
     def _tool_schemas(self) -> list[dict[str, Any]]:
         """Build JSON-schema tool definitions from each tool's type hints + docstring."""
@@ -280,6 +301,82 @@ class Agent:
         self._scrub_large_tool_args(call)
         return content
 
+    @staticmethod
+    def _eviction_stub(tool_name: str) -> str:
+        return (
+            f"[skill {tool_name!r} loaded earlier; content evicted "
+            f"to save context. Call read_skill({tool_name!r}) again "
+            f"to reload.]"
+        )
+
+    @staticmethod
+    def _assistant_turn_has_output(msg: Any) -> bool:
+        if not isinstance(msg, dict):
+            return False
+        if msg.get("role") != "assistant":
+            return False
+        if msg.get("text"):
+            return True
+        if msg.get("tool_calls"):
+            return True
+        return False
+
+    def _apply_eviction(self) -> int:
+        """Replace consumed eviction-flagged tool_result content with stubs.
+
+        Provable-staleness rule: a tool_result entry for a tool
+        registered with `evict_after_use=True` is stale once at least
+        one later assistant turn in the conversation has produced
+        output (text and/or tool_calls). The MOST RECENT such result
+        (no following assistant turn yet) is still load-bearing — the
+        agent is mid-consumption — so it is preserved.
+
+        Idempotent: a result whose content is already the stub is a
+        no-op on subsequent walks. JSONL on disk is not touched (see
+        issue #10 design notes; smoke_session_replay locks the
+        round-trip invariant).
+
+        Returns the number of result entries newly stubbed.
+        """
+        if not any(self._evict_after_use.values()):
+            return 0
+
+        # Build a forward-marching set of indices into self.conversation
+        # where an assistant turn with output appears. A tool_result at
+        # index i is stale iff there's at least one such assistant
+        # index > i.
+        assistant_with_output: list[int] = [
+            i for i, msg in enumerate(self.conversation)
+            if self._assistant_turn_has_output(msg)
+        ]
+        if not assistant_with_output:
+            return 0
+        last_with_output = assistant_with_output[-1]
+
+        stubbed = 0
+        for i, msg in enumerate(self.conversation):
+            if not isinstance(msg, dict):
+                continue
+            results = msg.get("tool_results")
+            if not results:
+                continue
+            # Stale only if SOME assistant turn with output appears
+            # later in the log. If the only assistant-with-output
+            # indices are all <= i, this batch is the most recent —
+            # leave it alone.
+            if i >= last_with_output:
+                continue
+            for r in results:
+                name = r.get("name")
+                if not name or not self._evict_after_use.get(name, False):
+                    continue
+                stub = self._eviction_stub(name)
+                if r.get("content") == stub:
+                    continue  # already evicted; idempotent
+                r["content"] = stub
+                stubbed += 1
+        return stubbed
+
     def _drain_pending_async(self) -> int:
         """Append every queued async-subagent reply as a user message.
 
@@ -325,6 +422,11 @@ class Agent:
                 self.conversation, stable, system_volatile=volatile
             )
             self.conversation.append(turn)
+            # After every assistant turn, evict stale single-shot tool
+            # results in-memory (see `_apply_eviction`). Cheap walk;
+            # only mutates entries belonging to tools registered with
+            # `evict_after_use=True`. JSONL on disk is untouched.
+            self._apply_eviction()
             usage = turn.get("usage") if isinstance(turn, dict) else None
             if usage:
                 for k in ("input", "output", "cache_creation", "cache_read"):

--- a/pyagent/agent_proc.py
+++ b/pyagent/agent_proc.py
@@ -421,7 +421,18 @@ def _register_tools(
     # memory-markdown plugin (see pyagent/plugins/memory_markdown/).
     # Disabling that plugin removes the tools entirely — clean
     # replacement surface for alternative memory backends.
-    _add("read_skill", skills_mod.read_skill, auto_offload=False)
+    # Skill bodies are single-shot reference content: the model reads
+    # one to decide what to do next, the next assistant turn records
+    # that decision, after which the body is dead weight on every
+    # subsequent turn. `evict_after_use=True` swaps the result for a
+    # short stub once the consuming assistant turn has produced
+    # output. Recovery is a second `read_skill` call. Issue #10.
+    _add(
+        "read_skill",
+        skills_mod.read_skill,
+        auto_offload=False,
+        evict_after_use=True,
+    )
     if allow_meta:
         assert state is not None and parent_session is not None and base_config is not None
         _add(
@@ -578,6 +589,12 @@ def _bootstrap(
 
     agent.conversation = session.load_history()
     if agent.conversation:
+        # JSONL on disk keeps full skill-body content (round-trip
+        # invariant — see smoke_session_replay). On resume, apply the
+        # same eviction pass that runs after each live assistant turn
+        # so in-memory state matches what would have been there had
+        # the session run continuously. Issue #10.
+        agent._apply_eviction()
         orphans = session.find_orphan_attachments()
         if orphans:
             session.purge_orphan_attachments(orphans=orphans)

--- a/tests/smoke_skill_eviction.py
+++ b/tests/smoke_skill_eviction.py
@@ -1,0 +1,304 @@
+"""Smoke for `read_skill` body eviction (issue #10).
+
+Locks six behaviors of `Agent._apply_eviction` and the
+`evict_after_use=True` flag on `Agent.add_tool`:
+
+  1. Default `evict_after_use=False` — result content stays in
+     conversation across many turns.
+  2. `evict_after_use=True` — result content is replaced with the
+     stub once the NEXT assistant turn produces output.
+  3. The most recent eviction-flagged result (no following
+     assistant turn yet) is preserved — load-bearing.
+  4. Idempotence — running `_apply_eviction` twice doesn't
+     double-stub; the second run reports zero new evictions.
+  5. Resume — `Session.load_history` returns the full content
+     (JSONL untouched), and a fresh Agent applying the same
+     eviction pass produces the in-memory stubs without mutating
+     the file on disk.
+  6. Multiple skills loaded in sequence — every consumed skill
+     gets evicted at the right turn (not just the first one).
+
+Run with:
+
+    .venv/bin/python -m tests.smoke_skill_eviction
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from pyagent.agent import Agent
+from pyagent.llms.pyagent import EchoClient
+from pyagent.session import Session
+
+
+def _user(content: str) -> dict:
+    return {"role": "user", "content": content}
+
+
+def _assistant(text: str = "", tool_calls: list | None = None) -> dict:
+    return {
+        "role": "assistant",
+        "text": text,
+        "tool_calls": tool_calls or [],
+    }
+
+
+def _tool_results(results: list[dict]) -> dict:
+    return {"role": "user", "tool_results": results}
+
+
+def _make_agent(*, evict_skill: bool, evict_other: bool = False) -> Agent:
+    """Build an Agent with stubbed tools registered for the test.
+
+    The tool callables are never invoked here — we synthesize the
+    conversation directly to exercise the eviction walk.
+    """
+    agent = Agent(client=EchoClient())
+
+    def _read_skill(name: str = "x") -> str:  # pragma: no cover (not invoked)
+        return f"body of {name}"
+
+    def _grep(pattern: str = "x") -> str:  # pragma: no cover (not invoked)
+        return f"matches for {pattern}"
+
+    agent.add_tool(
+        "read_skill", _read_skill,
+        auto_offload=False, evict_after_use=evict_skill,
+    )
+    agent.add_tool("grep", _grep, evict_after_use=evict_other)
+    return agent
+
+
+def _check_default_no_eviction() -> None:
+    """Tools without the flag never lose their result content."""
+    agent = _make_agent(evict_skill=False, evict_other=False)
+    grep_payload = "alpha\nbeta\ngamma"
+    agent.conversation = [
+        _user("hello"),
+        _assistant(text="", tool_calls=[
+            {"id": "c1", "name": "grep", "args": {"pattern": "x"}}
+        ]),
+        _tool_results([{"id": "c1", "name": "grep", "content": grep_payload}]),
+        _assistant(text="found stuff"),
+        _user("more"),
+        _assistant(text="ok"),
+        _user("again"),
+        _assistant(text="still ok"),
+    ]
+
+    n = agent._apply_eviction()
+    assert n == 0, f"unexpected eviction with no flagged tools: {n}"
+    # The grep result content should still be the original payload
+    # several assistant turns later.
+    found = agent.conversation[2]["tool_results"][0]["content"]
+    assert found == grep_payload, (
+        f"non-evictable content was mutated: {found!r}"
+    )
+    print("✓ default flag (False) keeps content across many turns")
+
+
+def _check_evict_after_next_assistant_turn() -> None:
+    """A flagged result is stubbed once the next assistant turn produces output."""
+    agent = _make_agent(evict_skill=True)
+    body = "Skill body: long reference content " * 100  # ~3.5KB
+    agent.conversation = [
+        _user("look up the skill"),
+        _assistant(text="", tool_calls=[
+            {"id": "c1", "name": "read_skill", "args": {"name": "foo"}}
+        ]),
+        _tool_results([
+            {"id": "c1", "name": "read_skill", "content": body}
+        ]),
+        # First consuming assistant turn — produces text.
+        _assistant(text="OK, I read the skill. Running it now."),
+    ]
+
+    # No FOLLOWING assistant turn after the consumer yet — wait, the
+    # consumer IS the only assistant-with-output AFTER the result, so
+    # it makes the result stale. Walk: assistant_with_output indices
+    # = [3]. The tool_results entry is at index 2, and 2 < 3, so it
+    # IS evicted.
+    n = agent._apply_eviction()
+    assert n == 1, f"expected exactly 1 eviction, got {n}"
+    stub = agent.conversation[2]["tool_results"][0]["content"]
+    assert "evicted to save context" in stub, stub
+    assert "'read_skill'" in stub, stub
+    assert body not in stub, "raw body leaked into stub"
+    print("✓ flagged result stubbed after a consuming assistant turn")
+
+
+def _check_most_recent_preserved() -> None:
+    """The most recent flagged result is load-bearing — never stubbed yet."""
+    agent = _make_agent(evict_skill=True)
+    body_1 = "skill one body " * 50
+    body_2 = "skill two body " * 50
+    agent.conversation = [
+        _user("read first skill"),
+        _assistant(text="", tool_calls=[
+            {"id": "c1", "name": "read_skill", "args": {"name": "foo"}}
+        ]),
+        _tool_results([
+            {"id": "c1", "name": "read_skill", "content": body_1}
+        ]),
+        _assistant(text="now read second"),  # consumes body_1
+        _user("ok"),
+        _assistant(text="", tool_calls=[
+            {"id": "c2", "name": "read_skill", "args": {"name": "bar"}}
+        ]),
+        _tool_results([
+            {"id": "c2", "name": "read_skill", "content": body_2}
+        ]),
+        # No assistant turn AFTER the second tool_results — the
+        # second result is the most recent and must be preserved.
+    ]
+
+    n = agent._apply_eviction()
+    assert n == 1, f"expected 1 eviction (body_1 only), got {n}"
+
+    first_content = agent.conversation[2]["tool_results"][0]["content"]
+    second_content = agent.conversation[6]["tool_results"][0]["content"]
+    assert "evicted to save context" in first_content, first_content
+    assert second_content == body_2, (
+        "most recent skill result was incorrectly evicted"
+    )
+    print("✓ most recent flagged result preserved (load-bearing)")
+
+
+def _check_idempotent() -> None:
+    """A second walk over already-stubbed results is a no-op."""
+    agent = _make_agent(evict_skill=True)
+    body = "body content " * 50
+    agent.conversation = [
+        _user("x"),
+        _assistant(text="", tool_calls=[
+            {"id": "c1", "name": "read_skill", "args": {"name": "foo"}}
+        ]),
+        _tool_results([
+            {"id": "c1", "name": "read_skill", "content": body}
+        ]),
+        _assistant(text="consumed"),
+    ]
+
+    n1 = agent._apply_eviction()
+    assert n1 == 1, f"first walk: expected 1, got {n1}"
+    stubbed_content = agent.conversation[2]["tool_results"][0]["content"]
+
+    n2 = agent._apply_eviction()
+    assert n2 == 0, f"second walk: expected 0 (idempotent), got {n2}"
+    # Content must be unchanged on the no-op walk.
+    assert agent.conversation[2]["tool_results"][0]["content"] == stubbed_content
+    print("✓ second walk is idempotent (0 new evictions)")
+
+
+def _check_resume_jsonl_untouched() -> None:
+    """JSONL on disk keeps full content; in-memory replay applies eviction."""
+    tmp = Path(tempfile.mkdtemp(prefix="pyagent-smoke-evict-resume-"))
+    session = Session(session_id="resume", root=tmp)
+
+    body = "Skill body for resume test " * 80  # ~2.2KB
+    entries = [
+        _user("hello"),
+        _assistant(text="", tool_calls=[
+            {"id": "c1", "name": "read_skill", "args": {"name": "foo"}}
+        ]),
+        _tool_results([
+            {"id": "c1", "name": "read_skill", "content": body}
+        ]),
+        _assistant(text="consumed it"),
+        _user("more work"),
+        _assistant(text="done"),
+    ]
+    session.append_history(entries)
+
+    # 1. The JSONL on disk contains the full body. Round-trip invariant.
+    raw = session.conversation_path.read_text()
+    assert body in raw, "full skill body missing from JSONL on disk"
+    loaded_back = session.load_history()
+    assert loaded_back == entries, (
+        "load_history did not round-trip its input — invariant broken"
+    )
+
+    # 2. A fresh Agent loads the history and applies the eviction
+    # pass. The in-memory conversation gets the stub; the JSONL on
+    # disk does NOT change.
+    agent = _make_agent(evict_skill=True)
+    agent.session = session
+    agent.conversation = session.load_history()
+    n = agent._apply_eviction()
+    assert n == 1, f"expected 1 eviction on resume, got {n}"
+    in_mem = agent.conversation[2]["tool_results"][0]["content"]
+    assert "evicted to save context" in in_mem, in_mem
+
+    raw_after = session.conversation_path.read_text()
+    assert raw_after == raw, "JSONL on disk was mutated by resume eviction"
+    assert body in raw_after, "full skill body must still live on disk"
+
+    # Defense-in-depth: each line on disk should still parse and
+    # round-trip identically.
+    on_disk = [json.loads(line) for line in raw_after.splitlines() if line.strip()]
+    assert on_disk == entries, "on-disk JSONL no longer matches what was written"
+
+    print(f"✓ resume: in-memory stubbed, JSONL unchanged ({len(raw)} bytes)")
+
+
+def _check_multiple_skills_in_sequence() -> None:
+    """Each consumed skill gets evicted; only the latest survives."""
+    agent = _make_agent(evict_skill=True)
+    body_1 = "first body " * 40
+    body_2 = "second body " * 40
+    body_3 = "third body " * 40
+
+    agent.conversation = [
+        _user("multi"),
+        _assistant(text="", tool_calls=[
+            {"id": "c1", "name": "read_skill", "args": {"name": "a"}}
+        ]),
+        _tool_results([
+            {"id": "c1", "name": "read_skill", "content": body_1}
+        ]),
+        _assistant(text="got one"),
+        _user("ok"),
+        _assistant(text="", tool_calls=[
+            {"id": "c2", "name": "read_skill", "args": {"name": "b"}}
+        ]),
+        _tool_results([
+            {"id": "c2", "name": "read_skill", "content": body_2}
+        ]),
+        _assistant(text="got two"),
+        _user("more"),
+        _assistant(text="", tool_calls=[
+            {"id": "c3", "name": "read_skill", "args": {"name": "c"}}
+        ]),
+        _tool_results([
+            {"id": "c3", "name": "read_skill", "content": body_3}
+        ]),
+        # No assistant-with-output after the third result; it
+        # remains load-bearing.
+    ]
+
+    n = agent._apply_eviction()
+    assert n == 2, f"expected 2 evictions (body_1 and body_2), got {n}"
+    first = agent.conversation[2]["tool_results"][0]["content"]
+    second = agent.conversation[6]["tool_results"][0]["content"]
+    third = agent.conversation[10]["tool_results"][0]["content"]
+    assert "evicted to save context" in first, first
+    assert "evicted to save context" in second, second
+    assert third == body_3, "most recent skill result wrongly evicted"
+    print("✓ multiple skills: all consumed bodies evicted, latest preserved")
+
+
+def main() -> None:
+    _check_default_no_eviction()
+    _check_evict_after_next_assistant_turn()
+    _check_most_recent_preserved()
+    _check_idempotent()
+    _check_resume_jsonl_untouched()
+    _check_multiple_skills_in_sequence()
+    print("\nALL CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Skill bodies loaded via `read_skill` rode every subsequent turn for the rest of a session even though they're single-shot reference content. The model uses one to decide what to do next, the next assistant turn records that decision, after which the body is dead weight. The well-mako session in #10 showed ~6,200 chars (~1,500 tokens) of skill-body bloat persisting 40+ turns past last use.

This implements the issue's Option B — a generalized `evict_after_use=True` opt-in on `Agent.add_tool` that any future single-shot reference tool can adopt without further API churn — and marks `read_skill` as `evict_after_use=True`.

## What's new

- **`Agent.add_tool(..., *, evict_after_use=False)`** — keyword-only flag stored on `self._evict_after_use`. Default `False` so existing tools and registrations are unaffected.
- **`Agent._apply_eviction()`** — walks `self.conversation`, finds tool_result entries belonging to flagged tools, replaces their `content` with `_eviction_stub(name)` if at least one later assistant turn in the log has produced output. The MOST RECENT flagged result (no following assistant turn yet) is preserved — load-bearing. Idempotent: an entry already carrying the stub is skipped.
- **Stub format**: `[skill 'read_skill' loaded earlier; content evicted to save context. Call read_skill('read_skill') again to reload.]` — short, names the tool, tells the agent how to recover.
- **`Agent.run`** calls `_apply_eviction()` right after appending each assistant turn.
- **`agent_proc._register_tools`** now registers `read_skill` with `evict_after_use=True`. After `agent.conversation = session.load_history()`, the same eviction pass runs so a resumed session's in-memory state matches what would have been there had the session run continuously.

## What's preserved

- **`smoke_session_replay` invariants are untouched.** Eviction is in-memory only — `Session.load_history` and `Session.append_history` are not modified, the round-trip invariant still holds, and `conversation.jsonl` on disk still contains full skill-body content. The new smoke explicitly re-asserts this on the resume path: same bytes before and after `_apply_eviction()`.
- **Prompt-cache behavior unchanged.** `pyagent/llms/anthropic.py` only places `cache_control: {type: ephemeral}` on `system` and `tools` blocks. Conversation messages aren't cache-marked, so mutating tool-result content in-conversation does not invalidate any cached prefix.
- **Subagents unaffected.** `_evict_after_use` is per-`Agent` instance; subagents have their own conversation and their own eviction state.

## Test plan

- [x] `tests/smoke_skill_eviction.py` (new): six checks — default flag preserves content; flagged result is stubbed after a consuming assistant turn; the most-recent flagged result is preserved; walk is idempotent (second run reports zero new evictions); resume path stubs in memory while JSONL on disk stays byte-identical (`load_history` round-trips); multiple skills loaded in sequence each evict at the right turn while the latest one is preserved.
- [x] Full smoke suite passes locally. `smoke_session_replay` (the canary), `smoke_subagent`, `smoke_subagent_routing`, `smoke_token_meter`, `smoke_arg_scrubbing`, and the rest are green. The pre-existing `smoke_roles` failure on `main` is unrelated and unchanged. `smoke_ctrlc` skips for environmental reasons (`.venv/bin/pyagent` not installed in this checkout).

Closes #10.