### PR TITLE
Bench-followups: record model in usage, coerce read_file ints, scale default budget by model

### DIFF
--- a/pyagent/bench_cli.py
+++ b/pyagent/bench_cli.py
@@ -142,17 +142,25 @@ class _BenchState:
     halt: bool = False  # set when budget exceeded; finish current turn then stop
 
 
-def _maybe_warn_opus(model: str, budget: float, no_budget: bool) -> None:
-    if no_budget:
-        return
-    name = pricing.model_name(model)
-    if name == "claude-opus-4-7" and abs(budget - 0.50) < 1e-9:
-        click.echo(
-            "[bench] note: well_mako is sized for Sonnet; Opus runs "
-            "typically halt mid-scenario at the $0.50 default. "
-            "Pass --budget 3.00 for a full run.",
-            err=True,
-        )
+# Default per-run budget by model. Sized so a typical scenario can
+# complete without halting at the budget cap, sized DOWN for cheap
+# models so a runaway Haiku run doesn't quietly cost more than the
+# user expected. Override at the CLI with --budget X (or --no-budget).
+_DEFAULT_BUDGET_BY_BARE_MODEL: dict[str, float] = {
+    "claude-haiku-4-5-20251001": 0.20,
+    "claude-sonnet-4-6": 0.50,
+    "claude-opus-4-7": 3.00,
+    "gpt-4o": 0.50,
+    "gpt-4o-mini": 0.10,
+    "gemini-2.5-flash": 0.10,
+}
+_BUDGET_FALLBACK_USD = 0.50
+
+
+def _default_budget_for(model: str) -> float:
+    """Pick a reasonable per-run budget for the resolved model."""
+    bare = pricing.model_name(model)
+    return _DEFAULT_BUDGET_BY_BARE_MODEL.get(bare, _BUDGET_FALLBACK_USD)
 
 
 def _build_agent_config(model: str, session_id: str) -> dict[str, Any]:
@@ -339,9 +347,12 @@ def list_cmd() -> None:
 @click.option(
     "--budget",
     type=float,
-    default=0.50,
-    show_default=True,
-    help="Halt after the first turn whose cumulative cost crosses this USD cap.",
+    default=None,
+    help=(
+        "Halt after the first turn whose cumulative cost crosses this "
+        "USD cap. Default scales by model: $0.20 Haiku, $0.50 Sonnet, "
+        "$3.00 Opus, $0.50 fallback."
+    ),
 )
 @click.option(
     "--no-budget",
@@ -357,19 +368,20 @@ def list_cmd() -> None:
 def run_cmd(
     scenario: str,
     model: str | None,
-    budget: float,
+    budget: float | None,
     no_budget: bool,
     out: Path | None,
 ) -> None:
     """Run a scenario and print a token / cost / tool report.
 
     Spawns a real agent subprocess against a real LLM. Costs real
-    money. The default $0.50 budget halts a runaway scenario before
-    it gets out of hand.
+    money. A per-model default budget halts a runaway scenario before
+    it gets out of hand; override with `--budget X` or `--no-budget`.
     """
     sc = _load_scenario(scenario)
     resolved_model = _resolve_bench_model(model)
-    _maybe_warn_opus(resolved_model, budget, no_budget)
+    if budget is None:
+        budget = _default_budget_for(resolved_model)
     cap = None if no_budget else budget
 
     # Mint the session up front so we can print + report the id even

--- a/pyagent/llms/anthropic.py
+++ b/pyagent/llms/anthropic.py
@@ -22,6 +22,10 @@ class AnthropicClient:
         cache: bool = True,
     ) -> None:
         self.model = model
+        # Full provider/model identifier persisted in each turn's usage
+        # dict so the audit can price per-turn correctly without the
+        # caller having to remember which model the session used.
+        self.provider_model = f"anthropic/{model}"
         self.max_tokens = max_tokens
         self.cache = cache
         api_key = api_key or os.environ.get("ANTHROPIC_API_KEY")
@@ -114,6 +118,7 @@ class AnthropicClient:
                 "output": getattr(usage, "output_tokens", 0) or 0,
                 "cache_creation": getattr(usage, "cache_creation_input_tokens", 0) or 0,
                 "cache_read": getattr(usage, "cache_read_input_tokens", 0) or 0,
+                "model": self.provider_model,
             },
         }
 

--- a/pyagent/llms/gemini.py
+++ b/pyagent/llms/gemini.py
@@ -39,6 +39,7 @@ class GeminiClient:
         api_key: str | None = None,
     ) -> None:
         self.model = model
+        self.provider_model = f"gemini/{model}"
         key = api_key or os.environ.get("GEMINI_API_KEY") or os.environ.get(
             "GOOGLE_API_KEY"
         )
@@ -113,6 +114,7 @@ class GeminiClient:
                 "output": getattr(usage_meta, "candidates_token_count", 0) or 0,
                 "cache_creation": 0,
                 "cache_read": getattr(usage_meta, "cached_content_token_count", 0) or 0,
+                "model": self.provider_model,
             },
         }
 

--- a/pyagent/llms/openai.py
+++ b/pyagent/llms/openai.py
@@ -27,6 +27,7 @@ class OpenAIClient:
         api_key: str | None = None,
     ) -> None:
         self.model = model
+        self.provider_model = f"openai/{model}"
         self.max_tokens = max_tokens
         self._client = OpenAI(api_key=api_key or os.environ.get("OPENAI_API_KEY"))
 
@@ -100,6 +101,7 @@ class OpenAIClient:
                 "output": getattr(usage, "completion_tokens", 0) or 0,
                 "cache_creation": 0,
                 "cache_read": cache_read,
+                "model": self.provider_model,
             },
         }
 

--- a/pyagent/llms/pyagent.py
+++ b/pyagent/llms/pyagent.py
@@ -27,6 +27,7 @@ class EchoClient:
 
     def __init__(self, model: str = "echo") -> None:
         self.model = model
+        self.provider_model = f"pyagent/{model}"
 
     def respond(
         self,
@@ -46,7 +47,13 @@ class EchoClient:
         return {
             "text": text,
             "tool_calls": [],
-            "usage": {"input": 0, "output": 0, "cache_creation": 0, "cache_read": 0},
+            "usage": {
+                "input": 0,
+                "output": 0,
+                "cache_creation": 0,
+                "cache_read": 0,
+                "model": self.provider_model,
+            },
         }
 
 
@@ -85,6 +92,7 @@ class LoremClient:
 
     def __init__(self, model: str = "loremipsum") -> None:
         self.model = model
+        self.provider_model = f"pyagent/{model}"
 
     def respond(
         self,
@@ -102,5 +110,11 @@ class LoremClient:
         return {
             "text": "\n\n".join(paragraphs),
             "tool_calls": [],
-            "usage": {"input": 0, "output": 0, "cache_creation": 0, "cache_read": 0},
+            "usage": {
+                "input": 0,
+                "output": 0,
+                "cache_creation": 0,
+                "cache_read": 0,
+                "model": self.provider_model,
+            },
         }

--- a/pyagent/sessions_audit.py
+++ b/pyagent/sessions_audit.py
@@ -155,6 +155,15 @@ def audit_session(
     last_assistant_idx = 0
     pre_15_turns = 0
     totals = {"input": 0, "output": 0, "cache_creation": 0, "cache_read": 0}
+    # Per-turn cost runs through the turn's RECORDED model (added to
+    # usage by the LLM clients in the bench-followups PR), falling back
+    # to the function arg for older sessions. Aggregating per-turn
+    # costs (vs. multiplying summed tokens by one model's rates) is the
+    # only way to stay correct across a session that spanned multiple
+    # models — e.g. the user switched via /model partway through.
+    per_turn_costs_sum = 0.0
+    any_cost_priced = False
+    recorded_models: list[str] = []
 
     for entry in entries:
         if not isinstance(entry, dict):
@@ -173,14 +182,21 @@ def audit_session(
             output_t = int(usage.get("output", 0) or 0)
             cache_w = int(usage.get("cache_creation", 0) or 0)
             cache_r = int(usage.get("cache_read", 0) or 0)
+            recorded = usage.get("model")
+            turn_model = recorded or model
+            if recorded:
+                recorded_models.append(recorded)
             totals["input"] += input_t
             totals["output"] += output_t
             totals["cache_creation"] += cache_w
             totals["cache_read"] += cache_r
             last_assistant_idx += 1
             cost = pricing.estimate_cost_usd(
-                model, input_t, output_t, cache_w, cache_r
+                turn_model, input_t, output_t, cache_w, cache_r
             )
+            if cost is not None:
+                per_turn_costs_sum += cost
+                any_cost_priced = True
             per_turn.append(
                 TurnRow(
                     turn_idx=last_assistant_idx,
@@ -250,17 +266,29 @@ def audit_session(
             if ref_count == 0:
                 orphans.append(f.name)
 
-    total_cost_usd = pricing.estimate_cost_usd(
-        model,
-        totals["input"],
-        totals["output"],
-        totals["cache_creation"],
-        totals["cache_read"],
-    )
+    # Aggregate cost = sum of per-turn costs (correct across mixed
+    # models). Falls back to summing-then-pricing only when no turn
+    # had a priceable model.
+    if any_cost_priced:
+        total_cost_usd: float | None = per_turn_costs_sum
+    else:
+        total_cost_usd = pricing.estimate_cost_usd(
+            model,
+            totals["input"],
+            totals["output"],
+            totals["cache_creation"],
+            totals["cache_read"],
+        )
+
+    # Header model: prefer the most recent turn's recorded model (the
+    # session's "current" identity) so a session whose only
+    # caller-supplied model was a fallback still surfaces what actually
+    # ran. Drop back to the function arg if no turn recorded one.
+    header_model = recorded_models[-1] if recorded_models else model
 
     return AuditReport(
         session_id=session_id,
-        model=model,
+        model=header_model,
         turn_count=last_assistant_idx,
         total_tokens=totals,
         total_cost_usd=total_cost_usd,

--- a/pyagent/tools.py
+++ b/pyagent/tools.py
@@ -77,6 +77,20 @@ def read_file(
         failures (missing path, permission denied, etc.) come back as a
         leading `<...>` marker string.
     """
+    # Models occasionally emit numeric tool args as strings ("50" instead
+    # of 50) even when the JSON schema declares int. Coerce defensively
+    # so the tool returns an actionable error instead of crashing the
+    # turn — surfaced live during the pyagent_self_audit bench run.
+    try:
+        start = int(start)
+    except (TypeError, ValueError):
+        return f"<error: start must be an integer, got {start!r}>"
+    if end is not None:
+        try:
+            end = int(end)
+        except (TypeError, ValueError):
+            return f"<error: end must be an integer or null, got {end!r}>"
+
     p = Path(path)
     if not permissions.require_access(p):
         return _denied(path)

--- a/tests/smoke_bench_defaults.py
+++ b/tests/smoke_bench_defaults.py
@@ -1,0 +1,59 @@
+"""Smoke for `pyagent-bench`'s default-budget-by-model table.
+
+Locks the per-model defaults so a future model rename / pricing-table
+update doesn't silently make Opus runs halt at the Sonnet budget (or
+vice versa). Doesn't run the bench — just checks the resolver.
+
+Run with:
+    .venv/bin/python -m tests.smoke_bench_defaults
+"""
+
+from __future__ import annotations
+
+from pyagent.bench_cli import _BUDGET_FALLBACK_USD, _default_budget_for
+
+
+def _check_anthropic_tiers() -> None:
+    # Opus is the expensive model; default budget is sized so a typical
+    # research scenario completes without halting.
+    assert _default_budget_for("anthropic/claude-opus-4-7") == 3.00
+    # Sonnet is the middle tier; matches the historical bench default.
+    assert _default_budget_for("anthropic/claude-sonnet-4-6") == 0.50
+    # Haiku is cheap; smaller cap so a runaway Haiku run can't quietly
+    # cost more than the user expected.
+    assert (
+        _default_budget_for("anthropic/claude-haiku-4-5-20251001") == 0.20
+    )
+    print(
+        "✓ Anthropic per-tier budgets: Opus $3.00 / Sonnet $0.50 / Haiku $0.20"
+    )
+
+
+def _check_other_providers() -> None:
+    # OpenAI gpt-4o is in the table at $0.50; gpt-4o-mini at $0.10.
+    assert _default_budget_for("openai/gpt-4o") == 0.50
+    assert _default_budget_for("openai/gpt-4o-mini") == 0.10
+    # Gemini in the table.
+    assert _default_budget_for("gemini/gemini-2.5-flash") == 0.10
+    print(
+        f"✓ Non-Anthropic budgets: gpt-4o $0.50 / gpt-4o-mini $0.10 / "
+        f"gemini-flash $0.10"
+    )
+
+
+def _check_unknown_model_falls_back() -> None:
+    # Unknown model → fallback. Don't crash on a future model name.
+    assert _default_budget_for("unknown/some-future-model") == _BUDGET_FALLBACK_USD
+    assert _default_budget_for("") == _BUDGET_FALLBACK_USD
+    print(f"✓ unknown model falls back to ${_BUDGET_FALLBACK_USD:.2f}")
+
+
+def main() -> None:
+    _check_anthropic_tiers()
+    _check_other_providers()
+    _check_unknown_model_falls_back()
+    print("\nALL CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/smoke_read_file_ceiling.py
+++ b/tests/smoke_read_file_ceiling.py
@@ -99,11 +99,35 @@ def _check_hard_ceiling_still_fires() -> None:
     print("✓ hard ceiling still offloads oversize read_skill output")
 
 
+def _check_read_file_coerces_string_args() -> None:
+    """Models occasionally emit numeric tool args as strings even when
+    the JSON schema declares int. read_file must coerce to int (or
+    return an actionable error string) instead of crashing the turn —
+    surfaced live during the pyagent_self_audit bench run."""
+    from pyagent import permissions, tools
+
+    with tempfile.TemporaryDirectory(prefix="pyagent-smoke-coerce-") as t:
+        permissions.set_workspace(t)
+        target = Path(t) / "lines.txt"
+        target.write_text("a\nb\nc\nd\ne\n")
+        # String start coerces to int.
+        result = tools.read_file(str(target), start="2", end="4")
+        assert result == "b\nc\nd\n", repr(result)
+        # Non-int-coercible start returns an error marker, not a crash.
+        result = tools.read_file(str(target), start="oops")
+        assert result.startswith("<error: start must be an integer"), result
+        # Same for end.
+        result = tools.read_file(str(target), start=1, end="not-a-number")
+        assert result.startswith("<error: end must be an integer"), result
+    print("✓ read_file coerces string ints; rejects non-coercible cleanly")
+
+
 def main() -> None:
     _check_small_read_file_inline()
     _check_large_read_file_offloads()
     _check_read_skill_unaffected()
     _check_hard_ceiling_still_fires()
+    _check_read_file_coerces_string_args()
     print("\nALL CHECKS PASSED")
 
 

--- a/tests/smoke_session_audit.py
+++ b/tests/smoke_session_audit.py
@@ -302,6 +302,87 @@ def _check_lower_bound_warning_is_specific() -> None:
         print("✓ lower-bound warning names X of Y assistant turns")
 
 
+def _check_per_turn_model_pricing() -> None:
+    """When per-turn `usage["model"]` is recorded, the audit prices each
+    turn against THAT model and aggregates per-turn costs (so a session
+    that spanned two models prices correctly), and the report header
+    reflects the most recent recorded model — not the caller's
+    fallback."""
+    with tempfile.TemporaryDirectory() as td:
+        session_dir = Path(td) / "mixed-model-session"
+        (session_dir / "attachments").mkdir(parents=True)
+        # Two assistant turns with different models recorded inline.
+        # Sonnet input rate is $3/MT; Haiku is $1/MT. Same token counts,
+        # different costs — the audit should bill each turn correctly.
+        entries = [
+            {"role": "user", "content": "first"},
+            {
+                "role": "assistant",
+                "text": "ok",
+                "tool_calls": [],
+                "usage": {
+                    "input": 1000,
+                    "output": 0,
+                    "cache_creation": 0,
+                    "cache_read": 0,
+                    "model": "anthropic/claude-sonnet-4-6",
+                },
+            },
+            {"role": "user", "content": "second"},
+            {
+                "role": "assistant",
+                "text": "ok",
+                "tool_calls": [],
+                "usage": {
+                    "input": 1000,
+                    "output": 0,
+                    "cache_creation": 0,
+                    "cache_read": 0,
+                    "model": "anthropic/claude-haiku-4-5-20251001",
+                },
+            },
+        ]
+        with (session_dir / "conversation.jsonl").open("w") as f:
+            for e in entries:
+                f.write(json.dumps(e) + "\n")
+        # Pass a wrong fallback model — recorded models must take
+        # precedence over the function arg.
+        report = audit_session(session_dir, model="openai/gpt-4o")
+
+        # Sonnet 1000 input @ $3/MT = $0.003; Haiku 1000 @ $1/MT = $0.001.
+        # Total = $0.004. NOT what gpt-4o (the fallback, $2.5/MT) would
+        # produce on summed 2000 tokens ($0.005), and NOT what either
+        # Anthropic model alone would produce on the sum.
+        assert report.total_cost_usd is not None
+        assert abs(report.total_cost_usd - 0.004) < 1e-9, report.total_cost_usd
+        # Per-turn rows reflect per-turn pricing.
+        assert abs(report.per_turn[0].cost_usd - 0.003) < 1e-9
+        assert abs(report.per_turn[1].cost_usd - 0.001) < 1e-9
+        # Header model = most recent recorded, not the function arg.
+        assert (
+            report.model == "anthropic/claude-haiku-4-5-20251001"
+        ), report.model
+    print(
+        "✓ per-turn model pricing: $0.004 across mixed Sonnet+Haiku turns"
+    )
+
+
+def _check_audit_falls_back_when_no_model_recorded() -> None:
+    """Old sessions (pre-bench-followups) lack `usage["model"]`; audit
+    falls back to the caller-supplied model and the header reflects it."""
+    with tempfile.TemporaryDirectory() as td:
+        session_dir = _write_synthetic_session(Path(td))
+        # Synthetic session predates the model field — none of its
+        # turns set `usage["model"]`.
+        report = audit_session(
+            session_dir, model="anthropic/claude-sonnet-4-6"
+        )
+        assert report.model == "anthropic/claude-sonnet-4-6", report.model
+        assert report.total_cost_usd is not None
+        assert report.total_cost_usd > 0
+    print("✓ audit falls back to caller's --model when no turn recorded one")
+
+
 def _check_path_traversal_refused() -> None:
     """`sessions_cli._resolve_session_dir` must refuse a session_id whose
     resolved path escapes the sessions root, so a typo or hostile input
@@ -345,6 +426,8 @@ def main() -> None:
     _check_section_filtering()
     _check_displayed_total_gates_to_anthropic()
     _check_lower_bound_warning_is_specific()
+    _check_per_turn_model_pricing()
+    _check_audit_falls_back_when_no_model_recorded()
     _check_path_traversal_refused()
     print("\nALL CHECKS PASSED")
 


### PR DESCRIPTION
## Summary

Three small fixes surfaced by the `pyagent_self_audit` bench run we just did. All three are independent of PR #20 (which adds the scenario itself + tmpdir workspace).

### 1. Record model in `conversation.jsonl`

Each LLM client now stores `provider_model` at construction (e.g. `"anthropic/claude-sonnet-4-6"`) and includes it in every turn's `usage` dict. The sessions audit:

- Prices each turn against its recorded model (correct across mid-session model switches via `/model`).
- Aggregates per-turn costs to a total — replaces the old "apply one model's rates to summed tokens" approach, which was wrong if the session spanned models.
- Sets the report header model from the most recent recorded model, falling back to the caller-supplied `--model` for old sessions.

This is what surfaced when running the bench against Opus and then auditing the resulting session — the audit defaulted to Sonnet pricing because the model wasn't in the JSONL, producing visibly-wrong numbers.

### 2. `read_file` coerces string args to int

The Sonnet run on `pyagent_self_audit` crashed mid-flight when the model emitted `start="50"` (string) for an int-typed parameter; `max(start, 1)` blew up with `TypeError: '>' not supported between instances of 'int' and 'str'`. The agent recovered (called again with int), but a clean tool error is the right behavior — fail gracefully with `<error: start must be an integer, got '50'>` instead of an exception that costs a tool slot. Same defensive coercion applied to `end`.

A generalized type-coercing dispatch (covering every int-arg tool) is worth doing eventually, but is its own design concern — defer to follow-up.

### 3. Default bench budget scales by model

Both Sonnet runs we did halted at the $0.50 default; Opus would halt at well under scenario coverage at the same number. New `_DEFAULT_BUDGET_BY_BARE_MODEL` table: Haiku $0.20, Sonnet $0.50, gpt-4o $0.50, Opus $3.00. Click `--budget` default flipped to a `None` sentinel; resolved after model resolution. The previous well_mako-Opus warning is gone — auto-scaling makes it redundant.

## Behavior changes

- `usage` dicts in `conversation.jsonl` gain a `model` field. Backward compatible — old sessions without the field fall back to the caller-supplied `--model`.
- `pyagent-bench run` picks $3.00 on Opus, $0.50 on Sonnet, $0.20 on Haiku without `--budget`.
- `read_file` rejects non-int-coercible `start`/`end` with `<error: ...>` instead of crashing.

## Test plan

- [x] All 23 existing smokes pass.
- [x] New `smoke_bench_defaults` locks the budget table.
- [x] New `_check_per_turn_model_pricing` synthesizes a mixed Sonnet+Haiku session, asserts aggregate cost = sum of per-turn costs.
- [x] New `_check_audit_falls_back_when_no_model_recorded` locks backward-compat.
- [x] New `_check_read_file_coerces_string_args` covers happy-path + rejection.

## Out of scope

- Generalized type-coercing dispatch for all tool args.
- `pyagent-bench compare a.json b.json`.
- Per-turn wall-clock timeout in `_drive`.
- Cumulative-cost-near-budget warning in the live status footer.