### PR TITLE
code-mapper: bundled plugin for tree-sitter symbol outlines

### DIFF
--- a/pyagent/config.py
+++ b/pyagent/config.py
@@ -51,7 +51,7 @@ LOCAL_CONFIG_DIR = Path(".pyagent")
 DEFAULTS: dict[str, Any] = {
     "default_model": "",
     "built_in_skills_enabled": ["write-skill", "write-plugin"],
-    "built_in_plugins_enabled": ["memory-markdown", "html-tools"],
+    "built_in_plugins_enabled": ["memory-markdown", "html-tools", "code-mapper"],
     "subagents": {
         "max_depth": 3,
         "max_fanout": 5,

--- a/pyagent/plugins/code_mapper/EXTENDING.md
+++ b/pyagent/plugins/code_mapper/EXTENDING.md
@@ -1,0 +1,174 @@
+# Adding a language to code-mapper
+
+Two files in `queries/` per language. No edit to `mapper.py`. Plugin
+picks up new languages on next agent restart.
+
+```
+queries/
+    <lang>.toml      # capture-name → kind mapping, def node types, etc.
+    <lang>.scm       # tree-sitter query that produces the captures
+```
+
+`<lang>` MUST match a tree-sitter-language-pack id (`get_language(<lang>)`
+must return a Language). See https://pypi.org/project/tree-sitter-language-pack/
+for the list of available languages.
+
+## The TOML schema
+
+```toml
+# Scalars FIRST. Anything after a [table] header belongs to that table
+# until the next header — TOML rule, easy to miss.
+
+language = "<id>"                    # tree-sitter-language-pack id
+description = "..."
+extensions = [".ext1", ".ext2"]      # case-insensitive, leading dot
+
+# Node types whose presence in an ancestor walk implies "the symbol
+# is inside a definition" — used for parent attribution. Empty list
+# means rely entirely on @parent captures from the .scm.
+definition_node_types = ["class_definition", "function_definition"]
+
+# Plugin-internal: which docstring extractor to use. Currently only
+# "python" is implemented in mapper.py:_docstring_for. Omit (or set
+# to a string this code doesn't recognize) to disable.
+docstrings = "python"
+
+# Tree-sitter capture name → normalized symbol kind. Anything not
+# listed here is dropped. Multiple capture names may map to the same
+# kind. The `@name` and `@parent` captures are special and must NOT
+# appear here — they're consumed by the loader directly.
+[captures]
+"definition.class" = "class"
+"definition.function" = "function"
+"reference.call" = "call"
+
+# Kind promotion rules. If an emitted symbol has kind=`from` and its
+# enclosing definition node type is one of `when_inside`, the kind is
+# upgraded to `to`. First matching rule wins.
+[[promote]]
+from = "function"
+to = "method"
+when_inside = ["class_definition"]
+```
+
+## The .scm convention
+
+The plugin uses `QueryCursor.matches()` (per-pattern), so every match
+is processed in isolation. For each match, the loader looks for:
+
+* `@name` — the identifier to use as the symbol's name. **Required.**
+  Multiple `@name` captures in one match emit multiple symbols.
+* `@definition.<kind>` *or* `@reference.<kind>` — the enclosing
+  definition node. **Required.** Exactly one per pattern. The
+  `<kind>` part has no meaning to the loader — it's the string you'll
+  map in `[captures]`.
+* `@parent` — *optional* explicit override of the enclosing-definition
+  name. Use this when the AST walk would attribute to the wrong scope
+  (e.g. C++ `void Foo::bar() {}` — the AST puts `bar` inside a
+  namespace, but `@parent` lets you record `Foo`).
+
+Predicates `(#match? @x "regex")` and `(#eq? @x "literal")` are
+supported by tree-sitter's query engine and are useful for matching
+sets of tag names (e.g. `^[hH][1-6]$` for HTML headings).
+
+## Workflow for adding a language
+
+1. **Find the upstream tags.scm.** Most tree-sitter grammars at
+   `github.com/tree-sitter/tree-sitter-<lang>` ship `queries/tags.scm`.
+   Pin the commit hash you read.
+
+2. **Vendor it as `queries/<lang>.scm`.** Add a header comment naming
+   the source repo + commit. Edit aggressively: upstream's tags.scm
+   is written for the GitHub code-nav tags spec, which collapses
+   distinct kinds (e.g. struct/enum/union all under
+   `@definition.class`). For our purposes finer kinds are better —
+   replace collapsed capture names with kind-specific ones. Mark
+   deviations inline with a `; DEVIATION:` comment so future refreshes
+   know what was patched.
+
+3. **Probe the actual grammar before trusting the query.** The
+   language-pack ships compiled grammars whose node types may have
+   drifted from upstream's tags.scm. The plugin exposes a
+   `probe_grammar` tool for exactly this — it prints the parse tree
+   with field names visible (`left:`, `name:`, `body:`, etc.) so you
+   write queries that reference what the grammar actually produces:
+
+   ```
+   probe_grammar(language="rust", source="impl Foo { fn bar() {} }")
+   →
+   source_file
+     impl_item
+       type: type_identifier  'Foo'
+       body: declaration_list
+         function_item
+           name: identifier  'bar'
+           parameters: parameters
+           body: block
+   ```
+
+   When upstream's pattern matches nothing, the cause is almost always
+   that the grammar wraps the matched node differently than the .scm
+   expects. Probe a representative snippet, see the real shape, patch
+   the .scm. The tool works for any language the language-pack ships,
+   not just languages already configured here.
+
+4. **Write `<lang>.toml`** mapping each capture name to a normalized
+   kind. Decide on `definition_node_types` (the AST node types you
+   want parent-walk to stop at) and any `[[promote]]` rules.
+
+5. **Add a fixture + assertions** to `tests/smoke_code_mapper.py`.
+   Use the `has(kind, name, parent)` helper pattern from existing
+   languages — assertion shape is uniform.
+
+6. **Run `python -m tests.smoke_code_mapper`** and iterate.
+
+## Common gotchas
+
+* **Capture-pattern drift.** Upstream tags.scm sometimes references
+  node types or field names that don't exist in the grammar version
+  the language pack ships. Symptom: the pattern simply doesn't match.
+  Fix: probe the grammar (step 3 above), patch the pattern, document
+  the deviation in the .scm header.
+
+* **Two patterns capturing the same node.** `<main id="...">` matches
+  both an "element with id" and a "semantic landmark" pattern. The
+  per-match logic (`QueryCursor.matches()`) keeps these separate, but
+  if you ever switch back to `captures()` the `@name` from one pattern
+  will pair with the `@definition.X` of another. Stay on `matches()`.
+
+* **The captured node isn't the scope-defining node.** In C/C++ the
+  function name is captured inside `function_declarator`, not
+  `function_definition`. Walking up from `function_declarator` hits
+  `function_definition` first — but `function_definition` has no
+  `name:` field and isn't a useful "scope" anyway. **Don't include
+  `function_definition` in `definition_node_types`** for C/C++; let
+  the walk continue to the actual surrounding class/namespace.
+
+* **`@parent` is per-match, not per-node.** When the same AST element
+  is captured by two different patterns, only the match that explicitly
+  captured `@parent` carries the override. The other match still gets
+  AST-walk-based parent attribution. This is intentional — see the
+  HTML `<main id="…">` case where the `element_id` symbol gets
+  parent="main" but the `section` symbol does not.
+
+* **Trait impls in Rust attribute methods to the trait.** `impl Greet
+  for Point { fn hello(&self) {} }` produces `method hello (in Greet)`,
+  not `(in Point)`. Upstream tags.scm captures the trait name as the
+  impl's @name. Fixing this would require capturing `type:` separately
+  and choosing between trait and type at attribution time — out of
+  scope for v1. Documented quirk, not a bug.
+
+* **TOML scalar vs table ordering.** Once you write `[captures]` or
+  `[[promote]]`, every subsequent scalar belongs to that table. Put
+  `language`, `description`, `extensions`, `definition_node_types`,
+  `docstrings` BEFORE any header.
+
+## Refreshing a vendored .scm
+
+Upstream tags.scm files barely change — manual refresh is fine. When
+you do refresh:
+
+1. Read the diff between the old commit and HEAD before pasting.
+2. Re-run any `; DEVIATION:` patches against the new file.
+3. Update the commit hash in the file's header.
+4. Run the smoke test.

--- a/pyagent/plugins/code_mapper/__init__.py
+++ b/pyagent/plugins/code_mapper/__init__.py
@@ -1,0 +1,144 @@
+"""code-mapper — bundled plugin that exposes a `map_code` tool.
+
+`map_code` runs a tree-sitter parse + tags-style query against a source
+file and returns a structured outline (functions, classes, methods,
+imports, …). The agent uses this to locate definitions before
+read_file'ing precise line ranges, instead of slurping whole files.
+
+v1: Python only. The dispatch table in `mapper.py` is multi-language
+ready — adding Rust / C / C++ / HTML is a vendor-the-`.scm` plus a
+table entry, not a rewrite.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pyagent import permissions
+from pyagent.plugins.code_mapper import mapper
+
+
+def _read_source(path: str) -> tuple[bool, bytes | str]:
+    """Read a source file as bytes for tree-sitter.
+
+    Returns (ok, payload). On error, ok=False and payload is a
+    leading-`<>`-marker error string the tool returns directly. On
+    success, payload is the file's bytes (tree-sitter parses bytes,
+    not str — many real C/C++ trees aren't UTF-8 clean).
+    """
+    if not permissions.require_access(path):
+        return (False, f"<permission denied (outside workspace): {path}>")
+    p = Path(path)
+    try:
+        return (True, p.read_bytes())
+    except FileNotFoundError:
+        return (False, f"<file not found: {path}>")
+    except IsADirectoryError:
+        return (False, f"<is a directory, not a file: {path}>")
+    except PermissionError:
+        return (False, f"<permission denied: {path}>")
+
+
+def register(api):
+    def map_code(
+        path: str,
+        kind: str = "all",
+        include_docstrings: bool = False,
+    ) -> str:
+        """Return a structured outline of a source file's symbols.
+
+        Reach for this before read_file'ing a file you don't already
+        know — it gives you the function/class/import locations as a
+        compact list (each with a 1-indexed line number you can pass
+        straight to `read_file(path, start=<line>)`). Far cheaper in
+        tokens than reading the whole file just to find a definition.
+
+        The outline is built by tree-sitter (a real parser, not regex),
+        so syntax errors don't break the call — partial files still
+        produce whatever symbols parsed cleanly, with an `errors`
+        array flagging the broken regions.
+
+        Args:
+            path: Path to the source file. Must be inside the workspace.
+                Currently supported extensions: .py.
+            kind: Which symbol categories to include. One of:
+                "all" (default — class/function/method/constant/import),
+                "imports", "functions" (functions + methods),
+                "classes", "constants", "calls" (call sites — noisy,
+                use only when chasing a specific reference).
+            include_docstrings: If True, attach the leading docstring
+                of each function/class as a `docstring` field.
+                Defaults False to keep responses small.
+
+        Returns:
+            JSON string with shape:
+            `{file, language, symbols: [{kind, name, line, parent}], errors}`.
+            `parent` is the enclosing class name when kind=="method",
+            otherwise null. Unsupported file extension returns
+            `{file, error: "unsupported language: …"}`.
+        """
+        ok, payload = _read_source(path)
+        if not ok:
+            return payload  # type: ignore[return-value]
+        return mapper.map_code_for_path(
+            path,
+            payload,  # type: ignore[arg-type]
+            kind=kind,
+            include_docstrings=include_docstrings,
+        )
+
+    def probe_grammar(
+        language: str,
+        source: str,
+        max_depth: int = 12,
+        max_nodes: int = 200,
+        include_anonymous: bool = False,
+    ) -> str:
+        """Print the tree-sitter parse tree for a source snippet.
+
+        Use this when authoring or debugging a code-mapper language
+        config (`pyagent/plugins/code_mapper/queries/<lang>.{scm,toml}`).
+        Tree-sitter queries reference grammar node types and field
+        names by exact string — if your `.scm` says
+        `(class_definition name: (identifier) @name)` but the grammar
+        actually emits `class_declaration` with no `name:` field, the
+        query silently matches nothing. Probing the grammar shows you
+        the real shape so you write a correct query the first time.
+        See `pyagent/plugins/code_mapper/EXTENDING.md` for the full
+        workflow.
+
+        Each named node prints as `[field_name: ]node_type[  'text']`,
+        with text shown only for token leaves. Anonymous tokens
+        (`(`, `=`, `;`) are hidden unless include_anonymous=True.
+
+        Args:
+            language: A tree-sitter-language-pack id ("python",
+                "rust", "go", "javascript", etc.). The full list is at
+                https://pypi.org/project/tree-sitter-language-pack/.
+                Works for languages NOT yet configured here — that's
+                the point, you call this before authoring the config.
+            source: Source snippet to parse. Keep it small (one or two
+                constructs you're trying to query); the output grows
+                quickly with file size.
+            max_depth: Cap on tree depth. Defaults to 12.
+            max_nodes: Cap on emitted lines. Defaults to 200. The
+                probe shouldn't need more than a few dozen lines for
+                a representative snippet.
+            include_anonymous: If True, also show anonymous tokens
+                (`(`, `=`, `;`). Default False — these are noise for
+                writing queries.
+
+        Returns:
+            The indented AST as plain text. Errors (unknown language)
+            return a single-line `<...>` marker.
+        """
+        return mapper.probe_grammar(
+            language,
+            source,
+            max_depth=max_depth,
+            max_nodes=max_nodes,
+            include_anonymous=include_anonymous,
+        )
+
+    api.register_tool("map_code", map_code)
+    api.register_tool("probe_grammar", probe_grammar)

--- a/pyagent/plugins/code_mapper/manifest.toml
+++ b/pyagent/plugins/code_mapper/manifest.toml
@@ -1,0 +1,15 @@
+name = "code-mapper"
+version = "0.1.0"
+description = "Symbol map for source files (functions, classes, imports, …) via tree-sitter."
+api_version = "1"
+
+# Single tool. Runs tree-sitter against a source file and returns a
+# structured outline so the agent can locate definitions without
+# reading the whole file. Python only in v1; the dispatch table inside
+# mapper.py is multi-language ready (Rust/C/C++/HTML coming next).
+[provides]
+tools = ["map_code", "probe_grammar"]
+
+# Stateless, read-only — safe to load in subagents.
+[load]
+in_subagents = true

--- a/pyagent/plugins/code_mapper/mapper.py
+++ b/pyagent/plugins/code_mapper/mapper.py
@@ -1,0 +1,709 @@
+"""Core code-mapping logic for the code-mapper plugin.
+
+Public surface is `map_code(path, kind, include_docstrings)` — see the
+docstring on the `__init__.py` wrapper for the LLM-facing contract.
+This module focuses on the parse-and-extract work and is unit-testable
+without going through the plugin loader.
+
+Design notes:
+
+  * Per-language config lives in `queries/<lang>.toml` next to its
+    `<lang>.scm` query. Adding a language is two files in `queries/`,
+    no edit to this file. See `EXTENDING.md`.
+
+  * Tree-sitter grammars are loaded lazily from
+    `tree_sitter_language_pack` and cached at module level. Same for
+    compiled queries. Re-parsing a file in the same agent process pays
+    only the parse cost, never the grammar/query compile cost.
+
+  * Tree-sitter is non-raising on syntax errors — bad files yield a
+    tree decorated with `ERROR` / `MISSING` nodes. The mapper still
+    extracts whatever symbols parsed cleanly and reports the error
+    locations in the response's `errors` array.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+# Lazy imports of tree_sitter / tree_sitter_language_pack happen inside
+# the public functions so that `import mapper` doesn't hard-fail in
+# environments where the deps aren't installed yet (e.g. during
+# manifest discovery).
+
+logger = logging.getLogger(__name__)
+
+_QUERIES_DIR = Path(__file__).parent / "queries"
+
+
+# -- Per-language registry (loaded from queries/*.toml) ---------------
+
+
+@dataclass
+class _PromoteRule:
+    src: str  # source kind to promote from
+    dst: str  # promoted kind
+    when_inside: tuple[str, ...]  # enclosing tree-sitter node types
+
+
+@dataclass
+class _LangConfig:
+    language: str  # tree-sitter-language-pack id (e.g. "python")
+    description: str
+    extensions: tuple[str, ...]
+    capture_to_kind: dict[str, str]
+    definition_node_types: frozenset[str]
+    promote_rules: tuple[_PromoteRule, ...]
+    docstrings: str | None  # extractor name, or None
+    scm_path: Path
+
+    def kinds_emitted(self) -> set[str]:
+        """All normalized kinds this language can produce, including
+        rule-promoted ones. Used to populate the user-facing `kind`
+        filter union."""
+        out = set(self.capture_to_kind.values())
+        for rule in self.promote_rules:
+            out.add(rule.dst)
+        return out
+
+
+_REGISTRY: dict[str, _LangConfig] = {}
+_EXTENSION_TO_LANG: dict[str, str] = {}
+_REGISTRY_LOADED = False
+
+
+def _load_registry() -> None:
+    """Discover queries/*.toml and build the language registry.
+
+    Idempotent — first call populates module-level dicts. Per-language
+    failures (malformed toml, missing scm, etc.) are logged and the
+    bad language is skipped; other languages still load.
+    """
+    global _REGISTRY_LOADED
+    if _REGISTRY_LOADED:
+        return
+    if not _QUERIES_DIR.exists():
+        _REGISTRY_LOADED = True
+        return
+    for toml_path in sorted(_QUERIES_DIR.glob("*.toml")):
+        try:
+            cfg = _parse_lang_toml(toml_path)
+        except Exception as e:
+            logger.warning(
+                "code-mapper: bad language config %s: %s", toml_path, e
+            )
+            continue
+        if not cfg.scm_path.exists():
+            logger.warning(
+                "code-mapper: %s declared but %s missing",
+                toml_path.name,
+                cfg.scm_path.name,
+            )
+            continue
+        _REGISTRY[cfg.language] = cfg
+        for ext in cfg.extensions:
+            existing = _EXTENSION_TO_LANG.get(ext)
+            if existing and existing != cfg.language:
+                logger.warning(
+                    "code-mapper: extension %s claimed by both %s and %s; "
+                    "first wins",
+                    ext,
+                    existing,
+                    cfg.language,
+                )
+                continue
+            _EXTENSION_TO_LANG[ext] = cfg.language
+    _REGISTRY_LOADED = True
+
+
+def _parse_lang_toml(toml_path: Path) -> _LangConfig:
+    with toml_path.open("rb") as f:
+        data = tomllib.load(f)
+    language = str(data["language"])
+    extensions = tuple(str(e).lower() for e in data["extensions"])
+    captures_raw = data.get("captures", {})
+    capture_to_kind = {str(k): str(v) for k, v in captures_raw.items()}
+    def_types = frozenset(
+        str(t) for t in data.get("definition_node_types", [])
+    )
+    promote_rules: list[_PromoteRule] = []
+    for entry in data.get("promote", []) or []:
+        promote_rules.append(
+            _PromoteRule(
+                src=str(entry["from"]),
+                dst=str(entry["to"]),
+                when_inside=tuple(
+                    str(t) for t in entry.get("when_inside", [])
+                ),
+            )
+        )
+    docstrings = data.get("docstrings")
+    docstrings = str(docstrings) if docstrings else None
+    return _LangConfig(
+        language=language,
+        description=str(data.get("description", "")),
+        extensions=extensions,
+        capture_to_kind=capture_to_kind,
+        definition_node_types=def_types,
+        promote_rules=tuple(promote_rules),
+        docstrings=docstrings,
+        scm_path=toml_path.with_suffix(".scm"),
+    )
+
+
+def _all_emitted_kinds() -> set[str]:
+    _load_registry()
+    out: set[str] = set()
+    for cfg in _REGISTRY.values():
+        out |= cfg.kinds_emitted()
+    return out
+
+
+# Static `kind=` filters that index by category rather than by literal
+# kind name. Anything not in this table is treated as a single-kind
+# literal filter (e.g. kind="struct" matches symbols with kind="struct").
+_NAMED_FILTERS: dict[str, set[str]] = {
+    "imports": {"import"},
+    "functions": {"function", "method"},
+    "classes": {"class", "struct", "enum", "union", "trait", "type"},
+    "constants": {"constant"},
+    "calls": {"call"},
+}
+
+
+def _resolve_kind_filter(kind: str) -> set[str] | None:
+    """Translate a user-facing `kind` argument into the set of
+    normalized kinds that pass.
+
+    `kind="all"`        → every kind any language emits, EXCEPT call.
+    `kind="<named>"`    → the named filter's set (see _NAMED_FILTERS).
+    `kind="<literal>"`  → that literal kind, if any language emits it.
+    Unknown literal     → None (caller emits an error).
+    """
+    if kind == "all":
+        return _all_emitted_kinds() - {"call"}
+    if kind in _NAMED_FILTERS:
+        return _NAMED_FILTERS[kind]
+    emitted = _all_emitted_kinds()
+    if kind in emitted:
+        return {kind}
+    return None
+
+
+# -- Caches -------------------------------------------------------------
+
+_lang_cache: dict[str, object] = {}  # language_id -> Language
+_query_cache: dict[str, object] = {}  # language_id -> Query
+_parser_cache: dict[str, object] = {}  # language_id -> Parser
+
+
+def _get_language(lang_id: str):
+    if lang_id not in _lang_cache:
+        from tree_sitter_language_pack import get_language
+
+        _lang_cache[lang_id] = get_language(lang_id)
+    return _lang_cache[lang_id]
+
+
+def _get_parser(lang_id: str):
+    if lang_id not in _parser_cache:
+        from tree_sitter import Parser
+
+        _parser_cache[lang_id] = Parser(_get_language(lang_id))
+    return _parser_cache[lang_id]
+
+
+def _get_query(lang_id: str):
+    if lang_id not in _query_cache:
+        from tree_sitter import Query
+
+        cfg = _REGISTRY[lang_id]
+        _query_cache[lang_id] = Query(
+            _get_language(lang_id), cfg.scm_path.read_text()
+        )
+    return _query_cache[lang_id]
+
+
+# -- Symbol extraction --------------------------------------------------
+
+
+@dataclass
+class _Symbol:
+    kind: str
+    name: str
+    line: int  # 1-indexed, matches read_file
+    parent: str | None
+    docstring: str | None = None
+
+    def to_dict(self, include_docstrings: bool) -> dict:
+        out = {
+            "kind": self.kind,
+            "name": self.name,
+            "line": self.line,
+            "parent": self.parent,
+        }
+        if include_docstrings and self.docstring is not None:
+            out["docstring"] = self.docstring
+        return out
+
+
+def _enclosing_definition(
+    node, def_node_types: frozenset[str]
+) -> object | None:
+    """Walk node.parent until we hit a node whose type is in
+    `def_node_types`, or None at root. Per-language because each
+    grammar names its definition nodes differently."""
+    cur = node.parent
+    while cur is not None:
+        if cur.type in def_node_types:
+            return cur
+        cur = cur.parent
+    return None
+
+
+def _definition_name(def_node) -> str | None:
+    """Pull the identifier text from the `name:` field of a definition
+    node (class/function/struct/etc.). Returns None if no `name:` field
+    is set — happens for unnamed/anonymous defs and for some grammar
+    quirks; the caller drops `parent` to None in that case."""
+    name_node = def_node.child_by_field_name("name")
+    if name_node is None:
+        return None
+    return name_node.text.decode("utf-8", errors="replace")
+
+
+def _docstring_for(def_node, source_bytes: bytes) -> str | None:
+    """Return the docstring text for a class_definition or
+    function_definition node, or None if absent.
+
+    The current Python grammar (tree-sitter-python via the language
+    pack) puts a docstring as a `string` node directly in the def's
+    `body:` block (no expression_statement wrapper). Older grammar
+    versions wrapped it; we accept both shapes.
+    """
+    body = def_node.child_by_field_name("body")
+    if body is None:
+        return None
+    for child in body.children:
+        if child.type == "comment":
+            continue
+        if child.type == "string":
+            return _strip_string_quotes(
+                child.text.decode("utf-8", errors="replace")
+            )
+        if child.type == "expression_statement":
+            for sub in child.children:
+                if sub.type == "string":
+                    return _strip_string_quotes(
+                        sub.text.decode("utf-8", errors="replace")
+                    )
+            return None
+        # First non-trivia, non-string statement → no docstring.
+        return None
+    return None
+
+
+def _strip_string_quotes(literal: str) -> str:
+    """Best-effort: strip Python triple- or single-quoted string
+    delimiters from the literal source text. Robust enough for
+    docstrings; not a full Python string-literal parser."""
+    s = literal.strip()
+    for prefix_len in (4, 3, 2, 1):  # b"...", r"...", """...""", "..."
+        if (
+            len(s) > 2 * prefix_len
+            and s[prefix_len:].startswith(('"""', "'''"))
+            and s.endswith(s[prefix_len : prefix_len + 3])
+        ):
+            return s[prefix_len + 3 : -3]
+    if s.startswith('"""') and s.endswith('"""'):
+        return s[3:-3]
+    if s.startswith("'''") and s.endswith("'''"):
+        return s[3:-3]
+    if (s.startswith('"') and s.endswith('"')) or (
+        s.startswith("'") and s.endswith("'")
+    ):
+        return s[1:-1]
+    return s
+
+
+@dataclass
+class _Match:
+    """One per-pattern match from the .scm: a name node, its
+    definition node, what kind the .scm tagged it as, and an optional
+    @parent override from the same match."""
+
+    cap_name: str
+    name_node: object
+    def_node: object
+    parent_override: str | None
+
+
+def _process_matches(
+    matches: list[tuple[int, dict]],
+) -> tuple[list[_Match], dict[int, str]]:
+    """Walk QueryCursor.matches() output and produce a flat list of
+    per-symbol matches plus a node→canonical-name index.
+
+    Each match groups together the captures from a single pattern in
+    the .scm — @name, @definition.X, optional @parent — so we pair
+    them within the match rather than across the whole capture dict
+    (cross-pattern bleed would happen when two patterns target the
+    same AST node, e.g. <main id="…"> matching both @definition.section
+    and @definition.element_id).
+
+    Returns (out, def_name_index):
+      - out: list of _Match records, one per emitted symbol.
+      - def_name_index: maps `def_node.id` → captured name text. Used
+        as the canonical name for grammars whose definition nodes lack
+        a `name:` field (Rust impl_item, etc.). Populated from the
+        first @name we see for each def node, so the smallest
+        enclosing match wins; this is read by ancestor-walk parent
+        attribution downstream.
+    """
+    out: list[_Match] = []
+    def_name_index: dict[int, str] = {}
+
+    for _pattern_idx, caps in matches:
+        name_nodes = caps.get("name") or []
+        parent_nodes = caps.get("parent") or []
+
+        def_cap_name: str | None = None
+        def_node = None
+        for k, nodes in caps.items():
+            if k.startswith(("definition.", "reference.")) and nodes:
+                def_cap_name = k
+                def_node = nodes[0]
+                break
+        if def_cap_name is None or def_node is None or not name_nodes:
+            continue
+
+        parent_override: str | None = None
+        if parent_nodes:
+            parent_override = parent_nodes[0].text.decode(
+                "utf-8", errors="replace"
+            )
+
+        for nm in name_nodes:
+            out.append(
+                _Match(
+                    cap_name=def_cap_name,
+                    name_node=nm,
+                    def_node=def_node,
+                    parent_override=parent_override,
+                )
+            )
+            def_name_index.setdefault(
+                def_node.id, nm.text.decode("utf-8", errors="replace")
+            )
+
+    return out, def_name_index
+
+
+def _collect_errors(root_node) -> list[dict]:
+    """Walk the parse tree and report ERROR / MISSING nodes.
+
+    Returns a list of `{line, message}` dicts (1-indexed lines), capped
+    at a small number to keep the response bounded. The point is to
+    *flag* that the file isn't fully parseable, not to be a linter.
+    """
+    out: list[dict] = []
+    MAX = 10
+    stack = [root_node]
+    while stack and len(out) < MAX:
+        node = stack.pop()
+        if node.is_missing:
+            out.append(
+                {
+                    "line": node.start_point[0] + 1,
+                    "message": f"missing {node.type!r}",
+                }
+            )
+        elif node.type == "ERROR":
+            out.append(
+                {
+                    "line": node.start_point[0] + 1,
+                    "message": "syntax error",
+                }
+            )
+        # Don't recurse into ERROR subtrees — they'd flood the report.
+        if node.type != "ERROR":
+            stack.extend(node.children)
+    return out
+
+
+def _build_symbols(
+    matches: list[tuple[int, dict]],
+    source_bytes: bytes,
+    cfg: _LangConfig,
+    *,
+    include_docstrings: bool,
+) -> list[_Symbol]:
+    processed, def_name_index = _process_matches(matches)
+    symbols: list[_Symbol] = []
+
+    for m in processed:
+        kind = cfg.capture_to_kind.get(m.cap_name)
+        if kind is None:
+            continue
+        name = m.name_node.text.decode("utf-8", errors="replace")
+        parent: str | None = m.parent_override
+        encl = (
+            _enclosing_definition(m.def_node, cfg.definition_node_types)
+            if cfg.definition_node_types
+            else None
+        )
+        if encl is not None:
+            if parent is None:
+                parent = def_name_index.get(encl.id) or _definition_name(encl)
+            # Apply promotion rules (e.g. function → method when
+            # enclosed by class_definition). First matching rule wins.
+            for rule in cfg.promote_rules:
+                if kind == rule.src and encl.type in rule.when_inside:
+                    kind = rule.dst
+                    break
+        docstring = None
+        if (
+            include_docstrings
+            and cfg.docstrings == "python"
+            and m.def_node.type
+            in {"class_definition", "function_definition"}
+        ):
+            docstring = _docstring_for(m.def_node, source_bytes)
+        symbols.append(
+            _Symbol(
+                kind=kind,
+                name=name,
+                line=m.name_node.start_point[0] + 1,
+                parent=parent,
+                docstring=docstring,
+            )
+        )
+
+    # Stable order: by line, then by name. Makes diffs (and human
+    # reads) predictable.
+    symbols.sort(key=lambda s: (s.line, s.name))
+    return symbols
+
+
+# -- Public API --------------------------------------------------------
+
+
+# Hard ceiling on emitted symbols per call. Keeps responses bounded for
+# pathological files; agent can re-call with a tighter `kind` filter.
+SYMBOL_LIMIT = 1000
+
+
+def supported_extensions() -> tuple[str, ...]:
+    _load_registry()
+    return tuple(sorted(_EXTENSION_TO_LANG))
+
+
+def supported_languages() -> tuple[str, ...]:
+    _load_registry()
+    return tuple(sorted(_REGISTRY))
+
+
+def map_source(
+    source_bytes: bytes,
+    lang_id: str,
+    *,
+    kind: str = "all",
+    include_docstrings: bool = False,
+) -> dict:
+    """Parse `source_bytes` as `lang_id` and return the symbol map dict
+    (the same shape as map_code's JSON response, minus the `file`
+    field). Useful for tests."""
+    _load_registry()
+    cfg = _REGISTRY.get(lang_id)
+    if cfg is None:
+        return {
+            "language": lang_id,
+            "symbols": [],
+            "errors": [
+                {
+                    "line": 0,
+                    "message": (
+                        f"unsupported language {lang_id!r}; "
+                        f"available: {list(supported_languages())}"
+                    ),
+                }
+            ],
+        }
+    wanted = _resolve_kind_filter(kind)
+    if wanted is None:
+        return {
+            "language": lang_id,
+            "symbols": [],
+            "errors": [
+                {
+                    "line": 0,
+                    "message": (
+                        f"unknown kind {kind!r}; valid: 'all', "
+                        f"{sorted(_NAMED_FILTERS)}, or any literal "
+                        f"kind emitted by a registered language: "
+                        f"{sorted(_all_emitted_kinds())}"
+                    ),
+                }
+            ],
+        }
+
+    parser = _get_parser(lang_id)
+    query = _get_query(lang_id)
+    tree = parser.parse(source_bytes)
+
+    from tree_sitter import QueryCursor
+
+    matches = list(QueryCursor(query).matches(tree.root_node))
+    symbols = _build_symbols(
+        matches,
+        source_bytes,
+        cfg,
+        include_docstrings=include_docstrings,
+    )
+
+    filtered = [s for s in symbols if s.kind in wanted]
+
+    truncated = False
+    if len(filtered) > SYMBOL_LIMIT:
+        filtered = filtered[:SYMBOL_LIMIT]
+        truncated = True
+
+    errors = _collect_errors(tree.root_node)
+    if truncated:
+        errors.append(
+            {
+                "line": 0,
+                "message": (
+                    f"truncated to first {SYMBOL_LIMIT} symbols; "
+                    f"narrow the request with a tighter `kind` filter."
+                ),
+            }
+        )
+
+    return {
+        "language": lang_id,
+        "symbols": [s.to_dict(include_docstrings) for s in filtered],
+        "errors": errors,
+    }
+
+
+def probe_grammar(
+    language: str,
+    source: str | bytes,
+    *,
+    max_depth: int = 12,
+    max_nodes: int = 200,
+    include_anonymous: bool = False,
+) -> str:
+    """Return an indented AST dump of `source` parsed as `language`.
+
+    Works for any language the tree-sitter-language-pack ships, not
+    just those with a configured .toml/.scm here — that's the point,
+    you call this BEFORE you've finished writing the config.
+
+    Each named node prints as `[field_name: ]node_type[  'text']`,
+    where text is shown only for token-leaf nodes (identifiers,
+    literals, etc.). Anonymous tokens (`(`, `=`, `;`) are hidden by
+    default. `max_depth` caps recursion; `max_nodes` caps total lines
+    so a probe of a large file stays bounded.
+    """
+    try:
+        lang = _get_language(language)
+    except Exception as e:
+        return f"<unknown language {language!r}: {e}>"
+
+    from tree_sitter import Parser
+
+    src_bytes = (
+        source.encode("utf-8") if isinstance(source, str) else source
+    )
+    tree = Parser(lang).parse(src_bytes)
+
+    lines: list[str] = []
+    state = {"count": 0, "truncated": False}
+
+    def emit(line: str) -> None:
+        lines.append(line)
+        state["count"] += 1
+
+    def is_token_leaf(node) -> bool:
+        # No children, or all children are anonymous tokens.
+        return not any(c.is_named for c in node.children)
+
+    def walk(node, depth: int, parent, child_idx: int) -> None:
+        if state["truncated"]:
+            return
+        if state["count"] >= max_nodes:
+            state["truncated"] = True
+            emit("  " * depth + f"... (truncated at {max_nodes} nodes)")
+            return
+        if not include_anonymous and not node.is_named:
+            return
+        field_prefix = ""
+        if parent is not None:
+            try:
+                fname = parent.field_name_for_child(child_idx)
+                if fname:
+                    field_prefix = f"{fname}: "
+            except Exception:
+                pass
+        text_suffix = ""
+        if is_token_leaf(node):
+            text = node.text.decode("utf-8", errors="replace")
+            text = text[:60].replace("\n", "\\n")
+            text_suffix = f"  '{text}'"
+        if depth > max_depth:
+            emit(
+                "  " * depth + f"{field_prefix}{node.type}  ..."
+            )
+            return
+        emit(
+            "  " * depth
+            + f"{field_prefix}{node.type}{text_suffix}"
+        )
+        for i, child in enumerate(node.children):
+            walk(child, depth + 1, parent=node, child_idx=i)
+
+    walk(tree.root_node, 0, parent=None, child_idx=0)
+    return "\n".join(lines)
+
+
+def map_code_for_path(
+    path: str,
+    source_bytes: bytes,
+    *,
+    kind: str = "all",
+    include_docstrings: bool = False,
+) -> str:
+    """Map source bytes attributed to `path`. Dispatches by extension
+    and returns a JSON-formatted string suitable for an LLM tool
+    response. Unknown extension → `{"error": "unsupported language: …"}`
+    (no exception)."""
+    _load_registry()
+    p = Path(path)
+    suffix = p.suffix.lower()
+    lang_id = _EXTENSION_TO_LANG.get(suffix)
+    if lang_id is None:
+        return json.dumps(
+            {
+                "file": str(path),
+                "error": (
+                    f"unsupported language for extension {suffix!r}; "
+                    f"supported: {list(supported_extensions())}"
+                ),
+            },
+            indent=2,
+        )
+
+    body = map_source(
+        source_bytes,
+        lang_id,
+        kind=kind,
+        include_docstrings=include_docstrings,
+    )
+    return json.dumps({"file": str(path), **body}, indent=2)

--- a/pyagent/plugins/code_mapper/queries/c.scm
+++ b/pyagent/plugins/code_mapper/queries/c.scm
@@ -1,0 +1,35 @@
+; Tags query for C.
+;
+; Source: tree-sitter/tree-sitter-c @ b780e47fc780ddc8da13afa35a3f4ed5c157823d
+;   queries/tags.scm — https://github.com/tree-sitter/tree-sitter-c/blob/master/queries/tags.scm
+;
+; Companion config: c.toml.
+;
+; DEVIATION FROM UPSTREAM: upstream collapses struct/union/typedef/enum
+; under @definition.class / @definition.type. We split them for the
+; same reason as Rust — finer kinds are useful for the agent. Patterns
+; below replace upstream's collapsed names with kind-specific ones.
+
+(struct_specifier
+    name: (type_identifier) @name
+    body: (_)) @definition.struct
+
+; Cover both shapes the C grammar produces:
+;   `union token foo;`            → declaration → union_specifier
+;   `union token { ... };`        → bare union_specifier at translation_unit
+(declaration
+    type: (union_specifier
+        name: (type_identifier) @name)) @definition.union
+
+(union_specifier
+    name: (type_identifier) @name
+    body: (_)) @definition.union
+
+(function_declarator
+    declarator: (identifier) @name) @definition.function
+
+(type_definition
+    declarator: (type_identifier) @name) @definition.typedef
+
+(enum_specifier
+    name: (type_identifier) @name) @definition.enum

--- a/pyagent/plugins/code_mapper/queries/c.toml
+++ b/pyagent/plugins/code_mapper/queries/c.toml
@@ -1,0 +1,23 @@
+# code-mapper language config — C.
+#
+# See ../EXTENDING.md for schema docs. Scalars before tables.
+
+language = "c"
+description = "C source and header files."
+extensions = [".c", ".h"]
+
+# Definition node types for parent attribution. C has fewer scoping
+# constructs than C++ — no namespaces, no class methods, just nested
+# functions / structs / unions / enums.
+definition_node_types = [
+    "struct_specifier",
+    "union_specifier",
+    "enum_specifier",
+]
+
+[captures]
+"definition.struct" = "struct"
+"definition.union" = "union"
+"definition.enum" = "enum"
+"definition.typedef" = "typedef"
+"definition.function" = "function"

--- a/pyagent/plugins/code_mapper/queries/cpp.scm
+++ b/pyagent/plugins/code_mapper/queries/cpp.scm
@@ -1,0 +1,53 @@
+; Tags query for C++.
+;
+; Source: tree-sitter/tree-sitter-cpp @ 8b5b49eb196bec7040441bee33b2c9a4838d6967
+;   queries/tags.scm — https://github.com/tree-sitter/tree-sitter-cpp/blob/master/queries/tags.scm
+;
+; Companion config: cpp.toml.
+;
+; DEVIATION FROM UPSTREAM: same kind-splitting as C/Rust (struct vs
+; class vs enum vs union vs typedef instead of upstream's collapsed
+; @definition.class / @definition.type), plus added namespace capture.
+
+(struct_specifier
+    name: (type_identifier) @name
+    body: (_)) @definition.struct
+
+(class_specifier
+    name: (type_identifier) @name) @definition.class
+
+(declaration
+    type: (union_specifier
+        name: (type_identifier) @name)) @definition.union
+
+(union_specifier
+    name: (type_identifier) @name
+    body: (_)) @definition.union
+
+(enum_specifier
+    name: (type_identifier) @name) @definition.enum
+
+(type_definition
+    declarator: (type_identifier) @name) @definition.typedef
+
+(namespace_definition
+    name: (namespace_identifier) @name) @definition.namespace
+
+; Plain function (free function or method body inside a class body).
+; Methods inside class_specifier are upgraded to "method" via
+; cpp.toml's promote rules; out-of-line `Foo::bar` definitions are
+; covered by the qualified pattern below.
+(function_declarator
+    declarator: (identifier) @name) @definition.function
+
+(function_declarator
+    declarator: (field_identifier) @name) @definition.function
+
+; Out-of-line method definitions: `void Foo::bar() { ... }`.
+; Captures @name = "bar" and @parent = "Foo" — the @parent capture
+; overrides the AST-walk-based parent attribution (which would
+; otherwise resolve to the surrounding namespace).
+(function_declarator
+    declarator: (qualified_identifier
+        scope: (namespace_identifier) @parent
+        name: (identifier) @name)) @definition.method

--- a/pyagent/plugins/code_mapper/queries/cpp.toml
+++ b/pyagent/plugins/code_mapper/queries/cpp.toml
@@ -1,0 +1,35 @@
+# code-mapper language config — C++.
+#
+# See ../EXTENDING.md for schema docs. Scalars before tables.
+
+language = "cpp"
+description = "C++ source and header files."
+extensions = [".cc", ".cpp", ".cxx", ".hh", ".hpp", ".hxx"]
+
+# Definition node types for parent attribution. Includes namespace
+# and class/struct so methods get correctly attributed up the chain.
+definition_node_types = [
+    "class_specifier",
+    "struct_specifier",
+    "union_specifier",
+    "enum_specifier",
+    "namespace_definition",
+]
+
+[captures]
+"definition.class" = "class"
+"definition.struct" = "struct"
+"definition.union" = "union"
+"definition.enum" = "enum"
+"definition.typedef" = "typedef"
+"definition.namespace" = "namespace"
+"definition.function" = "function"
+"definition.method" = "method"
+
+# Functions defined inside a class/struct body are methods. Out-of-line
+# definitions (`void Foo::bar() {}`) come in as @definition.method
+# directly via the dedicated query pattern, so they bypass this rule.
+[[promote]]
+from = "function"
+to = "method"
+when_inside = ["class_specifier", "struct_specifier"]

--- a/pyagent/plugins/code_mapper/queries/html.scm
+++ b/pyagent/plugins/code_mapper/queries/html.scm
@@ -1,0 +1,65 @@
+; Tags query for HTML.
+;
+; CUSTOM (not vendored): tree-sitter-html upstream ships only
+; highlights.scm and injections.scm — no tags.scm. Companion config:
+; html.toml.
+;
+; HTML doesn't have functions/classes; the useful structure is the
+; document outline. We capture:
+;
+;   * Headings h1..h6 — name = the heading text content.
+;   * Elements with an `id` attribute — name = the id value, parent =
+;     the tag name (so the agent sees `kind=element_id name=intro
+;     parent=section`).
+;   * Semantic landmarks (nav/main/section/article/aside/header/footer)
+;     — name = tag name.
+;   * <script> and <style> blocks — name = "script" / "style".
+;
+; The DOM as a whole is intentionally NOT captured — a real page has
+; hundreds of <div>s and the symbol map would be useless. Stick to
+; outline-bearing nodes only.
+
+; --- Headings ------------------------------------------------------
+; Match elements whose tag name is h1..h6, capture the inner text as
+; @name and the element itself as @definition.heading.
+
+(element
+    (start_tag
+        (tag_name) @_h
+        (#match? @_h "^[hH][1-6]$"))
+    (text) @name) @definition.heading
+
+; --- Elements with id attribute -----------------------------------
+; Capture the value of any id="..." attribute as @name, and the
+; element itself as @definition.element_id. Also capture the tag
+; name as @parent so the agent sees what kind of element owns the id.
+
+(element
+    (start_tag
+        (tag_name) @parent
+        (attribute
+            (attribute_name) @_attr
+            (quoted_attribute_value
+                (attribute_value) @name)
+            (#eq? @_attr "id")))) @definition.element_id
+
+; --- Semantic landmarks --------------------------------------------
+; nav, main, section, article, aside, header, footer.
+; @name = the tag itself (so search-by-name works).
+
+(element
+    (start_tag
+        (tag_name) @name
+        (#match? @name "^(nav|main|section|article|aside|header|footer)$"))) @definition.section
+
+; --- script / style blocks ----------------------------------------
+; tree-sitter-html distinguishes <script> and <style> as their own
+; node types so we can target them precisely.
+
+(script_element
+    (start_tag
+        (tag_name) @name)) @definition.script
+
+(style_element
+    (start_tag
+        (tag_name) @name)) @definition.style

--- a/pyagent/plugins/code_mapper/queries/html.toml
+++ b/pyagent/plugins/code_mapper/queries/html.toml
@@ -1,0 +1,22 @@
+# code-mapper language config — HTML.
+#
+# See ../EXTENDING.md for schema docs. Scalars before tables.
+
+language = "html"
+description = "HTML documents — outline view (headings, ids, landmarks, script/style)."
+extensions = [".html", ".htm"]
+
+# HTML has nesting but tree-sitter doesn't surface a single "definition
+# node type" the way function_definition does in C. Leaving this empty
+# means parent attribution comes only from explicit @parent captures
+# (e.g. "this id belongs to a <section>") rather than AST walks. That's
+# the right call for HTML — walking up through every <div>/<span> would
+# produce noisy parent chains.
+definition_node_types = []
+
+[captures]
+"definition.heading" = "heading"
+"definition.element_id" = "element_id"
+"definition.section" = "section"
+"definition.script" = "script"
+"definition.style" = "style"

--- a/pyagent/plugins/code_mapper/queries/python.scm
+++ b/pyagent/plugins/code_mapper/queries/python.scm
@@ -1,0 +1,53 @@
+; Tags query for Python.
+;
+; Source: tree-sitter/tree-sitter-python @ 26855eabccb19c6abf499fbc5b8dc7cc9ab8bc64
+;   queries/tags.scm — https://github.com/tree-sitter/tree-sitter-python/blob/master/queries/tags.scm
+;
+; Companion config: python.toml (capture → kind mapping, def node
+; types, promotion rules, extension list).
+;
+; Capture-name convention follows tree-sitter's tags spec:
+;   @name                — the identifier the symbol is bound to
+;   @definition.<kind>   — the surrounding node that constitutes the def
+;   @reference.<kind>    — a use site
+;
+; Deviations from upstream are flagged inline.
+
+; --- upstream patterns (verbatim, except as noted) ---
+
+; NOTE: upstream tags.scm wraps the top-level constant pattern in
+; `(expression_statement ...)`, but the current grammar in
+; tree-sitter-language-pack 1.6 produces `(module (assignment ...))`
+; directly, so that pattern matches nothing. Adapted below to match
+; module-level assignments without the obsolete wrapper.
+(module
+  (assignment
+    left: (identifier) @name) @definition.constant)
+
+(class_definition
+  name: (identifier) @name) @definition.class
+
+(function_definition
+  name: (identifier) @name) @definition.function
+
+(call
+  function: [
+      (identifier) @name
+      (attribute
+        attribute: (identifier) @name)
+  ]) @reference.call
+
+; --- pyagent extensions: imports ---
+
+(import_statement
+  name: (dotted_name) @name) @definition.import
+
+(import_statement
+  name: (aliased_import
+    name: (dotted_name) @name)) @definition.import
+
+(import_from_statement
+  module_name: (dotted_name) @name) @definition.import
+
+(import_from_statement
+  module_name: (relative_import) @name) @definition.import

--- a/pyagent/plugins/code_mapper/queries/python.toml
+++ b/pyagent/plugins/code_mapper/queries/python.toml
@@ -1,0 +1,40 @@
+# code-mapper language config — Python.
+#
+# See ../EXTENDING.md for the schema and the workflow for adding a new
+# language. The .scm file alongside this one is the tree-sitter query
+# that produces captures; this file says how those captures map to the
+# normalized symbol kinds the agent sees.
+#
+# IMPORTANT: scalars and arrays-of-scalars MUST appear before any
+# [table] / [[array_of_tables]] header — TOML's grouping rules mean
+# anything after a header belongs to that header until the next one.
+
+language = "python"
+description = "Python source and stub files."
+extensions = [".py", ".pyi"]
+
+# Node types whose presence in an ancestor walk implies "the symbol
+# is inside a definition" — used for parent attribution.
+definition_node_types = ["class_definition", "function_definition"]
+
+# Plugin-internal: which docstring extractor to use. Only "python" is
+# implemented in v1; other languages report `null` for docstrings.
+docstrings = "python"
+
+# Tree-sitter capture name → normalized symbol kind. Anything not
+# listed here is dropped (e.g. tags.scm's @local.scope). Multiple
+# capture names may map to the same kind; that's fine.
+[captures]
+"definition.class" = "class"
+"definition.function" = "function"
+"definition.constant" = "constant"
+"definition.import" = "import"
+"reference.call" = "call"
+
+# Kind promotion rules. If an emitted symbol has kind=`from` and its
+# enclosing definition is one of `when_inside`, the kind upgrades to
+# `to`. This is how a function inside a class becomes a method.
+[[promote]]
+from = "function"
+to = "method"
+when_inside = ["class_definition"]

--- a/pyagent/plugins/code_mapper/queries/rust.scm
+++ b/pyagent/plugins/code_mapper/queries/rust.scm
@@ -1,0 +1,73 @@
+; Tags query for Rust.
+;
+; Source: tree-sitter/tree-sitter-rust @ 77a3747266f4d621d0757825e6b11edcbf991ca5
+;   queries/tags.scm — https://github.com/tree-sitter/tree-sitter-rust/blob/master/queries/tags.scm
+;
+; Companion config: rust.toml.
+;
+; DEVIATION FROM UPSTREAM: upstream collapses struct/enum/union/type-alias
+; under @definition.class so a generic tags consumer renders them all as
+; "class". We keep them distinct (`struct`/`enum`/`union`/`type`) because
+; the agent benefits from the finer kind. The upstream patterns are
+; commented out below for traceability and replaced with kind-specific
+; capture names.
+
+; --- ADTs ------------------------------------------------------------
+; upstream: (struct_item name: (type_identifier) @name) @definition.class
+(struct_item
+    name: (type_identifier) @name) @definition.struct
+
+; upstream: (enum_item name: (type_identifier) @name) @definition.class
+(enum_item
+    name: (type_identifier) @name) @definition.enum
+
+; upstream: (union_item name: (type_identifier) @name) @definition.class
+(union_item
+    name: (type_identifier) @name) @definition.union
+
+; upstream: (type_item name: (type_identifier) @name) @definition.class
+(type_item
+    name: (type_identifier) @name) @definition.type
+
+; --- Functions / methods --------------------------------------------
+; DEVIATION FROM UPSTREAM: upstream emits @definition.method for any
+; function_item inside a declaration_list, but that incorrectly tags
+; functions inside `mod { ... }` blocks (which also use
+; declaration_list as their body) as methods. We instead capture all
+; function_items as @definition.function and let rust.toml's
+; promote-rules upgrade to "method" only when the enclosing definition
+; is impl_item or trait_item.
+(function_item
+    name: (identifier) @name) @definition.function
+
+; --- Traits, modules, macros ----------------------------------------
+(trait_item
+    name: (type_identifier) @name) @definition.trait
+
+(mod_item
+    name: (identifier) @name) @definition.module
+
+(macro_definition
+    name: (identifier) @name) @definition.macro
+
+; --- References (call sites) ---------------------------------------
+(call_expression
+    function: (identifier) @name) @reference.call
+
+(call_expression
+    function: (field_expression
+        field: (field_identifier) @name)) @reference.call
+
+(macro_invocation
+    macro: (identifier) @name) @reference.call
+
+; --- impl blocks ----------------------------------------------------
+; Upstream emits @reference.implementation; we promote to @definition.impl
+; because for code-mapping purposes these blocks ARE definition sites
+; (where methods get attached to a type).
+(impl_item
+    trait: (type_identifier) @name) @definition.impl
+
+(impl_item
+    type: (type_identifier) @name
+    !trait) @definition.impl

--- a/pyagent/plugins/code_mapper/queries/rust.toml
+++ b/pyagent/plugins/code_mapper/queries/rust.toml
@@ -1,0 +1,45 @@
+# code-mapper language config — Rust.
+#
+# See ../EXTENDING.md for schema docs. Scalars MUST come before any
+# [table] / [[array_of_tables]] header.
+
+language = "rust"
+description = "Rust source files."
+extensions = [".rs"]
+
+# Definition node types we walk through during parent attribution.
+# Includes impl_item and trait_item so functions inside them get
+# correctly attributed to the impl/trait, and via the promote rules
+# below get upgraded from "function" to "method".
+definition_node_types = [
+    "function_item",
+    "struct_item",
+    "enum_item",
+    "union_item",
+    "type_item",
+    "trait_item",
+    "impl_item",
+    "mod_item",
+]
+
+# Capture-name → normalized kind. We split ADTs into struct/enum/union
+# instead of upstream's @definition.class — see rust.scm header for the
+# rationale.
+[captures]
+"definition.struct" = "struct"
+"definition.enum" = "enum"
+"definition.union" = "union"
+"definition.type" = "type"
+"definition.function" = "function"
+"definition.trait" = "trait"
+"definition.module" = "module"
+"definition.macro" = "macro"
+"definition.impl" = "impl"
+"reference.call" = "call"
+
+# Functions inside an impl or trait block are methods. Functions
+# inside a mod block stay functions (they're plain module-level fns).
+[[promote]]
+from = "function"
+to = "method"
+when_inside = ["impl_item", "trait_item"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "platformdirs>=4",
     "requests>=2.31",
     "rich>=13",
+    "tree-sitter>=0.25",
+    "tree-sitter-language-pack>=0.10",
 ]
 
 [project.scripts]
@@ -45,6 +47,8 @@ pyagent = [
     "plugins/**/*.md",
     "plugins/**/*.toml",
     "plugins/**/*.json",
+    "plugins/**/*.scm",
+    "plugins/**/EXTENDING.md",
     # Bench scenarios.
     "bench/scenarios/*.toml",
     # Bundled role library — one .md per role, parsed at runtime.

--- a/tests/smoke_code_mapper.py
+++ b/tests/smoke_code_mapper.py
@@ -1,0 +1,462 @@
+"""End-to-end smoke for the code-mapper plugin.
+
+Three concerns:
+
+  1. **Plugin loads under default config.** With "code-mapper" in
+     built_in_plugins_enabled, `discover()` and `load()` produce the
+     `map_code` tool.
+
+  2. **Maps a clean Python file correctly.** Symbol kinds, names, parents,
+     1-indexed line numbers, docstring opt-in.
+
+  3. **Degrades gracefully.** Broken-syntax file still produces partial
+     symbols + non-empty `errors`. Unsupported extension returns the
+     `error` payload, not an exception.
+
+Run with:
+
+    .venv/bin/python -m tests.smoke_code_mapper
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+from pyagent import (
+    config as config_mod,
+    paths as paths_mod,
+    plugins,
+)
+from pyagent.plugins.code_mapper import mapper
+
+
+_CLEAN_PY = b'''"""Module docstring."""
+
+import os
+from pathlib import Path
+
+CONST = 42
+
+class Animal:
+    """An animal."""
+
+    def speak(self):
+        """Make a sound."""
+        return "..."
+
+    def name(self):
+        return "anon"
+
+
+def top_level():
+    """A top-level function."""
+    return 1
+
+
+def _nested_outer():
+    def inner():
+        return 0
+    return inner
+'''
+
+
+_BROKEN_PY = b'''import os
+
+def good():
+    return 1
+
+class Half:
+    def fine(self):
+        return 2
+
+    def broken(self
+        # missing close-paren and body
+'''
+
+
+def _check_map_clean_python() -> None:
+    """Symbols, kinds, parents, lines all line up for a normal file."""
+    out = mapper.map_source(_CLEAN_PY, "python", kind="all")
+    assert out["language"] == "python", out
+    assert out["errors"] == [], out["errors"]
+    syms = out["symbols"]
+    by_name = {s["name"]: s for s in syms}
+
+    # Imports.
+    assert by_name["os"]["kind"] == "import", by_name["os"]
+    assert by_name["os"]["line"] == 3, by_name["os"]
+    assert by_name["pathlib"]["kind"] == "import", by_name["pathlib"]
+    assert by_name["pathlib"]["line"] == 4, by_name["pathlib"]
+
+    # Top-level constant.
+    assert by_name["CONST"]["kind"] == "constant", by_name["CONST"]
+    assert by_name["CONST"]["line"] == 6, by_name["CONST"]
+
+    # Class + methods.
+    assert by_name["Animal"]["kind"] == "class", by_name["Animal"]
+    assert by_name["Animal"]["parent"] is None
+    assert by_name["Animal"]["line"] == 8, by_name["Animal"]
+
+    speak = by_name["speak"]
+    assert speak["kind"] == "method", speak
+    assert speak["parent"] == "Animal", speak
+    assert speak["line"] == 11, speak
+
+    name_method = by_name["name"]
+    assert name_method["kind"] == "method", name_method
+    assert name_method["parent"] == "Animal", name_method
+
+    # Top-level function.
+    tl = by_name["top_level"]
+    assert tl["kind"] == "function", tl
+    assert tl["parent"] is None, tl
+    assert tl["line"] == 19, tl
+
+    # Nested function: parent is the enclosing function, not None.
+    inner = by_name["inner"]
+    assert inner["kind"] == "function", inner
+    assert inner["parent"] == "_nested_outer", inner
+
+    print(
+        f"✓ clean Python: {len(syms)} symbols mapped "
+        f"(class/method/function/import/constant)"
+    )
+
+
+def _check_kind_filter() -> None:
+    out = mapper.map_source(_CLEAN_PY, "python", kind="imports")
+    kinds = {s["kind"] for s in out["symbols"]}
+    assert kinds == {"import"}, kinds
+
+    out = mapper.map_source(_CLEAN_PY, "python", kind="functions")
+    kinds = {s["kind"] for s in out["symbols"]}
+    # functions filter pulls in both functions and methods.
+    assert kinds <= {"function", "method"}, kinds
+    assert "function" in kinds and "method" in kinds, kinds
+
+    out = mapper.map_source(_CLEAN_PY, "python", kind="classes")
+    kinds = {s["kind"] for s in out["symbols"]}
+    assert kinds == {"class"}, kinds
+
+    print(f"✓ kind= filter narrows symbol set as documented")
+
+
+def _check_docstrings_optin() -> None:
+    out_off = mapper.map_source(_CLEAN_PY, "python", kind="functions")
+    assert all("docstring" not in s for s in out_off["symbols"]), (
+        out_off["symbols"]
+    )
+
+    out_on = mapper.map_source(
+        _CLEAN_PY, "python", kind="functions", include_docstrings=True
+    )
+    by_name = {s["name"]: s for s in out_on["symbols"]}
+    assert by_name["speak"]["docstring"].strip() == "Make a sound.", (
+        by_name["speak"]
+    )
+    assert by_name["top_level"]["docstring"].strip() == (
+        "A top-level function."
+    ), by_name["top_level"]
+    # `name` method has no docstring → field absent or None.
+    name_doc = by_name["name"].get("docstring")
+    assert name_doc is None, name_doc
+    print(f"✓ include_docstrings=True attaches docstrings; default omits them")
+
+
+def _check_broken_python_degrades() -> None:
+    """Tree-sitter recovers around the broken region — the `good`
+    function and the `Half.fine` method should still appear, and
+    `errors` should be non-empty."""
+    out = mapper.map_source(_BROKEN_PY, "python", kind="all")
+    names = {s["name"] for s in out["symbols"]}
+    assert "good" in names, names
+    assert "fine" in names, names
+    assert len(out["errors"]) > 0, out["errors"]
+    # Errors should carry a positive line number.
+    assert all(e["line"] >= 0 for e in out["errors"]), out["errors"]
+    print(
+        f"✓ broken Python: {len(out['symbols'])} symbols recovered, "
+        f"{len(out['errors'])} error(s) reported"
+    )
+
+
+def _check_unsupported_extension() -> None:
+    """`map_code_for_path` should return a clean error payload, not
+    raise, for an extension we don't ship a grammar/query for."""
+    out_str = mapper.map_code_for_path(
+        "/tmp/whatever.foo", b"junk", kind="all"
+    )
+    payload = json.loads(out_str)
+    assert "error" in payload, payload
+    assert ".foo" in payload["error"], payload["error"]
+    print(f"✓ unsupported extension → clean error payload")
+
+
+def _check_plugin_loads_under_default_config() -> None:
+    """With the default config, code-mapper is in
+    built_in_plugins_enabled and load() exposes the map_code tool."""
+    tmp = Path(tempfile.mkdtemp(prefix="pyagent-smoke-codemapper-"))
+    with mock.patch.object(paths_mod, "config_dir", return_value=tmp):
+        with mock.patch.object(
+            plugins, "LOCAL_PLUGINS_DIR", Path(tmp / "no_local_plugins")
+        ):
+            cfg = config_mod.load()
+            assert "code-mapper" in cfg["built_in_plugins_enabled"], (
+                cfg["built_in_plugins_enabled"]
+            )
+            loaded = plugins.load()
+            tool_names = set(loaded.tools().keys())
+    assert "map_code" in tool_names, tool_names
+    print(f"✓ plugin loads by default; map_code in tools = {sorted(tool_names)}")
+
+
+def _check_end_to_end_against_real_file() -> None:
+    """As-if-the-agent: feed mapper a real file from this repo and
+    confirm the output is well-formed JSON with believable symbols."""
+    target = Path(__file__).resolve().parents[1] / "pyagent" / "agent.py"
+    if not target.exists():
+        print(f"  (skipped: {target} not found)")
+        return
+    out_str = mapper.map_code_for_path(
+        str(target), target.read_bytes(), kind="classes"
+    )
+    payload = json.loads(out_str)
+    assert payload["file"] == str(target)
+    assert payload["language"] == "python", payload
+    # pyagent/agent.py defines Agent — should appear under kind=classes.
+    names = [s["name"] for s in payload["symbols"]]
+    assert "Agent" in names, names
+    print(f"✓ end-to-end on pyagent/agent.py → classes: {names}")
+
+
+_RUST_SRC = b'''use std::io;
+
+struct Point { x: i32, y: i32 }
+
+enum Color { Red, Green }
+
+trait Greet { fn hello(&self); }
+
+mod nested {
+    pub fn inside() {}
+}
+
+impl Point {
+    fn new() -> Self { Point { x: 0, y: 0 } }
+}
+
+impl Greet for Point {
+    fn hello(&self) {}
+}
+
+fn top() {}
+'''
+
+
+def _check_map_rust() -> None:
+    out = mapper.map_source(_RUST_SRC, "rust", kind="all")
+    assert out["errors"] == [], out["errors"]
+    has = lambda kind, name, parent: any(
+        s["kind"] == kind and s["name"] == name and s["parent"] == parent
+        for s in out["symbols"]
+    )
+
+    # ADTs split into kind-specific buckets (NOT collapsed under "class").
+    assert has("struct", "Point", None), out["symbols"]
+    assert has("enum", "Color", None), out["symbols"]
+    assert has("trait", "Greet", None), out["symbols"]
+
+    # Function inside `mod` stays a function (NOT promoted to method).
+    assert has("function", "inside", "nested"), out["symbols"]
+
+    # Function inside `impl` becomes a method, attributed to Point.
+    assert has("method", "new", "Point"), out["symbols"]
+
+    # Trait impl: tags.scm captures the trait name as the impl's @name,
+    # so methods inside attribute to the trait — known convention,
+    # documented in EXTENDING.md.
+    assert has("method", "hello", "Greet"), out["symbols"]
+
+    # Both impl blocks captured.
+    assert has("impl", "Point", None), out["symbols"]
+    assert has("impl", "Greet", None), out["symbols"]
+
+    assert has("function", "top", None), out["symbols"]
+    print(f"✓ Rust: struct/enum/trait/method/function classified correctly")
+
+
+_C_SRC = b'''#include <stdio.h>
+
+typedef struct point { int x, y; } point_t;
+
+enum color { RED, GREEN, BLUE };
+
+union token { int i; float f; };
+
+int add(int a, int b) { return a + b; }
+
+static void greet(const char *name) { printf("hi"); }
+'''
+
+
+def _check_map_c() -> None:
+    out = mapper.map_source(_C_SRC, "c", kind="all")
+    assert out["errors"] == [], out["errors"]
+    by_name = {s["name"]: s for s in out["symbols"]}
+    assert by_name["point"]["kind"] == "struct", by_name["point"]
+    assert by_name["point_t"]["kind"] == "typedef", by_name["point_t"]
+    assert by_name["color"]["kind"] == "enum", by_name["color"]
+    assert by_name["token"]["kind"] == "union", by_name["token"]
+    assert by_name["add"]["kind"] == "function", by_name["add"]
+    assert by_name["greet"]["kind"] == "function", by_name["greet"]
+    print(f"✓ C: struct/typedef/enum/union/function classified correctly")
+
+
+_CPP_SRC = b'''namespace app {
+
+class Animal {
+public:
+    Animal();
+    void speak() const;
+};
+
+void Animal::speak() const {}
+
+struct Point { int x, y; };
+
+void top() {}
+
+}  // namespace app
+'''
+
+
+def _check_map_cpp() -> None:
+    out = mapper.map_source(_CPP_SRC, "cpp", kind="all")
+    assert out["errors"] == [], out["errors"]
+    has = lambda kind, name, parent: any(
+        s["kind"] == kind and s["name"] == name and s["parent"] == parent
+        for s in out["symbols"]
+    )
+    assert has("namespace", "app", None), out["symbols"]
+    assert has("class", "Animal", "app"), out["symbols"]
+    assert has("struct", "Point", "app"), out["symbols"]
+    # Both the in-class declaration and the out-of-line definition of
+    # `Animal::speak` attribute to Animal — the latter via @parent.
+    speak_in_animal = [
+        s
+        for s in out["symbols"]
+        if s["kind"] == "method"
+        and s["name"] == "speak"
+        and s["parent"] == "Animal"
+    ]
+    assert len(speak_in_animal) == 2, speak_in_animal
+    # Free function inside namespace.
+    assert has("function", "top", "app"), out["symbols"]
+    print(f"✓ C++: class/struct/method (in-class + out-of-line)/namespace OK")
+
+
+_HTML_SRC = b'''<!doctype html>
+<html><body>
+<main id="top">
+  <h1>Title</h1>
+  <h2>Sub</h2>
+  <section id="intro"><p>hi</p></section>
+  <nav><a href="#">link</a></nav>
+  <script>console.log(1);</script>
+  <style>p { color: red; }</style>
+</main>
+</body></html>
+'''
+
+
+def _check_map_html() -> None:
+    out = mapper.map_source(_HTML_SRC, "html", kind="all")
+    assert out["errors"] == [], out["errors"]
+    by = {(s["kind"], s["name"]): s for s in out["symbols"]}
+    # Headings.
+    assert ("heading", "Title") in by, list(by)
+    assert ("heading", "Sub") in by, list(by)
+    # Element ids carry the owning tag as their parent.
+    top = by[("element_id", "top")]
+    assert top["parent"] == "main", top
+    intro = by[("element_id", "intro")]
+    assert intro["parent"] == "section", intro
+    # Semantic landmarks.
+    assert ("section", "main") in by, list(by)
+    assert ("section", "section") in by, list(by)
+    assert ("section", "nav") in by, list(by)
+    # script/style blocks.
+    assert ("script", "script") in by, list(by)
+    assert ("style", "style") in by, list(by)
+    print(
+        f"✓ HTML: {len(out['symbols'])} outline symbols "
+        f"(headings/ids/landmarks/script/style)"
+    )
+
+
+def _check_probe_grammar() -> None:
+    """probe_grammar prints the parse tree with field names visible,
+    works for languages without a config (the whole point), and
+    bounds output via max_nodes."""
+    out = mapper.probe_grammar("python", "CONST = 1")
+    assert "module" in out, out
+    assert "assignment" in out, out
+    # Field names must show — they're what queries reference.
+    assert "left:" in out, out
+    assert "right:" in out, out
+    # Token leaves carry their text.
+    assert "'CONST'" in out, out
+
+    # Languages without a code-mapper config still probe — that's
+    # what the agent does when adding a new language.
+    out = mapper.probe_grammar("go", "func main() {}")
+    assert "function_declaration" in out or "function_definition" in out, out
+
+    # max_nodes bounds output.
+    out = mapper.probe_grammar(
+        "python", "a=1\nb=2\nc=3\nd=4\ne=5", max_nodes=4
+    )
+    assert "truncated" in out, out
+
+    # Unknown language returns a clean error marker, not an exception.
+    err = mapper.probe_grammar("klingon", "qapla")
+    assert err.startswith("<unknown language"), err
+    print(f"✓ probe_grammar: field names visible, bounded, language-pack-direct")
+
+
+def _check_extension_dispatch() -> None:
+    """The plugin's extension table covers all four languages."""
+    exts = set(mapper.supported_extensions())
+    for required in (
+        ".py", ".pyi",
+        ".rs",
+        ".c", ".h",
+        ".cc", ".cpp", ".cxx", ".hh", ".hpp", ".hxx",
+        ".html", ".htm",
+    ):
+        assert required in exts, (required, exts)
+    print(f"✓ supported_extensions() covers Python/Rust/C/C++/HTML: {sorted(exts)}")
+
+
+def main() -> None:
+    _check_map_clean_python()
+    _check_kind_filter()
+    _check_docstrings_optin()
+    _check_broken_python_degrades()
+    _check_unsupported_extension()
+    _check_plugin_loads_under_default_config()
+    _check_end_to_end_against_real_file()
+    _check_map_rust()
+    _check_map_c()
+    _check_map_cpp()
+    _check_map_html()
+    _check_probe_grammar()
+    _check_extension_dispatch()
+    print("smoke_code_mapper: all checks passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Bundled plugin exposing two tools: `map_code` (returns a structured outline of a source file — functions, classes, methods, imports, … with 1-indexed line numbers) and `probe_grammar` (prints the tree-sitter parse tree for query authoring).
- Per-language config is data, not code. Each language ships `queries/<lang>.{toml,scm}` declaring extensions, capture-name → kind mapping, definition node types, and `[[promote]]` rules. Adding a language is two files in `queries/`, no edit to `mapper.py`. See `EXTENDING.md` for the agent-facing playbook.
- Five languages out of the box: Python, Rust, C, C++, HTML. Rust/C/C++ vendor upstream `tags.scm` (commits pinned in each `.scm` header, deviations marked inline). HTML written from scratch (no upstream `tags.scm`).
- New deps: `tree-sitter>=0.25`, `tree-sitter-language-pack>=0.10` — both ship prebuilt wheels for CPython 3.10–3.14 on Linux/macOS/Windows, no C toolchain at install time.
- Default config now lists `code-mapper` in `built_in_plugins_enabled` alongside `memory-markdown` and `html-tools`.

## Test plan

- [ ] `.venv/bin/python -m tests.smoke_code_mapper` — 13 checks (clean Python mapping, kind= filter, docstring opt-in, syntax-error recovery, unsupported-extension dispatch, default-config plugin load, end-to-end against pyagent/agent.py, per-language fixtures for Rust/C/C++/HTML, probe_grammar shape, extension dispatch table)
- [ ] `.venv/bin/python -m tests.smoke_plugins` — regression
- [ ] `.venv/bin/python -m tests.smoke_html_tools` — regression
- [ ] Spot check: `map_code(path="pyagent/agent.py", kind="classes")` returns `Agent`
- [ ] Spot check: `probe_grammar(language="go", source="func main() {}")` works for a language with no config (the whole point — agent uses this when adding a language)