### PR TITLE
bench: tmpdir workspace + pyagent_self_audit scenario

### DIFF
--- a/pyagent/bench/scenarios/pyagent_self_audit.toml
+++ b/pyagent/bench/scenarios/pyagent_self_audit.toml
@@ -1,0 +1,30 @@
+name = "pyagent_self_audit"
+description = "Audit the pyagent codebase itself: trace tool registration, evaluate the offload threshold design, and propose a one-paragraph improvement. No network, fully reproducible from the snapshotted source."
+
+# Snapshot the user's cwd into the bench workspace before spawning. The
+# agent edits/reads against the snapshot, never the live repo. Run this
+# scenario from inside the pyagent project root so the snapshot makes
+# sense (the prompts assume the codebase layout).
+seed_workspace_from = "cwd"
+
+# Hint for humans reading the file; not enforced.
+tools = ["grep", "read_file", "list_directory"]
+
+[[prompts]]
+text = """List every tool that the root agent registers by default. \
+For each tool, give the source file and a one-sentence description of \
+what it does. Look at the registration site, not the imports — be \
+specific about which tools are core vs. plugin-provided."""
+
+[[prompts]]
+text = """For each tool you listed, identify whether it's registered \
+with `auto_offload=True` (the default) or `auto_offload=False`. \
+Briefly explain the reasoning behind any tool that bypasses \
+auto-offload — what makes that tool's outputs different from the ones \
+that auto-offload at 8K chars?"""
+
+[[prompts]]
+text = """Look at `Agent.SOFT_THRESHOLD_FORCED_TOOLS` in pyagent/agent.py. \
+Are any tools missing from that set that should arguably be included? \
+Justify your answer in two sentences, citing one concrete example of \
+how a missing tool could produce inline-bloat under realistic usage."""

--- a/pyagent/bench/scenarios/well_mako.toml
+++ b/pyagent/bench/scenarios/well_mako.toml
@@ -18,4 +18,4 @@ https://en.wikipedia.org/wiki/Charles_Babbage. Where do they emphasize \
 different things?"""
 
 [[prompts]]
-text = "Save your full analysis as a markdown file at /tmp/bench-output.md and confirm the path."
+text = "Save your full analysis as a markdown file named bench-output.md (relative path — the workspace is a fresh tmpdir set up by the bench) and confirm the path."

--- a/pyagent/bench_cli.py
+++ b/pyagent/bench_cli.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 import multiprocessing
+import shutil
 import sys
 import tempfile
 import time
@@ -48,6 +49,14 @@ class Scenario:
     description: str
     prompts: list[str]
     tools_hint: list[str] = field(default_factory=list)
+    # If set, snapshot this directory into the bench's tmpdir workspace
+    # before spawning the agent. `"cwd"` means the directory the user
+    # invoked `pyagent-bench` from; an absolute path snapshots that
+    # directory specifically. The agent operates on the snapshot, so
+    # any edits it makes don't touch the live source. Empty (default)
+    # means the workspace stays bare — appropriate for scenarios that
+    # source their inputs from the network (e.g. well_mako).
+    seed_workspace_from: str = ""
 
 
 @dataclass
@@ -103,6 +112,7 @@ def _load_scenario(name: str) -> Scenario:
         description=data.get("description", ""),
         prompts=prompts,
         tools_hint=list(data.get("tools", []) or []),
+        seed_workspace_from=str(data.get("seed_workspace_from", "") or ""),
     )
 
 
@@ -390,6 +400,36 @@ def run_cmd(
     workspace = Path(
         tempfile.mkdtemp(prefix=f"pyagent-bench-{sc.name}-")
     )
+
+    # Optionally snapshot a source directory into the workspace. Used
+    # by self-audit-style scenarios that need real code or data on
+    # disk; the snapshot keeps the agent's edits off the live source.
+    if sc.seed_workspace_from:
+        if sc.seed_workspace_from == "cwd":
+            seed_src = Path.cwd().resolve()
+        else:
+            seed_src = Path(sc.seed_workspace_from).expanduser().resolve()
+        if not seed_src.is_dir():
+            raise click.ClickException(
+                f"scenario {sc.name!r} seed source {seed_src} "
+                f"is not a directory."
+            )
+        click.echo(f"[bench] seed:      {seed_src} → {workspace}")
+        # Don't copy git/venv/cache cruft. .pyagent IS copied so the
+        # agent inherits the user's project-tier plugins, skills, and
+        # roles; the bench's own session is keyed by id under
+        # .pyagent/sessions/ and won't collide with anything carried
+        # over.
+        shutil.copytree(
+            seed_src,
+            workspace,
+            dirs_exist_ok=True,
+            ignore=shutil.ignore_patterns(
+                ".git", ".venv", "venv", "node_modules",
+                "__pycache__", "*.pyc", "*.egg-info", ".pytest_cache",
+            ),
+        )
+
     session_root = workspace / ".pyagent" / "sessions"
 
     # Mint the session up front so we can print + report the id even

--- a/pyagent/bench_cli.py
+++ b/pyagent/bench_cli.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import json
 import multiprocessing
 import sys
+import tempfile
 import time
 import tomllib
 from dataclasses import asdict, dataclass, field
@@ -54,6 +55,7 @@ class BenchReport:
     scenario: str
     model: str
     session_id: str
+    workspace: str  # absolute path to the run's tmpdir workspace
     reason: str  # "complete" | "budget" | "cancelled" | "error"
     prompts_run: int
     prompts_total: int
@@ -155,18 +157,22 @@ def _maybe_warn_opus(model: str, budget: float, no_budget: bool) -> None:
         )
 
 
-def _build_agent_config(model: str, session_id: str) -> dict[str, Any]:
+def _build_agent_config(
+    model: str, session_id: str, workspace: Path
+) -> dict[str, Any]:
     """Mirror the CLI's startup setup but for a non-interactive run.
 
-    The bench owns its own session id (so it can print it before
-    spawning the child) and runs in the user's cwd so plugins resolve
-    against real config.
+    `workspace` becomes the agent's cwd. The bench mints a fresh
+    tmpdir per run (see `run_cmd`) so write_file targets like
+    `bench-output.md` land inside the workspace and don't trip the
+    permissions gate, AND so back-to-back runs don't leave artifacts
+    in the user's project dir.
     """
     soul = paths.resolve("SOUL.md", override=None, seed="SOUL.md")
     tools_md = paths.resolve("TOOLS.md", override=None, seed="TOOLS.md")
     primer = paths.resolve("PRIMER.md", override=None, seed="PRIMER.md")
     return {
-        "cwd": str(Path.cwd().resolve()),
+        "cwd": str(workspace.resolve()),
         "model": model,
         "session_id": session_id,
         "soul_path": str(soul),
@@ -270,6 +276,7 @@ def _render_report(report: BenchReport) -> str:
     lines.append(f"BENCH REPORT  scenario={report.scenario}")
     lines.append("=" * 60)
     lines.append(f"model:       {report.model}")
+    lines.append(f"workspace:   {report.workspace}")
     lines.append(f"session:     {report.session_id}")
     lines.append(f"reason:      {report.reason}")
     lines.append(
@@ -302,6 +309,7 @@ def _render_report(report: BenchReport) -> str:
         lines.append("tool_calls:  (none)")
     lines.append("")
     lines.append("To inspect this session in detail:")
+    lines.append(f"  cd {report.workspace}")
     lines.append(f"  pyagent-sessions audit {report.session_id}")
     return "\n".join(lines)
 
@@ -372,18 +380,33 @@ def run_cmd(
     _maybe_warn_opus(resolved_model, budget, no_budget)
     cap = None if no_budget else budget
 
+    # Each bench run gets a fresh tmpdir as its workspace. write_file
+    # calls in the scenario (e.g. "save the analysis to bench-output.md")
+    # land inside this dir and pass the workspace gate; the user's
+    # project dir stays clean across runs. The session and its
+    # attachments live under <tmpdir>/.pyagent/sessions/<id>/, so the
+    # parent and child agree on absolute paths even though they have
+    # different cwds at construction time.
+    workspace = Path(
+        tempfile.mkdtemp(prefix=f"pyagent-bench-{sc.name}-")
+    )
+    session_root = workspace / ".pyagent" / "sessions"
+
     # Mint the session up front so we can print + report the id even
     # if the child never reaches `ready`.
-    session = Session()
-    click.echo(f"[bench] scenario: {sc.name} ({sc.description})")
-    click.echo(f"[bench] model:    {resolved_model}")
-    click.echo(f"[bench] session:  {session.id}")
+    session = Session(root=session_root)
+    click.echo(f"[bench] scenario:  {sc.name} ({sc.description})")
+    click.echo(f"[bench] model:     {resolved_model}")
+    click.echo(f"[bench] workspace: {workspace}")
+    click.echo(f"[bench] session:   {session.id}")
     if cap is not None:
-        click.echo(f"[bench] budget:   ${cap:.2f}")
+        click.echo(f"[bench] budget:    ${cap:.2f}")
     else:
-        click.echo("[bench] budget:   (disabled)")
+        click.echo("[bench] budget:    (disabled)")
 
-    agent_config = _build_agent_config(resolved_model, session.id)
+    agent_config = _build_agent_config(
+        resolved_model, session.id, workspace
+    )
     state = _BenchState()
     started = time.monotonic()
 
@@ -479,6 +502,7 @@ def run_cmd(
             scenario=sc.name,
             model=resolved_model,
             session_id=session.id,
+            workspace=str(workspace.resolve()),
             reason=reason,
             prompts_run=prompts_run,
             prompts_total=len(sc.prompts),


### PR DESCRIPTION
## Summary

- The bench now mints a fresh `tempfile.mkdtemp` per run and uses it as the agent's cwd. Fixes a silent failure in `well_mako` where prompt 3's "save to /tmp/bench-output.md" was permission-denied (out-of-workspace) but the run still reported `complete`. The `well_mako` scenario was updated to ask for a relative filename, which now lands inside the workspace.
- New `seed_workspace_from` field on the scenario TOML format. When set, the bench `shutil.copytree`s that directory into the run's workspace before spawning the agent — so the agent operates on a snapshot, not the live source.
- New `pyagent_self_audit` scenario uses `seed_workspace_from = "cwd"` to point the agent at the pyagent codebase itself. Three prompts exercise grep / read_file / list_directory under realistic load (root-tool enumeration, auto_offload coverage, SOFT_THRESHOLD_FORCED_TOOLS evaluation). Reproducible (no network) and meaningfully cheaper than `well_mako`.
- The report grew a `workspace` field; the inspect-this-session hint now prints `cd <workspace>` before the audit invocation since `pyagent-sessions` resolves the sessions root from cwd.

## Test plan

- [ ] `pyagent-bench run well_mako --budget 0.5` — verify prompt 3 writes the file inside the workspace, no silent permission denial
- [ ] `pyagent-bench run pyagent_self_audit` — verify the agent operates on the snapshot (changes don't leak into the live tree)
- [ ] Verify report shows `workspace: <path>` and the inspect hint includes the `cd` prefix
- [ ] Back-to-back runs don't pollute the user's project dir