### PR TITLE
Roles: drop bundled tool allowlists, default to inherited toolset

### DIFF
--- a/pyagent/roles.py
+++ b/pyagent/roles.py
@@ -442,8 +442,8 @@ def catalog() -> str:
         "`spawn_subagent` (alongside raw provider/model strings). Role "
         "definitions live as markdown files under "
         "`pyagent/roles/`, `<config-dir>/roles/`, or `.pyagent/roles/`, "
-        "and pin the model, default persona, and tool restrictions for "
-        "that role.",
+        "and pin the model and default persona (with an optional tool "
+        "allowlist) for that role.",
         "",
     ]
     for role in sorted(roles.values(), key=lambda r: r.name):

--- a/pyagent/roles_bundled/RESEARCHER.md
+++ b/pyagent/roles_bundled/RESEARCHER.md
@@ -1,5 +1,4 @@
 +++
-tools = ["read_file", "grep", "list_directory", "fetch_url", "html_to_md", "html_select", "read_skill"]
 meta_tools = false
 description = "Investigates a question end-to-end: fetches sources, cross-references them, returns synthesized findings with citations."
 +++

--- a/pyagent/roles_bundled/REVIEWER.md
+++ b/pyagent/roles_bundled/REVIEWER.md
@@ -1,15 +1,14 @@
 +++
-tools = ["read_file", "grep", "list_directory", "read_skill"]
 meta_tools = false
-description = "Read-only critique of code or output. Identifies bugs, logic errors, and design problems without authority to fix them."
+description = "Critique of code or output. Identifies bugs, logic errors, and design problems; does not fix them."
 +++
 
 # Role: Reviewer
 
 You are a reviewer. The caller asks you to look over code, a
 proposed change, or a piece of output, and tell them what's wrong.
-You have no edit or execute authority — the only thing you can do is
-read and respond.
+Don't edit or execute — read, think, and respond. The caller will
+act on your verdict, not you.
 
 Lead with substance. Your first paragraph should name the most
 important problem you see, or state plainly that you didn't find

--- a/pyagent/roles_bundled/SCRIBE.md
+++ b/pyagent/roles_bundled/SCRIBE.md
@@ -1,7 +1,6 @@
 +++
-tools = ["read_file", "write_file", "edit_file", "list_directory", "grep", "read_skill"]
 meta_tools = false
-description = "Captures, organizes, and edits notes and documentation. Read/write file access; no execute authority."
+description = "Captures, organizes, and edits notes and documentation."
 +++
 
 # Role: Scribe


### PR DESCRIPTION
## Summary

- The bundled roles (`researcher`, `reviewer`, `scribe`) pinned closed `tools=` allowlists in their frontmatter. That meant any tool added later — including plugin tools — was silently locked out of those roles, and the allowlist was duplicating soft-scoping work the persona prompt already does.
- Strip `tools=` from the three bundled roles so they inherit the parent's full toolset (and any plugins). `tools=` stays in the schema as an opt-in hard fence for cases where capability restriction matters.
- Soften the catalog preamble and the reviewer persona body's "you have no edit or execute authority" line, since the persona is now the constraint, not the toolset.

## Test plan

- [x] `tests.smoke_roles_md` — passes (frontmatter parsing, tier precedence, catalog rendering, CLI subcommands).
- [x] `tests.smoke_roles` — passes through role load + resolve + `_build_subagent_config` + spawn-with-role + `set_model`. The pre-existing `test_register_tools_allowlist` assertion (expects 9 default tools, gets 8) fails on `main` too — unrelated to this change.
- [ ] Spawn a researcher/reviewer/scribe subagent in a real session and confirm the inherited toolset is what's expected.