### PR TITLE
code-mapper: language pack — Tier 1+2+3 (19 languages)

### DIFF
--- a/pyagent/plugins/code_mapper/queries/bash.scm
+++ b/pyagent/plugins/code_mapper/queries/bash.scm
@@ -1,0 +1,25 @@
+; Tags query for Bash.
+;
+; CUSTOM (not vendored): no upstream tags.scm exists for bash —
+; tree-sitter-bash ships highlights but not tags, and aider /
+; nvim-treesitter / tree-sitter-bash itself don't ship one. Companion
+; config: bash.toml.
+;
+; Bash's only meaningful "definition" is `function foo() { ... }`
+; or the equivalent `foo() { ... }` shorthand. We also capture
+; top-level variable assignments (KEY=value) since those are the
+; primary thing a shell-script outline cares about — they're the
+; configurable knobs.
+
+; Both `function foo { }` and `foo() { }` parse as function_definition
+; with name: word.
+(function_definition
+    name: (word) @name) @definition.function
+
+; Top-level variable assignments: KEY=value or KEY="..."
+; The grammar wraps every assignment in variable_assignment regardless
+; of nesting, so this matches every assignment in the file. That's
+; arguably noisy in a deeply nested script, but in practice shell
+; scripts have shallow nesting.
+(variable_assignment
+    name: (variable_name) @name) @definition.variable

--- a/pyagent/plugins/code_mapper/queries/bash.toml
+++ b/pyagent/plugins/code_mapper/queries/bash.toml
@@ -1,0 +1,16 @@
+# code-mapper language config — Bash.
+#
+# See ../EXTENDING.md for schema docs. Scalars MUST come before any
+# [table] / [[array_of_tables]] header.
+
+language = "bash"
+description = "Bash / shell scripts."
+extensions = [".sh", ".bash"]
+
+definition_node_types = [
+    "function_definition",
+]
+
+[captures]
+"definition.function" = "function"
+"definition.variable" = "variable"

--- a/pyagent/plugins/code_mapper/queries/css.scm
+++ b/pyagent/plugins/code_mapper/queries/css.scm
@@ -1,0 +1,26 @@
+; Tags query for CSS.
+;
+; CUSTOM (not vendored): no upstream tags.scm. Useful structure for
+; agents reading a stylesheet is the selector list — what rules
+; exist, by class / id / tag — and the @media / @keyframes / @font-face
+; at-rules. We capture top-level selectors and at-rule headers.
+; Companion config: css.toml.
+
+(class_selector
+    (class_name
+        (identifier) @name)) @definition.class_selector
+
+(id_selector
+    (id_name) @name) @definition.id_selector
+
+; @media (min-width: 600px) { ... }
+(media_statement
+    "@media" @name) @definition.at_rule
+
+; @keyframes spin { ... } — keyframes_name is positional, not a field.
+(keyframes_statement
+    (keyframes_name) @name) @definition.at_rule
+
+; @font-face { ... } and other at-rule headers.
+(at_rule
+    (at_keyword) @name) @definition.at_rule

--- a/pyagent/plugins/code_mapper/queries/css.toml
+++ b/pyagent/plugins/code_mapper/queries/css.toml
@@ -1,0 +1,16 @@
+# code-mapper language config — CSS.
+#
+# See ../EXTENDING.md for schema docs. Scalars MUST come before any
+# [table] / [[array_of_tables]] header.
+
+language = "css"
+description = "CSS stylesheets — selectors and at-rules."
+extensions = [".css"]
+
+definition_node_types = []
+
+[captures]
+"definition.class_selector" = "class_selector"
+"definition.id_selector" = "id_selector"
+"definition.tag_selector" = "tag_selector"
+"definition.at_rule" = "at_rule"

--- a/pyagent/plugins/code_mapper/queries/css.toml
+++ b/pyagent/plugins/code_mapper/queries/css.toml
@@ -12,5 +12,4 @@ definition_node_types = []
 [captures]
 "definition.class_selector" = "class_selector"
 "definition.id_selector" = "id_selector"
-"definition.tag_selector" = "tag_selector"
 "definition.at_rule" = "at_rule"

--- a/pyagent/plugins/code_mapper/queries/dockerfile.scm
+++ b/pyagent/plugins/code_mapper/queries/dockerfile.scm
@@ -1,0 +1,40 @@
+; Tags query for Dockerfile.
+;
+; CUSTOM (not vendored): no upstream tags.scm. Useful structure for
+; an agent reading a Dockerfile is the instruction list — what does
+; each line do — and the stage names in multi-stage builds. We emit
+; one symbol per instruction with kind=directive (name=instruction
+; keyword like "RUN" / "COPY"), plus a kind=stage symbol per
+; `FROM ... AS <name>` for quick stage navigation. Companion config:
+; dockerfile.toml.
+
+; Stage marker: `FROM image AS my-stage`. Capture the alias as @name
+; and the whole instruction as the def — agents use this to navigate
+; multi-stage builds.
+(from_instruction
+    as: (image_alias) @name) @definition.stage
+
+; FROM without AS still gets a directive entry (named "FROM").
+(from_instruction
+    "FROM" @name) @definition.directive
+
+; Each instruction type's keyword is an anonymous token; capture it
+; literally as @name. Per-instruction patterns rather than one big
+; alternation so a future grammar that adds a new instruction doesn't
+; silently break the query.
+(run_instruction "RUN" @name) @definition.directive
+(copy_instruction "COPY" @name) @definition.directive
+(workdir_instruction "WORKDIR" @name) @definition.directive
+(env_instruction "ENV" @name) @definition.directive
+(expose_instruction "EXPOSE" @name) @definition.directive
+(cmd_instruction "CMD" @name) @definition.directive
+(entrypoint_instruction "ENTRYPOINT" @name) @definition.directive
+(label_instruction "LABEL" @name) @definition.directive
+(user_instruction "USER" @name) @definition.directive
+(arg_instruction "ARG" @name) @definition.directive
+(volume_instruction "VOLUME" @name) @definition.directive
+(shell_instruction "SHELL" @name) @definition.directive
+(onbuild_instruction "ONBUILD" @name) @definition.directive
+(healthcheck_instruction "HEALTHCHECK" @name) @definition.directive
+(add_instruction "ADD" @name) @definition.directive
+(maintainer_instruction "MAINTAINER" @name) @definition.directive

--- a/pyagent/plugins/code_mapper/queries/dockerfile.toml
+++ b/pyagent/plugins/code_mapper/queries/dockerfile.toml
@@ -1,0 +1,14 @@
+# code-mapper language config — Dockerfile.
+#
+# See ../EXTENDING.md for schema docs. Scalars MUST come before any
+# [table] / [[array_of_tables]] header.
+
+language = "dockerfile"
+description = "Dockerfiles — instructions and stage markers."
+extensions = [".dockerfile"]
+
+definition_node_types = []
+
+[captures]
+"definition.directive" = "directive"
+"definition.stage" = "stage"

--- a/pyagent/plugins/code_mapper/queries/go.scm
+++ b/pyagent/plugins/code_mapper/queries/go.scm
@@ -1,0 +1,51 @@
+; Tags query for Go.
+;
+; Source: Aider-AI/aider @ 3ec8ec5a7d695b08a6c24fe6c0c235c8f87df9af
+;   aider/queries/tree-sitter-language-pack/go-tags.scm
+;   https://github.com/Aider-AI/aider/blob/main/aider/queries/tree-sitter-language-pack/go-tags.scm
+; License: Apache-2.0
+;
+; Companion config: go.toml.
+;
+; DEVIATION FROM UPSTREAM: aider's queries use `@name.definition.X`
+; plus `(#strip!)` / `(#set-adjacent!)` doc-comment predicates. We
+; rewrite to bare `@name` and drop the @doc/predicate scaffolding.
+; The blanket `(type_identifier) @name.reference.type @reference.type`
+; capture is dropped — it fires on every type identifier in the file
+; and produces an unusable amount of "type" noise for an outline.
+; Per-call-site @reference.call captures are also dropped.
+
+(function_declaration
+    name: (identifier) @name) @definition.function
+
+(method_declaration
+    name: (field_identifier) @name) @definition.method
+
+; struct → kind="struct" (mapped via go.toml's @definition.class slot,
+; which we re-purpose here since Go doesn't have classes proper).
+(type_declaration
+    (type_spec
+        name: (type_identifier) @name
+        type: (struct_type))) @definition.class
+
+(type_declaration
+    (type_spec
+        name: (type_identifier) @name
+        type: (interface_type))) @definition.interface
+
+; Other type aliases (function types, slices, maps, named scalar types).
+(type_spec
+    name: (type_identifier) @name
+    type: [(function_type) (slice_type) (map_type) (pointer_type) (array_type) (channel_type) (qualified_type) (type_identifier)]) @definition.type
+
+(package_clause
+    "package"
+    (package_identifier) @name) @definition.module
+
+(var_declaration
+    (var_spec
+        name: (identifier) @name)) @definition.variable
+
+(const_declaration
+    (const_spec
+        name: (identifier) @name)) @definition.constant

--- a/pyagent/plugins/code_mapper/queries/go.toml
+++ b/pyagent/plugins/code_mapper/queries/go.toml
@@ -1,0 +1,25 @@
+# code-mapper language config — Go.
+#
+# See ../EXTENDING.md for schema docs. Scalars MUST come before any
+# [table] / [[array_of_tables]] header.
+
+language = "go"
+description = "Go source files."
+extensions = [".go"]
+
+definition_node_types = [
+    "function_declaration",
+    "method_declaration",
+    "type_declaration",
+    "type_spec",
+]
+
+[captures]
+"definition.function" = "function"
+"definition.method" = "method"
+"definition.type" = "type"
+"definition.class" = "struct"
+"definition.interface" = "interface"
+"definition.module" = "module"
+"definition.variable" = "variable"
+"definition.constant" = "constant"

--- a/pyagent/plugins/code_mapper/queries/java.scm
+++ b/pyagent/plugins/code_mapper/queries/java.scm
@@ -1,0 +1,40 @@
+; Tags query for Java.
+;
+; Source: Aider-AI/aider @ 3ec8ec5a7d695b08a6c24fe6c0c235c8f87df9af
+;   aider/queries/tree-sitter-language-pack/java-tags.scm
+;   https://github.com/Aider-AI/aider/blob/main/aider/queries/tree-sitter-language-pack/java-tags.scm
+; License: Apache-2.0
+;
+; Companion config: java.toml.
+;
+; DEVIATION FROM UPSTREAM: aider's queries use `@name.definition.X`;
+; we rewrite to bare `@name`. Per-call-site / per-type-reference
+; captures (method_invocation, object_creation_expression, superclass)
+; are dropped — too noisy for an outline. Added enum / record /
+; annotation_type / constructor / field captures that aider's spec
+; omits.
+
+(class_declaration
+    name: (identifier) @name) @definition.class
+
+(interface_declaration
+    name: (identifier) @name) @definition.interface
+
+(enum_declaration
+    name: (identifier) @name) @definition.enum
+
+(record_declaration
+    name: (identifier) @name) @definition.record
+
+(annotation_type_declaration
+    name: (identifier) @name) @definition.annotation
+
+(method_declaration
+    name: (identifier) @name) @definition.method
+
+(constructor_declaration
+    name: (identifier) @name) @definition.constructor
+
+(field_declaration
+    declarator: (variable_declarator
+        name: (identifier) @name)) @definition.field

--- a/pyagent/plugins/code_mapper/queries/java.toml
+++ b/pyagent/plugins/code_mapper/queries/java.toml
@@ -1,0 +1,28 @@
+# code-mapper language config — Java.
+#
+# See ../EXTENDING.md for schema docs. Scalars MUST come before any
+# [table] / [[array_of_tables]] header.
+
+language = "java"
+description = "Java source files."
+extensions = [".java"]
+
+definition_node_types = [
+    "class_declaration",
+    "interface_declaration",
+    "enum_declaration",
+    "record_declaration",
+    "annotation_type_declaration",
+    "method_declaration",
+    "constructor_declaration",
+]
+
+[captures]
+"definition.class" = "class"
+"definition.interface" = "interface"
+"definition.enum" = "enum"
+"definition.record" = "record"
+"definition.annotation" = "annotation"
+"definition.method" = "method"
+"definition.constructor" = "constructor"
+"definition.field" = "field"

--- a/pyagent/plugins/code_mapper/queries/javascript.scm
+++ b/pyagent/plugins/code_mapper/queries/javascript.scm
@@ -1,0 +1,54 @@
+; Tags query for JavaScript.
+;
+; Source: Aider-AI/aider @ 3ec8ec5a7d695b08a6c24fe6c0c235c8f87df9af
+;   aider/queries/tree-sitter-language-pack/javascript-tags.scm
+;   https://github.com/Aider-AI/aider/blob/main/aider/queries/tree-sitter-language-pack/javascript-tags.scm
+; License: Apache-2.0
+;
+; Companion config: javascript.toml.
+;
+; DEVIATION FROM UPSTREAM: aider's queries use `@name.definition.X`
+; and ship `(#strip!)` / `(#select-adjacent!)` predicates for doc-
+; comment association. Our loader expects bare `@name` and doesn't
+; implement those predicates, so captures are simplified and the
+; @doc / predicate scaffolding is dropped. Per-call-site
+; @reference.call captures are also dropped (excessive noise for
+; symbol outlines; aider uses them for repo-map ranking).
+
+(method_definition
+    name: (property_identifier) @name) @definition.method
+
+(class
+    name: (_) @name) @definition.class
+
+(class_declaration
+    name: (_) @name) @definition.class
+
+(function_expression
+    name: (identifier) @name) @definition.function
+
+(function_declaration
+    name: (identifier) @name) @definition.function
+
+(generator_function
+    name: (identifier) @name) @definition.function
+
+(generator_function_declaration
+    name: (identifier) @name) @definition.function
+
+; Top-level `const x = () => ...` / `var x = function() {}` shapes
+; — the modern idiom for "this is a function" in modules.
+(lexical_declaration
+    (variable_declarator
+        name: (identifier) @name
+        value: [(arrow_function) (function_expression)])) @definition.function
+
+(variable_declaration
+    (variable_declarator
+        name: (identifier) @name
+        value: [(arrow_function) (function_expression)])) @definition.function
+
+; Object-literal method shorthand: `{ key: () => {} }`.
+(pair
+    key: (property_identifier) @name
+    value: [(arrow_function) (function_expression)]) @definition.function

--- a/pyagent/plugins/code_mapper/queries/javascript.toml
+++ b/pyagent/plugins/code_mapper/queries/javascript.toml
@@ -1,0 +1,24 @@
+# code-mapper language config — JavaScript.
+#
+# See ../EXTENDING.md for schema docs. Scalars MUST come before any
+# [table] / [[array_of_tables]] header.
+
+language = "javascript"
+description = "JavaScript and JSX source files."
+extensions = [".js", ".mjs", ".cjs", ".jsx"]
+
+definition_node_types = [
+    "class",
+    "class_declaration",
+    "function_declaration",
+    "function_expression",
+    "generator_function",
+    "generator_function_declaration",
+    "method_definition",
+    "arrow_function",
+]
+
+[captures]
+"definition.class" = "class"
+"definition.function" = "function"
+"definition.method" = "method"

--- a/pyagent/plugins/code_mapper/queries/json.scm
+++ b/pyagent/plugins/code_mapper/queries/json.scm
@@ -1,0 +1,12 @@
+; Tags query for JSON.
+;
+; CUSTOM (not vendored): JSON has no upstream tags.scm — the grammar
+; is too small for a "tags" concept to make sense in the GitHub
+; code-nav sense. We capture every `pair` (object key/value) so the
+; agent gets an outline of the document's keys at every depth, which
+; is the primary navigational structure in a JSON config file.
+; Companion config: json.toml.
+
+(pair
+    key: (string
+        (string_content) @name)) @definition.field

--- a/pyagent/plugins/code_mapper/queries/json.toml
+++ b/pyagent/plugins/code_mapper/queries/json.toml
@@ -1,0 +1,18 @@
+# code-mapper language config — JSON.
+#
+# See ../EXTENDING.md for schema docs. Scalars MUST come before any
+# [table] / [[array_of_tables]] header.
+
+language = "json"
+description = "JSON documents — top-level keys captured as fields."
+extensions = [".json"]
+
+# Only `pair` is a parent anchor — putting `object` here would stop
+# the walk at the immediate enclosing object (which has no name in
+# def_name_index), so nested keys would lose their parent. With just
+# `pair`, the walk passes through the object up to the next pair,
+# whose @name is in the index.
+definition_node_types = ["pair"]
+
+[captures]
+"definition.field" = "field"

--- a/pyagent/plugins/code_mapper/queries/kotlin.scm
+++ b/pyagent/plugins/code_mapper/queries/kotlin.scm
@@ -1,0 +1,22 @@
+; Tags query for Kotlin.
+;
+; Source: Aider-AI/aider @ 3ec8ec5a7d695b08a6c24fe6c0c235c8f87df9af
+;   aider/queries/tree-sitter-languages/kotlin-tags.scm
+;   https://github.com/Aider-AI/aider/blob/main/aider/queries/tree-sitter-languages/kotlin-tags.scm
+; License: Apache-2.0
+;
+; Companion config: kotlin.toml.
+;
+; DEVIATION FROM UPSTREAM: aider's queries use `@name.definition.X`;
+; we rewrite to bare `@name`. The `delegation_specifier` and
+; per-call-site `call_expression` reference patterns are dropped —
+; too noisy for an outline.
+
+(class_declaration
+    (type_identifier) @name) @definition.class
+
+(object_declaration
+    (type_identifier) @name) @definition.object
+
+(function_declaration
+    (simple_identifier) @name) @definition.function

--- a/pyagent/plugins/code_mapper/queries/kotlin.toml
+++ b/pyagent/plugins/code_mapper/queries/kotlin.toml
@@ -1,0 +1,26 @@
+# code-mapper language config — Kotlin.
+#
+# See ../EXTENDING.md for schema docs. Scalars MUST come before any
+# [table] / [[array_of_tables]] header.
+
+language = "kotlin"
+description = "Kotlin source files."
+extensions = [".kt", ".kts"]
+
+definition_node_types = [
+    "class_declaration",
+    "object_declaration",
+    "function_declaration",
+]
+
+[captures]
+"definition.class" = "class"
+"definition.object" = "object"
+"definition.function" = "function"
+"definition.method" = "method"
+
+# Functions inside a class body are methods.
+[[promote]]
+from = "function"
+to = "method"
+when_inside = ["class_declaration", "object_declaration"]

--- a/pyagent/plugins/code_mapper/queries/lua.scm
+++ b/pyagent/plugins/code_mapper/queries/lua.scm
@@ -1,0 +1,43 @@
+; Tags query for Lua.
+;
+; Source: Aider-AI/aider @ 3ec8ec5a7d695b08a6c24fe6c0c235c8f87df9af
+;   aider/queries/tree-sitter-language-pack/lua-tags.scm
+;   https://github.com/Aider-AI/aider/blob/main/aider/queries/tree-sitter-language-pack/lua-tags.scm
+; License: Apache-2.0
+;
+; Companion config: lua.toml.
+;
+; DEVIATION FROM UPSTREAM: aider's queries use `@name.definition.X`;
+; we rewrite to bare `@name`. The function_call reference patterns
+; are dropped — too noisy for a symbol outline.
+
+; Plain `function foo()` and `function t.foo()` (dot-indexed
+; assignment to a table field).
+(function_declaration
+    name: [
+        (identifier) @name
+        (dot_index_expression
+            field: (identifier) @name)
+    ]) @definition.function
+
+; Method shorthand: `function obj:method()`.
+(function_declaration
+    name: (method_index_expression
+        method: (identifier) @name)) @definition.method
+
+; `local f = function() ... end` and `t.f = function() ... end`.
+(assignment_statement
+    (variable_list
+        name: [
+            (identifier) @name
+            (dot_index_expression
+                field: (identifier) @name)
+        ])
+    (expression_list
+        value: (function_definition))) @definition.function
+
+; Table-literal entries that bind a function: `{ key = function() end }`.
+(table_constructor
+    (field
+        name: (identifier) @name
+        value: (function_definition))) @definition.function

--- a/pyagent/plugins/code_mapper/queries/lua.toml
+++ b/pyagent/plugins/code_mapper/queries/lua.toml
@@ -1,0 +1,17 @@
+# code-mapper language config — Lua.
+#
+# See ../EXTENDING.md for schema docs. Scalars MUST come before any
+# [table] / [[array_of_tables]] header.
+
+language = "lua"
+description = "Lua source files."
+extensions = [".lua"]
+
+definition_node_types = [
+    "function_declaration",
+    "function_definition",
+]
+
+[captures]
+"definition.function" = "function"
+"definition.method" = "method"

--- a/pyagent/plugins/code_mapper/queries/markdown.scm
+++ b/pyagent/plugins/code_mapper/queries/markdown.scm
@@ -1,0 +1,19 @@
+; Tags query for Markdown.
+;
+; CUSTOM (not vendored): no upstream tags.scm. The useful structure
+; for an agent navigating a markdown doc is the heading hierarchy
+; (H1, H2, H3), not body text. We capture only ATX-style headings
+; (`#`, `##`, `###`); H4-H6 are intentionally skipped to keep the
+; outline scannable in long docs. Companion config: markdown.toml.
+
+(atx_heading
+    (atx_h1_marker)
+    heading_content: (inline) @name) @definition.heading
+
+(atx_heading
+    (atx_h2_marker)
+    heading_content: (inline) @name) @definition.heading
+
+(atx_heading
+    (atx_h3_marker)
+    heading_content: (inline) @name) @definition.heading

--- a/pyagent/plugins/code_mapper/queries/markdown.toml
+++ b/pyagent/plugins/code_mapper/queries/markdown.toml
@@ -1,0 +1,14 @@
+# code-mapper language config — Markdown.
+#
+# See ../EXTENDING.md for schema docs. Scalars MUST come before any
+# [table] / [[array_of_tables]] header.
+
+language = "markdown"
+description = "Markdown documents — H1-H3 headings as outline."
+extensions = [".md", ".markdown"]
+
+# Section nesting follows H1 > H2 > H3 in the markdown grammar.
+definition_node_types = ["section"]
+
+[captures]
+"definition.heading" = "heading"

--- a/pyagent/plugins/code_mapper/queries/php.scm
+++ b/pyagent/plugins/code_mapper/queries/php.scm
@@ -1,0 +1,35 @@
+; Tags query for PHP.
+;
+; Source: Aider-AI/aider @ 3ec8ec5a7d695b08a6c24fe6c0c235c8f87df9af
+;   aider/queries/tree-sitter-languages/php-tags.scm
+;   https://github.com/Aider-AI/aider/blob/main/aider/queries/tree-sitter-languages/php-tags.scm
+; License: Apache-2.0
+;
+; Companion config: php.toml.
+;
+; DEVIATION FROM UPSTREAM: aider's queries use `@name.definition.X`;
+; we rewrite to bare `@name`. Aider also collapses
+; method_declaration under @definition.function — we keep them
+; distinct as @definition.method. Per-call-site reference captures
+; (function_call_expression, scoped_call_expression,
+; member_call_expression, object_creation_expression) are dropped.
+; Added interface_declaration, trait_declaration, enum_declaration
+; that aider's spec omits.
+
+(class_declaration
+    name: (name) @name) @definition.class
+
+(interface_declaration
+    name: (name) @name) @definition.interface
+
+(trait_declaration
+    name: (name) @name) @definition.trait
+
+(enum_declaration
+    name: (name) @name) @definition.enum
+
+(function_definition
+    name: (name) @name) @definition.function
+
+(method_declaration
+    name: (name) @name) @definition.method

--- a/pyagent/plugins/code_mapper/queries/php.toml
+++ b/pyagent/plugins/code_mapper/queries/php.toml
@@ -1,0 +1,25 @@
+# code-mapper language config — PHP.
+#
+# See ../EXTENDING.md for schema docs. Scalars MUST come before any
+# [table] / [[array_of_tables]] header.
+
+language = "php"
+description = "PHP source files."
+extensions = [".php"]
+
+definition_node_types = [
+    "class_declaration",
+    "interface_declaration",
+    "trait_declaration",
+    "enum_declaration",
+    "method_declaration",
+    "function_definition",
+]
+
+[captures]
+"definition.class" = "class"
+"definition.interface" = "interface"
+"definition.trait" = "trait"
+"definition.enum" = "enum"
+"definition.function" = "function"
+"definition.method" = "method"

--- a/pyagent/plugins/code_mapper/queries/ruby.scm
+++ b/pyagent/plugins/code_mapper/queries/ruby.scm
@@ -1,0 +1,45 @@
+; Tags query for Ruby.
+;
+; Source: Aider-AI/aider @ 3ec8ec5a7d695b08a6c24fe6c0c235c8f87df9af
+;   aider/queries/tree-sitter-language-pack/ruby-tags.scm
+;   https://github.com/Aider-AI/aider/blob/main/aider/queries/tree-sitter-language-pack/ruby-tags.scm
+; License: Apache-2.0
+;
+; Companion config: ruby.toml.
+;
+; DEVIATION FROM UPSTREAM: aider's queries use `@name.definition.X`
+; with `(#strip!)`/`(#select-adjacent!)` doc-comment predicates and
+; per-identifier `@reference.call` captures (using `(#is-not? local)`,
+; which our loader does not implement). Captures are rewritten to
+; bare `@name` and the @doc/predicate scaffolding plus the noisy
+; reference patterns are dropped.
+
+(method
+    name: (_) @name) @definition.method
+
+(singleton_method
+    name: (_) @name) @definition.method
+
+(alias
+    name: (_) @name) @definition.method
+
+(class
+    name: [
+        (constant) @name
+        (scope_resolution
+            name: (_) @name)
+    ]) @definition.class
+
+(singleton_class
+    value: [
+        (constant) @name
+        (scope_resolution
+            name: (_) @name)
+    ]) @definition.class
+
+(module
+    name: [
+        (constant) @name
+        (scope_resolution
+            name: (_) @name)
+    ]) @definition.module

--- a/pyagent/plugins/code_mapper/queries/ruby.toml
+++ b/pyagent/plugins/code_mapper/queries/ruby.toml
@@ -1,0 +1,21 @@
+# code-mapper language config — Ruby.
+#
+# See ../EXTENDING.md for schema docs. Scalars MUST come before any
+# [table] / [[array_of_tables]] header.
+
+language = "ruby"
+description = "Ruby source files."
+extensions = [".rb"]
+
+definition_node_types = [
+    "class",
+    "singleton_class",
+    "module",
+    "method",
+    "singleton_method",
+]
+
+[captures]
+"definition.class" = "class"
+"definition.module" = "module"
+"definition.method" = "method"

--- a/pyagent/plugins/code_mapper/queries/scala.scm
+++ b/pyagent/plugins/code_mapper/queries/scala.scm
@@ -1,0 +1,59 @@
+; Tags query for Scala.
+;
+; Source: Aider-AI/aider @ 3ec8ec5a7d695b08a6c24fe6c0c235c8f87df9af
+;   aider/queries/tree-sitter-languages/scala-tags.scm
+;   https://github.com/Aider-AI/aider/blob/main/aider/queries/tree-sitter-languages/scala-tags.scm
+; License: Apache-2.0
+;
+; Companion config: scala.toml.
+;
+; DEVIATION FROM UPSTREAM: aider's queries use `@name.definition.X`;
+; we rewrite to bare `@name`. Per-call-site / per-type reference
+; captures (call_expression, instance_expression, extends_clause)
+; are dropped — too noisy for a symbol outline.
+
+(package_clause
+    name: (package_identifier) @name) @definition.module
+
+(trait_definition
+    name: (identifier) @name) @definition.interface
+
+(enum_definition
+    name: (identifier) @name) @definition.enum
+
+(simple_enum_case
+    name: (identifier) @name) @definition.class
+
+(full_enum_case
+    name: (identifier) @name) @definition.class
+
+(class_definition
+    name: (identifier) @name) @definition.class
+
+(object_definition
+    name: (identifier) @name) @definition.object
+
+(function_definition
+    name: (identifier) @name) @definition.function
+
+; Abstract methods in traits are function_declaration (no body).
+(function_declaration
+    name: (identifier) @name) @definition.function
+
+(val_definition
+    pattern: (identifier) @name) @definition.variable
+
+(var_definition
+    pattern: (identifier) @name) @definition.variable
+
+(val_declaration
+    name: (identifier) @name) @definition.variable
+
+(var_declaration
+    name: (identifier) @name) @definition.variable
+
+(type_definition
+    name: (type_identifier) @name) @definition.type
+
+(class_parameter
+    name: (identifier) @name) @definition.property

--- a/pyagent/plugins/code_mapper/queries/scala.toml
+++ b/pyagent/plugins/code_mapper/queries/scala.toml
@@ -1,0 +1,35 @@
+# code-mapper language config — Scala.
+#
+# See ../EXTENDING.md for schema docs. Scalars MUST come before any
+# [table] / [[array_of_tables]] header.
+
+language = "scala"
+description = "Scala source files."
+extensions = [".scala", ".sc"]
+
+definition_node_types = [
+    "class_definition",
+    "object_definition",
+    "trait_definition",
+    "enum_definition",
+    "function_definition",
+    "function_declaration",
+    "package_clause",
+]
+
+[captures]
+"definition.module" = "module"
+"definition.class" = "class"
+"definition.object" = "object"
+"definition.interface" = "trait"
+"definition.enum" = "enum"
+"definition.function" = "function"
+"definition.method" = "method"
+"definition.type" = "type"
+"definition.variable" = "variable"
+"definition.property" = "property"
+
+[[promote]]
+from = "function"
+to = "method"
+when_inside = ["class_definition", "object_definition", "trait_definition"]

--- a/pyagent/plugins/code_mapper/queries/sql.scm
+++ b/pyagent/plugins/code_mapper/queries/sql.scm
@@ -1,0 +1,44 @@
+; Tags query for SQL.
+;
+; CUSTOM (not vendored): no upstream tags.scm. The useful structure
+; for an agent reading SQL is the schema-defining statements
+; (CREATE TABLE / VIEW / INDEX / FUNCTION / PROCEDURE / TRIGGER /
+; SCHEMA). Per-SELECT references are intentionally omitted — they
+; would dwarf real definitions in any non-trivial query file.
+; Companion config: sql.toml.
+
+(create_table
+    (object_reference
+        name: (identifier) @name)) @definition.table
+
+(create_view
+    (object_reference
+        name: (identifier) @name)) @definition.view
+
+; create_index puts the index name as a positional `column:` field on
+; the create_index node itself, not inside an object_reference.
+(create_index
+    column: (identifier) @name) @definition.index
+
+(create_function
+    (object_reference
+        name: (identifier) @name)) @definition.function
+
+(create_procedure
+    (object_reference
+        name: (identifier) @name)) @definition.procedure
+
+; create_trigger has multiple object_references (the trigger name,
+; the target table, optionally the executed function). The trigger
+; name is the one DIRECTLY after `keyword_trigger`; we match that
+; via positional anchoring with the keyword_trigger immediately
+; preceding.
+(create_trigger
+    (keyword_trigger)
+    .
+    (object_reference
+        name: (identifier) @name)) @definition.trigger
+
+; create_schema's name is a bare identifier child.
+(create_schema
+    (identifier) @name) @definition.schema

--- a/pyagent/plugins/code_mapper/queries/sql.toml
+++ b/pyagent/plugins/code_mapper/queries/sql.toml
@@ -1,0 +1,19 @@
+# code-mapper language config — SQL.
+#
+# See ../EXTENDING.md for schema docs. Scalars MUST come before any
+# [table] / [[array_of_tables]] header.
+
+language = "sql"
+description = "SQL — table / view / index / function definitions."
+extensions = [".sql"]
+
+definition_node_types = []
+
+[captures]
+"definition.table" = "table"
+"definition.view" = "view"
+"definition.index" = "index"
+"definition.function" = "function"
+"definition.procedure" = "procedure"
+"definition.trigger" = "trigger"
+"definition.schema" = "schema"

--- a/pyagent/plugins/code_mapper/queries/swift.scm
+++ b/pyagent/plugins/code_mapper/queries/swift.scm
@@ -1,0 +1,31 @@
+; Tags query for Swift.
+;
+; Source: Aider-AI/aider @ 3ec8ec5a7d695b08a6c24fe6c0c235c8f87df9af
+;   aider/queries/tree-sitter-language-pack/swift-tags.scm
+;   https://github.com/Aider-AI/aider/blob/main/aider/queries/tree-sitter-language-pack/swift-tags.scm
+; License: Apache-2.0
+;
+; Companion config: swift.toml.
+;
+; DEVIATION FROM UPSTREAM: aider's queries use `@name.definition.X`
+; (rewritten to bare `@name` here) and emit duplicate symbols for
+; in-class function_declarations (once via the class_body wrapper as
+; @definition.method, once via the bare function_declaration pattern
+; as @definition.function). We drop the wrapper patterns and rely on
+; swift.toml's promote rule to upgrade in-class functions to methods,
+; matching the C++ approach.
+
+(class_declaration
+    name: (type_identifier) @name) @definition.class
+
+(protocol_declaration
+    name: (type_identifier) @name) @definition.interface
+
+(protocol_function_declaration
+    name: (simple_identifier) @name) @definition.method
+
+(property_declaration
+    (pattern (simple_identifier) @name)) @definition.property
+
+(function_declaration
+    name: (simple_identifier) @name) @definition.function

--- a/pyagent/plugins/code_mapper/queries/swift.toml
+++ b/pyagent/plugins/code_mapper/queries/swift.toml
@@ -1,0 +1,28 @@
+# code-mapper language config — Swift.
+#
+# See ../EXTENDING.md for schema docs. Scalars MUST come before any
+# [table] / [[array_of_tables]] header.
+
+language = "swift"
+description = "Swift source files."
+extensions = [".swift"]
+
+definition_node_types = [
+    "class_declaration",
+    "protocol_declaration",
+    "function_declaration",
+    "protocol_function_declaration",
+]
+
+[captures]
+"definition.class" = "class"
+"definition.interface" = "interface"
+"definition.method" = "method"
+"definition.function" = "function"
+"definition.property" = "property"
+
+# Functions defined inside a class body are methods.
+[[promote]]
+from = "function"
+to = "method"
+when_inside = ["class_declaration"]

--- a/pyagent/plugins/code_mapper/queries/toml.scm
+++ b/pyagent/plugins/code_mapper/queries/toml.scm
@@ -1,0 +1,33 @@
+; Tags query for TOML.
+;
+; CUSTOM (not vendored): TOML has no upstream tags.scm. We capture
+; section headers (`[section]` and `[[array.of.tables]]`) as modules
+; and pairs as fields. The mapper attributes child fields to their
+; enclosing section via parent-walk. Companion config: toml.toml.
+
+; [section] header — bare_key directly under a `table` parent.
+(table
+    (bare_key) @name) @definition.module
+
+; [section.subsection] dotted-key header — capture the whole
+; dotted_key span as the name.
+(table
+    (dotted_key) @name) @definition.module
+
+; [[array.of.tables]] header (and its dotted variant).
+(table_array_element
+    (bare_key) @name) @definition.module
+
+(table_array_element
+    (dotted_key) @name) @definition.module
+
+; Top-level or in-section key/value pairs.
+(pair
+    (bare_key) @name) @definition.field
+
+; Dotted/quoted keys (`a.b.c = 1`, `"key" = 1`).
+(pair
+    (dotted_key) @name) @definition.field
+
+(pair
+    (quoted_key) @name) @definition.field

--- a/pyagent/plugins/code_mapper/queries/toml.toml
+++ b/pyagent/plugins/code_mapper/queries/toml.toml
@@ -1,0 +1,17 @@
+# code-mapper language config — TOML.
+#
+# See ../EXTENDING.md for schema docs. Scalars MUST come before any
+# [table] / [[array_of_tables]] header.
+
+language = "toml"
+description = "TOML documents — section headers and top-level keys."
+extensions = [".toml"]
+
+# `table` and `table_array_element` are the section anchors. The
+# enclosing-walk uses them to attribute child keys to the section
+# they're declared under.
+definition_node_types = ["table", "table_array_element"]
+
+[captures]
+"definition.module" = "module"
+"definition.field" = "field"

--- a/pyagent/plugins/code_mapper/queries/tsx.scm
+++ b/pyagent/plugins/code_mapper/queries/tsx.scm
@@ -1,0 +1,49 @@
+; Tags query for TSX (TypeScript + JSX).
+;
+; CUSTOM (not vendored): no upstream tags.scm exists for tsx —
+; tree-sitter-typescript ships only highlights/locals/injections, and
+; aider/nvim-treesitter ship typescript-tags but not tsx-tags. The
+; tsx grammar uses the same node types as typescript, so this file
+; mirrors typescript.scm verbatim. Companion config: tsx.toml.
+; License (style/conventions): Apache-2.0 (matches typescript.scm
+; lineage).
+
+(function_declaration
+    name: (identifier) @name) @definition.function
+
+(method_definition
+    name: (property_identifier) @name) @definition.method
+
+(abstract_method_signature
+    name: (property_identifier) @name) @definition.method
+
+(method_signature
+    name: (property_identifier) @name) @definition.method
+
+(function_signature
+    name: (identifier) @name) @definition.function
+
+(class_declaration
+    name: (type_identifier) @name) @definition.class
+
+(abstract_class_declaration
+    name: (type_identifier) @name) @definition.class
+
+(interface_declaration
+    name: (type_identifier) @name) @definition.interface
+
+(enum_declaration
+    name: (identifier) @name) @definition.enum
+
+(type_alias_declaration
+    name: (type_identifier) @name) @definition.type
+
+(internal_module
+    name: (identifier) @name) @definition.module
+
+; Top-level arrow / function-expression bound to const/let — the
+; canonical React component shape.
+(lexical_declaration
+    (variable_declarator
+        name: (identifier) @name
+        value: [(arrow_function) (function_expression)])) @definition.function

--- a/pyagent/plugins/code_mapper/queries/tsx.toml
+++ b/pyagent/plugins/code_mapper/queries/tsx.toml
@@ -1,0 +1,27 @@
+# code-mapper language config — TSX (TypeScript + JSX).
+#
+# See ../EXTENDING.md for schema docs. Scalars MUST come before any
+# [table] / [[array_of_tables]] header.
+
+language = "tsx"
+description = "TypeScript JSX (React) source files."
+extensions = [".tsx"]
+
+definition_node_types = [
+    "class_declaration",
+    "abstract_class_declaration",
+    "interface_declaration",
+    "enum_declaration",
+    "module",
+    "function_declaration",
+    "method_definition",
+]
+
+[captures]
+"definition.class" = "class"
+"definition.interface" = "interface"
+"definition.enum" = "enum"
+"definition.module" = "module"
+"definition.type" = "type"
+"definition.function" = "function"
+"definition.method" = "method"

--- a/pyagent/plugins/code_mapper/queries/typescript.scm
+++ b/pyagent/plugins/code_mapper/queries/typescript.scm
@@ -1,0 +1,58 @@
+; Tags query for TypeScript.
+;
+; Source: Aider-AI/aider @ 3ec8ec5a7d695b08a6c24fe6c0c235c8f87df9af
+;   aider/queries/tree-sitter-languages/typescript-tags.scm
+;   https://github.com/Aider-AI/aider/blob/main/aider/queries/tree-sitter-languages/typescript-tags.scm
+; License: Apache-2.0
+;
+; Companion config: typescript.toml.
+;
+; DEVIATION FROM UPSTREAM: aider's queries use the GitHub-tags
+; convention `@name.definition.X` and `@reference.X`. This loader
+; expects bare `@name` and a single `@definition.X` / `@reference.X`
+; per match, so we rewrite captures accordingly. Reference patterns
+; that emit per-identifier noise (every type annotation, every
+; new_expression target) are dropped — too noisy for a symbol
+; outline. Upstream also collapses interface_declaration under both
+; @definition.interface and @definition.class; we keep only the
+; interface tag.
+
+(function_declaration
+    name: (identifier) @name) @definition.function
+
+(method_definition
+    name: (property_identifier) @name) @definition.method
+
+(abstract_method_signature
+    name: (property_identifier) @name) @definition.method
+
+(method_signature
+    name: (property_identifier) @name) @definition.method
+
+(function_signature
+    name: (identifier) @name) @definition.function
+
+(class_declaration
+    name: (type_identifier) @name) @definition.class
+
+(abstract_class_declaration
+    name: (type_identifier) @name) @definition.class
+
+(interface_declaration
+    name: (type_identifier) @name) @definition.interface
+
+(enum_declaration
+    name: (identifier) @name) @definition.enum
+
+(type_alias_declaration
+    name: (type_identifier) @name) @definition.type
+
+(internal_module
+    name: (identifier) @name) @definition.module
+
+; Top-level arrow function / function-expression bound to a const/let.
+;   const handler = () => { ... }
+(lexical_declaration
+    (variable_declarator
+        name: (identifier) @name
+        value: [(arrow_function) (function_expression)])) @definition.function

--- a/pyagent/plugins/code_mapper/queries/typescript.toml
+++ b/pyagent/plugins/code_mapper/queries/typescript.toml
@@ -1,0 +1,28 @@
+# code-mapper language config — TypeScript.
+#
+# See ../EXTENDING.md for schema docs. Scalars MUST come before any
+# [table] / [[array_of_tables]] header.
+
+language = "typescript"
+description = "TypeScript source files (non-JSX)."
+extensions = [".ts", ".mts", ".cts"]
+
+# Definition node types we walk through during parent attribution.
+definition_node_types = [
+    "class_declaration",
+    "abstract_class_declaration",
+    "interface_declaration",
+    "enum_declaration",
+    "module",
+    "function_declaration",
+    "method_definition",
+]
+
+[captures]
+"definition.class" = "class"
+"definition.interface" = "interface"
+"definition.enum" = "enum"
+"definition.module" = "module"
+"definition.type" = "type"
+"definition.function" = "function"
+"definition.method" = "method"

--- a/pyagent/plugins/code_mapper/queries/yaml.scm
+++ b/pyagent/plugins/code_mapper/queries/yaml.scm
@@ -1,0 +1,21 @@
+; Tags query for YAML.
+;
+; CUSTOM (not vendored): YAML has no upstream tags.scm — the grammar
+; is too small for a "tags" concept. We capture mapping keys as
+; fields, which is the document outline for any config-shaped YAML
+; file (Kubernetes manifests, GitHub Actions workflows, Ansible
+; playbooks, docker-compose, etc.). Companion config: yaml.toml.
+
+(block_mapping_pair
+    key: (flow_node
+        (plain_scalar
+            (string_scalar) @name))) @definition.field
+
+; Quoted-string keys (`"key": value`) parse as a different shape.
+(block_mapping_pair
+    key: (flow_node
+        (double_quote_scalar) @name)) @definition.field
+
+(block_mapping_pair
+    key: (flow_node
+        (single_quote_scalar) @name)) @definition.field

--- a/pyagent/plugins/code_mapper/queries/yaml.toml
+++ b/pyagent/plugins/code_mapper/queries/yaml.toml
@@ -1,0 +1,15 @@
+# code-mapper language config — YAML.
+#
+# See ../EXTENDING.md for schema docs. Scalars MUST come before any
+# [table] / [[array_of_tables]] header.
+
+language = "yaml"
+description = "YAML documents — mapping keys captured as fields."
+extensions = [".yaml", ".yml"]
+
+# Same logic as json.toml: only the pair (block_mapping_pair) is the
+# parent anchor — block_mapping itself has no name to look up.
+definition_node_types = ["block_mapping_pair"]
+
+[captures]
+"definition.field" = "field"

--- a/tests/smoke_code_mapper.py
+++ b/tests/smoke_code_mapper.py
@@ -397,6 +397,565 @@ def _check_map_html() -> None:
     )
 
 
+_TYPESCRIPT_SRC = b'''class Foo {
+  bar() { return 1; }
+  static baz() { return 2; }
+}
+interface IThing { do(): void; }
+enum Color { Red, Blue }
+type Pair = [number, number];
+function freeFn() {}
+const arrow = () => 1;
+namespace App { export const x = 1; }
+'''
+
+
+def _check_map_typescript() -> None:
+    out = mapper.map_source(_TYPESCRIPT_SRC, "typescript", kind="all")
+    assert out["errors"] == [], out["errors"]
+    has = lambda kind, name, parent: any(
+        s["kind"] == kind and s["name"] == name and s["parent"] == parent
+        for s in out["symbols"]
+    )
+    assert has("class", "Foo", None), out["symbols"]
+    assert has("method", "bar", "Foo"), out["symbols"]
+    assert has("method", "baz", "Foo"), out["symbols"]
+    assert has("interface", "IThing", None), out["symbols"]
+    assert has("enum", "Color", None), out["symbols"]
+    assert has("type", "Pair", None), out["symbols"]
+    assert has("function", "freeFn", None), out["symbols"]
+    assert has("function", "arrow", None), out["symbols"]
+    assert has("module", "App", None), out["symbols"]
+    print(f"✓ TypeScript: class/method/interface/enum/type/function/module")
+
+
+_TSX_SRC = b'''function App() { return <div>Hi</div>; }
+class Comp { render() { return null; } }
+const Btn = () => <button/>;
+interface Props { name: string; }
+'''
+
+
+def _check_map_tsx() -> None:
+    out = mapper.map_source(_TSX_SRC, "tsx", kind="all")
+    assert out["errors"] == [], out["errors"]
+    has = lambda kind, name, parent: any(
+        s["kind"] == kind and s["name"] == name and s["parent"] == parent
+        for s in out["symbols"]
+    )
+    assert has("function", "App", None), out["symbols"]
+    assert has("class", "Comp", None), out["symbols"]
+    assert has("method", "render", "Comp"), out["symbols"]
+    assert has("function", "Btn", None), out["symbols"]
+    assert has("interface", "Props", None), out["symbols"]
+    print(f"✓ TSX: JSX functions / class component / arrow component")
+
+
+_JAVASCRIPT_SRC = b'''class Foo { bar() { return 1; } static baz() {} }
+function freeFn() {}
+const arrow = () => 1;
+function* gen() { yield 1; }
+'''
+
+
+def _check_map_javascript() -> None:
+    out = mapper.map_source(_JAVASCRIPT_SRC, "javascript", kind="all")
+    assert out["errors"] == [], out["errors"]
+    has = lambda kind, name, parent: any(
+        s["kind"] == kind and s["name"] == name and s["parent"] == parent
+        for s in out["symbols"]
+    )
+    assert has("class", "Foo", None), out["symbols"]
+    assert has("method", "bar", "Foo"), out["symbols"]
+    assert has("method", "baz", "Foo"), out["symbols"]
+    assert has("function", "freeFn", None), out["symbols"]
+    assert has("function", "arrow", None), out["symbols"]
+    assert has("function", "gen", None), out["symbols"]
+    print(f"✓ JavaScript: class/method/function/arrow/generator")
+
+
+_GO_SRC = b'''package main
+
+import "fmt"
+
+type Point struct { X, Y int }
+type Greeter interface { Hello() string }
+type Handler func(int) error
+
+const Pi = 3.14
+var Verbose = false
+
+func (p *Point) Distance() int { return 0 }
+func main() { fmt.Println("hi") }
+'''
+
+
+def _check_map_go() -> None:
+    out = mapper.map_source(_GO_SRC, "go", kind="all")
+    assert out["errors"] == [], out["errors"]
+    has = lambda kind, name, parent: any(
+        s["kind"] == kind and s["name"] == name and s["parent"] == parent
+        for s in out["symbols"]
+    )
+    assert has("module", "main", None), out["symbols"]
+    assert has("struct", "Point", None), out["symbols"]
+    assert has("interface", "Greeter", None), out["symbols"]
+    assert has("type", "Handler", None), out["symbols"]
+    assert has("constant", "Pi", None), out["symbols"]
+    assert has("variable", "Verbose", None), out["symbols"]
+    # Go's grammar puts the receiver outside method_declaration, so
+    # parent attribution to the receiver type isn't trivially
+    # available; document the as-is behavior.
+    distance = [s for s in out["symbols"] if s["name"] == "Distance"]
+    assert len(distance) == 1 and distance[0]["kind"] == "method", distance
+    assert has("function", "main", None), out["symbols"]
+    print(f"✓ Go: package/struct/interface/type/const/var/method/function")
+
+
+_JAVA_SRC = b'''package com.example;
+
+public class Foo {
+    private int count;
+    public Foo() { this.count = 0; }
+    public void bar() {}
+    public static int baz() { return 1; }
+}
+
+interface IThing { void doIt(); }
+enum Color { RED, GREEN }
+record Pair(int x, int y) {}
+'''
+
+
+def _check_map_java() -> None:
+    out = mapper.map_source(_JAVA_SRC, "java", kind="all")
+    assert out["errors"] == [], out["errors"]
+    has = lambda kind, name, parent: any(
+        s["kind"] == kind and s["name"] == name and s["parent"] == parent
+        for s in out["symbols"]
+    )
+    assert has("class", "Foo", None), out["symbols"]
+    assert has("field", "count", "Foo"), out["symbols"]
+    assert has("constructor", "Foo", "Foo"), out["symbols"]
+    assert has("method", "bar", "Foo"), out["symbols"]
+    assert has("method", "baz", "Foo"), out["symbols"]
+    assert has("interface", "IThing", None), out["symbols"]
+    assert has("method", "doIt", "IThing"), out["symbols"]
+    assert has("enum", "Color", None), out["symbols"]
+    assert has("record", "Pair", None), out["symbols"]
+    print(f"✓ Java: class/field/method/constructor/interface/enum/record")
+
+
+_BASH_SRC = b'''#!/bin/bash
+PORT=8080
+NAME="world"
+
+function greet() {
+    echo "hello $NAME"
+}
+
+run_server() {
+    python -m http.server $PORT
+}
+'''
+
+
+def _check_map_bash() -> None:
+    out = mapper.map_source(_BASH_SRC, "bash", kind="all")
+    assert out["errors"] == [], out["errors"]
+    by_name = {s["name"]: s for s in out["symbols"]}
+    assert by_name["PORT"]["kind"] == "variable", by_name["PORT"]
+    assert by_name["NAME"]["kind"] == "variable", by_name["NAME"]
+    assert by_name["greet"]["kind"] == "function", by_name["greet"]
+    assert by_name["run_server"]["kind"] == "function", by_name["run_server"]
+    print(f"✓ Bash: function + variable_assignment")
+
+
+_RUBY_SRC = b'''module Greeter
+  class Animal
+    def speak
+      "hi"
+    end
+
+    def self.species
+      "mammal"
+    end
+  end
+end
+
+def top_level
+  1
+end
+'''
+
+
+def _check_map_ruby() -> None:
+    out = mapper.map_source(_RUBY_SRC, "ruby", kind="all")
+    assert out["errors"] == [], out["errors"]
+    has = lambda kind, name, parent: any(
+        s["kind"] == kind and s["name"] == name and s["parent"] == parent
+        for s in out["symbols"]
+    )
+    assert has("module", "Greeter", None), out["symbols"]
+    assert has("class", "Animal", "Greeter"), out["symbols"]
+    assert has("method", "speak", "Animal"), out["symbols"]
+    assert has("method", "species", "Animal"), out["symbols"]
+    assert has("method", "top_level", None), out["symbols"]
+    print(f"✓ Ruby: module/class/method (incl. singleton methods)")
+
+
+_JSON_SRC = b'''{
+  "name": "foo",
+  "version": "1.0",
+  "deps": {
+    "left-pad": "1.0",
+    "react": "18.0"
+  }
+}'''
+
+
+def _check_map_json() -> None:
+    out = mapper.map_source(_JSON_SRC, "json", kind="all")
+    assert out["errors"] == [], out["errors"]
+    has = lambda kind, name, parent: any(
+        s["kind"] == kind and s["name"] == name and s["parent"] == parent
+        for s in out["symbols"]
+    )
+    assert has("field", "name", None), out["symbols"]
+    assert has("field", "deps", None), out["symbols"]
+    assert has("field", "left-pad", "deps"), out["symbols"]
+    assert has("field", "react", "deps"), out["symbols"]
+    print(f"✓ JSON: top-level + nested fields with parent attribution")
+
+
+_YAML_SRC = b'''name: my-app
+version: 1.0
+deps:
+  left-pad: 1.0
+  react:
+    version: 18.0
+    peer: true
+'''
+
+
+def _check_map_yaml() -> None:
+    out = mapper.map_source(_YAML_SRC, "yaml", kind="all")
+    assert out["errors"] == [], out["errors"]
+    has = lambda kind, name, parent: any(
+        s["kind"] == kind and s["name"] == name and s["parent"] == parent
+        for s in out["symbols"]
+    )
+    assert has("field", "name", None), out["symbols"]
+    assert has("field", "deps", None), out["symbols"]
+    assert has("field", "left-pad", "deps"), out["symbols"]
+    assert has("field", "react", "deps"), out["symbols"]
+    assert has("field", "version", "react"), out["symbols"]
+    print(f"✓ YAML: nested mapping keys with parent attribution")
+
+
+_TOML_SRC = b'''name = "my-app"
+version = "1.0"
+
+[deps]
+left-pad = "1.0"
+react = "18.0"
+
+[[plugins]]
+id = "a"
+
+[deps.dev]
+pytest = "7.0"
+'''
+
+
+def _check_map_toml() -> None:
+    out = mapper.map_source(_TOML_SRC, "toml", kind="all")
+    assert out["errors"] == [], out["errors"]
+    has = lambda kind, name, parent: any(
+        s["kind"] == kind and s["name"] == name and s["parent"] == parent
+        for s in out["symbols"]
+    )
+    assert has("field", "name", None), out["symbols"]
+    assert has("module", "deps", None), out["symbols"]
+    assert has("field", "left-pad", "deps"), out["symbols"]
+    assert has("field", "react", "deps"), out["symbols"]
+    assert has("module", "plugins", None), out["symbols"]
+    assert has("field", "id", "plugins"), out["symbols"]
+    assert has("module", "deps.dev", None), out["symbols"]
+    assert has("field", "pytest", "deps.dev"), out["symbols"]
+    print(f"✓ TOML: section headers (incl. dotted) + pairs with attribution")
+
+
+_MARKDOWN_SRC = b'''# Title
+
+Some intro text.
+
+## Section A
+
+### Subsection A.1
+
+text
+
+## Section B
+
+#### too-deep heading
+'''
+
+
+def _check_map_markdown() -> None:
+    out = mapper.map_source(_MARKDOWN_SRC, "markdown", kind="all")
+    # Markdown grammar is loose; tolerate non-fatal "errors" from
+    # block-level parser quirks but require the headings.
+    names = {s["name"] for s in out["symbols"]}
+    assert "Title" in names, out["symbols"]
+    assert "Section A" in names, out["symbols"]
+    assert "Subsection A.1" in names, out["symbols"]
+    assert "Section B" in names, out["symbols"]
+    # H4 deliberately omitted from outline.
+    assert "too-deep heading" not in names, out["symbols"]
+    kinds = {s["kind"] for s in out["symbols"]}
+    assert kinds == {"heading"}, kinds
+    print(f"✓ Markdown: H1-H3 headings, H4+ excluded")
+
+
+_DOCKERFILE_SRC = b'''FROM python:3.11 AS builder
+WORKDIR /app
+COPY . .
+RUN pip install -r reqs.txt
+
+FROM builder AS final
+USER nobody
+ENV PORT=8080
+EXPOSE 8080
+CMD ["python", "app.py"]
+'''
+
+
+def _check_map_dockerfile() -> None:
+    out = mapper.map_source(_DOCKERFILE_SRC, "dockerfile", kind="all")
+    assert out["errors"] == [], out["errors"]
+    by = {(s["kind"], s["name"]) for s in out["symbols"]}
+    assert ("stage", "builder") in by, by
+    assert ("stage", "final") in by, by
+    assert ("directive", "WORKDIR") in by, by
+    assert ("directive", "RUN") in by, by
+    assert ("directive", "ENV") in by, by
+    assert ("directive", "CMD") in by, by
+    print(f"✓ Dockerfile: stages + per-instruction directives")
+
+
+_SWIFT_SRC = b'''class Animal {
+    var name: String = ""
+    func speak() {}
+}
+
+protocol Greet {
+    func hi()
+}
+
+func top() {}
+'''
+
+
+def _check_map_swift() -> None:
+    out = mapper.map_source(_SWIFT_SRC, "swift", kind="all")
+    assert out["errors"] == [], out["errors"]
+    has = lambda kind, name, parent: any(
+        s["kind"] == kind and s["name"] == name and s["parent"] == parent
+        for s in out["symbols"]
+    )
+    assert has("class", "Animal", None), out["symbols"]
+    assert has("property", "name", "Animal"), out["symbols"]
+    assert has("method", "speak", "Animal"), out["symbols"]
+    assert has("interface", "Greet", None), out["symbols"]
+    assert has("method", "hi", "Greet"), out["symbols"]
+    assert has("function", "top", None), out["symbols"]
+    print(f"✓ Swift: class/property/method/protocol/function")
+
+
+_KOTLIN_SRC = b'''class Foo {
+    fun bar() = 1
+    fun baz(x: Int): String = "hi"
+}
+
+object Greeter {
+    fun greet() = "hi"
+}
+
+fun top() = 2
+'''
+
+
+def _check_map_kotlin() -> None:
+    out = mapper.map_source(_KOTLIN_SRC, "kotlin", kind="all")
+    assert out["errors"] == [], out["errors"]
+    has = lambda kind, name, parent: any(
+        s["kind"] == kind and s["name"] == name and s["parent"] == parent
+        for s in out["symbols"]
+    )
+    assert has("class", "Foo", None), out["symbols"]
+    assert has("method", "bar", "Foo"), out["symbols"]
+    assert has("method", "baz", "Foo"), out["symbols"]
+    assert has("object", "Greeter", None), out["symbols"]
+    assert has("method", "greet", "Greeter"), out["symbols"]
+    assert has("function", "top", None), out["symbols"]
+    print(f"✓ Kotlin: class/method/object/function")
+
+
+_SCALA_SRC = b'''package mypkg
+
+class Foo(val x: Int) {
+  def bar(): Int = x
+}
+
+object Bar {
+  def hi() = 1
+}
+
+trait Greeter {
+  def greet(): String
+}
+
+def topLevel() = 1
+'''
+
+
+def _check_map_scala() -> None:
+    out = mapper.map_source(_SCALA_SRC, "scala", kind="all")
+    assert out["errors"] == [], out["errors"]
+    has = lambda kind, name, parent: any(
+        s["kind"] == kind and s["name"] == name and s["parent"] == parent
+        for s in out["symbols"]
+    )
+    assert has("module", "mypkg", None), out["symbols"]
+    assert has("class", "Foo", None), out["symbols"]
+    assert has("method", "bar", "Foo"), out["symbols"]
+    assert has("object", "Bar", None), out["symbols"]
+    assert has("method", "hi", "Bar"), out["symbols"]
+    assert has("trait", "Greeter", None), out["symbols"]
+    assert has("method", "greet", "Greeter"), out["symbols"]
+    assert has("function", "topLevel", None), out["symbols"]
+    print(f"✓ Scala: package/class/object/trait/method/function")
+
+
+_LUA_SRC = b'''function top()
+  return 1
+end
+
+function t.bar()
+  return 2
+end
+
+function obj:meth()
+  return 3
+end
+
+local f = function() return 4 end
+
+local M = {
+  helper = function() end,
+}
+'''
+
+
+def _check_map_lua() -> None:
+    out = mapper.map_source(_LUA_SRC, "lua", kind="all")
+    assert out["errors"] == [], out["errors"]
+    by_name = {s["name"]: s for s in out["symbols"]}
+    assert by_name["top"]["kind"] == "function", by_name["top"]
+    assert by_name["bar"]["kind"] == "function", by_name["bar"]
+    assert by_name["meth"]["kind"] == "method", by_name["meth"]
+    assert by_name["f"]["kind"] == "function", by_name["f"]
+    assert by_name["helper"]["kind"] == "function", by_name["helper"]
+    print(f"✓ Lua: function (plain/dotted/local/table) + method (colon)")
+
+
+_PHP_SRC = b'''<?php
+
+class Foo {
+    public function bar() { return 1; }
+    private function baz() { return 2; }
+}
+
+interface IThing { public function doIt(); }
+trait Greetable { public function greet() {} }
+function top() { return 3; }
+'''
+
+
+def _check_map_php() -> None:
+    out = mapper.map_source(_PHP_SRC, "php", kind="all")
+    assert out["errors"] == [], out["errors"]
+    has = lambda kind, name, parent: any(
+        s["kind"] == kind and s["name"] == name and s["parent"] == parent
+        for s in out["symbols"]
+    )
+    assert has("class", "Foo", None), out["symbols"]
+    assert has("method", "bar", "Foo"), out["symbols"]
+    assert has("method", "baz", "Foo"), out["symbols"]
+    assert has("interface", "IThing", None), out["symbols"]
+    assert has("method", "doIt", "IThing"), out["symbols"]
+    assert has("trait", "Greetable", None), out["symbols"]
+    assert has("method", "greet", "Greetable"), out["symbols"]
+    assert has("function", "top", None), out["symbols"]
+    print(f"✓ PHP: class/method/interface/trait/function")
+
+
+_CSS_SRC = b'''.btn { color: red; }
+#header { background: blue; }
+.btn-primary { color: white; }
+
+@media (min-width: 600px) {
+  .x { color: blue; }
+}
+
+@keyframes spin {
+  from { transform: rotate(0); }
+  to { transform: rotate(360deg); }
+}
+
+@font-face {
+  src: url(x.ttf);
+}
+'''
+
+
+def _check_map_css() -> None:
+    out = mapper.map_source(_CSS_SRC, "css", kind="all")
+    assert out["errors"] == [], out["errors"]
+    by = {(s["kind"], s["name"]) for s in out["symbols"]}
+    assert ("class_selector", "btn") in by, by
+    assert ("id_selector", "header") in by, by
+    assert ("class_selector", "btn-primary") in by, by
+    assert ("at_rule", "@media") in by, by
+    assert ("at_rule", "spin") in by, by
+    assert ("at_rule", "@font-face") in by, by
+    print(f"✓ CSS: class/id selectors + at-rules (@media / @keyframes / @font-face)")
+
+
+_SQL_SRC = b'''CREATE TABLE users (id INT, name TEXT);
+CREATE VIEW recent_users AS SELECT * FROM users;
+CREATE INDEX idx_users_name ON users(name);
+CREATE FUNCTION fn() RETURNS INT AS $$ SELECT 1 $$ LANGUAGE sql;
+CREATE SCHEMA reporting;
+CREATE TRIGGER audit_trg BEFORE INSERT ON users FOR EACH ROW EXECUTE FUNCTION fn();
+'''
+
+
+def _check_map_sql() -> None:
+    out = mapper.map_source(_SQL_SRC, "sql", kind="all")
+    # tree-sitter-sql tolerates a few quirks; require schema-defining
+    # symbols but allow non-fatal errors.
+    by = {(s["kind"], s["name"]) for s in out["symbols"]}
+    assert ("table", "users") in by, by
+    assert ("view", "recent_users") in by, by
+    assert ("index", "idx_users_name") in by, by
+    assert ("function", "fn") in by, by
+    assert ("schema", "reporting") in by, by
+    assert ("trigger", "audit_trg") in by, by
+    print(f"✓ SQL: table/view/index/function/schema/trigger")
+
+
 def _check_probe_grammar() -> None:
     """probe_grammar prints the parse tree with field names visible,
     works for languages without a config (the whole point), and
@@ -428,17 +987,40 @@ def _check_probe_grammar() -> None:
 
 
 def _check_extension_dispatch() -> None:
-    """The plugin's extension table covers all four languages."""
+    """The plugin's extension table covers all configured languages."""
     exts = set(mapper.supported_extensions())
     for required in (
+        # v1 base set
         ".py", ".pyi",
         ".rs",
         ".c", ".h",
         ".cc", ".cpp", ".cxx", ".hh", ".hpp", ".hxx",
         ".html", ".htm",
+        # tier 1 — most common
+        ".ts", ".mts", ".cts",
+        ".tsx",
+        ".js", ".mjs", ".cjs", ".jsx",
+        ".go",
+        ".java",
+        ".sh", ".bash",
+        ".rb",
+        # tier 2 — config / data formats
+        ".json",
+        ".yaml", ".yml",
+        ".toml",
+        ".md", ".markdown",
+        ".dockerfile",
+        # tier 3 — broader coverage
+        ".swift",
+        ".kt", ".kts",
+        ".scala", ".sc",
+        ".lua",
+        ".php",
+        ".css",
+        ".sql",
     ):
         assert required in exts, (required, exts)
-    print(f"✓ supported_extensions() covers Python/Rust/C/C++/HTML: {sorted(exts)}")
+    print(f"✓ supported_extensions() covers all language packs: {sorted(exts)}")
 
 
 def main() -> None:
@@ -453,6 +1035,28 @@ def main() -> None:
     _check_map_c()
     _check_map_cpp()
     _check_map_html()
+    # tier 1 language pack
+    _check_map_typescript()
+    _check_map_tsx()
+    _check_map_javascript()
+    _check_map_go()
+    _check_map_java()
+    _check_map_bash()
+    _check_map_ruby()
+    # tier 2 — data formats
+    _check_map_json()
+    _check_map_yaml()
+    _check_map_toml()
+    _check_map_markdown()
+    _check_map_dockerfile()
+    # tier 3 — broader coverage
+    _check_map_swift()
+    _check_map_kotlin()
+    _check_map_scala()
+    _check_map_lua()
+    _check_map_php()
+    _check_map_css()
+    _check_map_sql()
     _check_probe_grammar()
     _check_extension_dispatch()
     print("smoke_code_mapper: all checks passed")


### PR DESCRIPTION
## Summary

Extends the bundled `code_mapper` plugin from 5 languages (python/rust/c/cpp/html) to 24 by adding 19 more across three tiers. Each language ships a `queries/<lang>.toml` (capture-name → kind mapping, def node types, promote rules) plus `queries/<lang>.scm` (the tree-sitter query). No edits to `mapper.py` — every entry is purely declarative.

### Tier 1 — most common code languages (7)
| Language | Source |
|---|---|
| typescript | https://github.com/Aider-AI/aider/blob/main/aider/queries/tree-sitter-languages/typescript-tags.scm |
| tsx | hand-authored (no upstream tags.scm; mirrors typescript) |
| javascript | https://github.com/Aider-AI/aider/blob/main/aider/queries/tree-sitter-language-pack/javascript-tags.scm |
| go | https://github.com/Aider-AI/aider/blob/main/aider/queries/tree-sitter-language-pack/go-tags.scm |
| java | https://github.com/Aider-AI/aider/blob/main/aider/queries/tree-sitter-language-pack/java-tags.scm |
| bash | hand-authored (no upstream tags.scm anywhere) |
| ruby | https://github.com/Aider-AI/aider/blob/main/aider/queries/tree-sitter-language-pack/ruby-tags.scm |

### Tier 2 — data formats (5)
All hand-authored — these grammars are too small for the GitHub tags concept upstream.

| Language | Outline shape |
|---|---|
| json | mapping keys at every depth; nested keys carry `parent` |
| yaml | block_mapping_pair keys with the same nested-parent shape |
| toml | section headers (`[x]`, `[[x]]`, dotted) as `module`, pairs as `field` attributed to the section |
| markdown | H1-H3 ATX headings as `heading` (H4+ deliberately skipped) |
| dockerfile | per-instruction `directive` (name = keyword), plus `stage` per `FROM ... AS <name>` |

### Tier 3 — broader coverage (7)
| Language | Source |
|---|---|
| swift | https://github.com/Aider-AI/aider/blob/main/aider/queries/tree-sitter-language-pack/swift-tags.scm |
| kotlin | https://github.com/Aider-AI/aider/blob/main/aider/queries/tree-sitter-languages/kotlin-tags.scm |
| scala | https://github.com/Aider-AI/aider/blob/main/aider/queries/tree-sitter-languages/scala-tags.scm |
| lua | https://github.com/Aider-AI/aider/blob/main/aider/queries/tree-sitter-language-pack/lua-tags.scm |
| php | https://github.com/Aider-AI/aider/blob/main/aider/queries/tree-sitter-languages/php-tags.scm |
| css | hand-authored |
| sql | hand-authored |

All vendored sources at aider commit `3ec8ec5a7d695b08a6c24fe6c0c235c8f87df9af` (Apache-2.0). Each `.scm` carries a one-line attribution comment + SPDX identifier at the top.

## Notable adaptations

- **Aider's `@name.definition.X` capture convention** is rewritten to the loader's bare `@name` + `@definition.X`. Aider-specific predicates (`#strip!`, `#select-adjacent!`, `#set-adjacent!`, `#is-not? local`) are dropped — the loader doesn't implement them and they're for editor doc-comment association anyway.
- **Per-call-site `@reference.*` captures** are dropped from all aider-derived files. Editor tagging wants them; AI symbol outlines don't. Keeping them would make `kind="all"` outputs unusable.
- **Some kinds split where upstream collapses** — e.g. java keeps `class` / `interface` / `enum` / `record` / `annotation` distinct; aider folds enum/record/annotation under method-or-class. PHP keeps `interface` / `trait` distinct; aider drops them.
- **In-class methods via promote rules** — swift/kotlin/scala emit functions as `function` and let the `.toml`'s `[[promote]]` rule upgrade to `method` when enclosed by the right ancestor type. Same approach as the existing C++ config. Swift's upstream had a `class_body` wrapper that emitted duplicates; we drop it in favor of the cleaner promote path.
- **SQL `create_trigger`** has multiple `object_reference` children (the trigger name, the target table, and optionally the executed function). Captured only the trigger name via positional anchoring after `keyword_trigger`.

## Test plan

- [x] Each new language has a `_check_map_<lang>()` smoke covering the canonical shapes (class/method/function/parent, or field-with-parent for data formats). All 19 added checks pass.
- [x] `_check_extension_dispatch` extended with all new extensions (`.ts/.tsx/.js/.go/.java/.sh/.rb/.json/.yaml/.toml/.md/.dockerfile/.swift/.kt/.scala/.lua/.php/.css/.sql` and minor variants).
- [x] Full `tests/smoke_*.py` suite run; only pre-existing `smoke_roles` failure (unrelated, noted in task brief) and `smoke_ctrlc` skip (binary not installed in this env). Everything else PASSES.