### PR TITLE
Plugin data dir: route through XDG_DATA_HOME

### DIFF
--- a/docs/examples/memory_markdown/plugin.py
+++ b/docs/examples/memory_markdown/plugin.py
@@ -33,7 +33,7 @@ def register(api):
     plugin_dir = Path(__file__).parent
     seeds = plugin_dir / "defaults"
 
-    # Persistent ledger storage: <config-dir>/plugins/memory-markdown/.
+    # Persistent ledger storage: <data-dir>/plugins/memory-markdown/.
     # Lazy-created on first access.
     storage = api.user_data_dir
 

--- a/docs/plugin-design.md
+++ b/docs/plugin-design.md
@@ -121,7 +121,7 @@ Read-only attributes (5):
 ```python
 api.config_dir       # Path: <config-dir>
 api.workspace        # Path: cwd at agent startup
-api.user_data_dir    # Path: <config-dir>/plugins/<name>/  — lazy-created
+api.user_data_dir    # Path: <data-dir>/plugins/<name>/  — lazy-created
 api.plugin_config    # dict: this plugin's [plugins.<name>] table
 api.plugin_name      # str: this plugin's name
 ```

--- a/docs/plugin-feature-summary.md
+++ b/docs/plugin-feature-summary.md
@@ -157,7 +157,7 @@ total.**
 | --- | --- |
 | `api.config_dir` | `<config-dir>` (Path) |
 | `api.workspace` | cwd at agent startup |
-| `api.user_data_dir` | `<config-dir>/plugins/<name>/`, lazy-created |
+| `api.user_data_dir` | `<data-dir>/plugins/<name>/`, lazy-created |
 | `api.plugin_config` | this plugin's `[plugins.<name>]` table |
 | `api.plugin_name` | this plugin's name |
 

--- a/pyagent/paths.py
+++ b/pyagent/paths.py
@@ -8,10 +8,18 @@ Resolution priority for a given name (e.g. "SOUL.md"):
   3. <config_dir>/{name}, seeded from the package's bundled default
      on first run if `seed` was provided.
 
-The config dir is resolved via platformdirs:
-  Linux:   ~/.config/pyagent/
-  macOS:   ~/Library/Application Support/pyagent/
-  Windows: %APPDATA%\\pyagent\\
+Two XDG-flavored homes via platformdirs:
+  config_dir() — user-edited preferences (config.toml, persona files,
+                 roles, skills, plugin manifests).
+    Linux:   ~/.config/pyagent/
+    macOS:   ~/Library/Application Support/pyagent/
+    Windows: %APPDATA%\\pyagent\\
+  data_dir()   — agent-generated data (plugin ledgers, sessions,
+                 anything irreplaceable that the user doesn't
+                 hand-edit).
+    Linux:   ~/.local/share/pyagent/
+    macOS:   ~/Library/Application Support/pyagent/
+    Windows: %LOCALAPPDATA%\\pyagent\\
 """
 
 from __future__ import annotations
@@ -26,6 +34,10 @@ _PACKAGE_DEFAULTS = "pyagent.defaults"
 
 def config_dir() -> Path:
     return Path(platformdirs.user_config_dir("pyagent"))
+
+
+def data_dir() -> Path:
+    return Path(platformdirs.user_data_dir("pyagent"))
 
 
 def resolve(

--- a/pyagent/plugins/__init__.py
+++ b/pyagent/plugins/__init__.py
@@ -149,7 +149,7 @@ class PluginAPI:
 
     @property
     def user_data_dir(self) -> Path:
-        d = paths.config_dir() / "plugins" / self._state.manifest.name
+        d = paths.data_dir() / "plugins" / self._state.manifest.name
         d.mkdir(parents=True, exist_ok=True)
         return d
 

--- a/pyagent/plugins/memory_markdown/__init__.py
+++ b/pyagent/plugins/memory_markdown/__init__.py
@@ -33,7 +33,7 @@ def register(api):
     plugin_dir = Path(__file__).parent
     seeds = plugin_dir / "defaults"
 
-    # Persistent ledger storage: <config-dir>/plugins/memory-markdown/.
+    # Persistent ledger storage: <data-dir>/plugins/memory-markdown/.
     # Lazy-created on first access.
     storage = api.user_data_dir
 

--- a/pyagent/skills/write-plugin/SKILL.md
+++ b/pyagent/skills/write-plugin/SKILL.md
@@ -114,7 +114,7 @@ config-dir resolution is allowed.
 ```python
 api.config_dir        # Path: <config-dir>
 api.workspace         # Path: cwd at agent startup
-api.user_data_dir     # Path: <config-dir>/plugins/<name>/  — lazy-created
+api.user_data_dir     # Path: <data-dir>/plugins/<name>/  — lazy-created
 api.plugin_config     # dict: this plugin's [plugins.<name>] table
 api.plugin_name       # str: this plugin's name
 ```

--- a/tests/smoke_plugins.py
+++ b/tests/smoke_plugins.py
@@ -76,24 +76,30 @@ def _write_plugin(
 
 
 def _isolated_config_dir() -> tuple[Path, callable]:
-    """Point pyagent.paths.config_dir() at a temp dir for the test.
+    """Point pyagent.paths.config_dir() and paths.data_dir() at a temp
+    dir for the test.
 
     Pre-seeds the temp config.toml with `built_in_plugins_enabled = []`
     so the bundled memory-markdown plugin doesn't appear in test
     fixtures by default. Tests that want bundled plugins enabled can
     overwrite the config file.
 
-    Returns the dir and a restore function.
+    Returns the dir and a restore function. (One temp dir backs both
+    config and data — tests don't care about the split, and a shared
+    fixture keeps cleanup trivial.)
     """
     tmp_cfg = Path(tempfile.mkdtemp(prefix="pyagent-plugin-cfg-"))
     (tmp_cfg / "config.toml").write_text(
         "built_in_plugins_enabled = []\n"
     )
-    original = paths.config_dir
+    original_config = paths.config_dir
+    original_data = paths.data_dir
     paths.config_dir = lambda: tmp_cfg  # type: ignore[assignment]
+    paths.data_dir = lambda: tmp_cfg  # type: ignore[assignment]
 
     def restore() -> None:
-        paths.config_dir = original  # type: ignore[assignment]
+        paths.config_dir = original_config  # type: ignore[assignment]
+        paths.data_dir = original_data  # type: ignore[assignment]
         shutil.rmtree(tmp_cfg, ignore_errors=True)
 
     return tmp_cfg, restore


### PR DESCRIPTION
## Summary

`api.user_data_dir` was misrouted: named correctly but resolving to
`~/.config/pyagent/plugins/<name>/`. By XDG spec, generated data
(ledgers, sessions, indexes) belongs in `~/.local/share/pyagent/`,
not in the same drawer as user-edited preferences. This PR fixes
the routing.

- `paths.py` gets a `data_dir()` companion to `config_dir()`,
  backed by `platformdirs.user_data_dir`. Module docstring updated.
- `PluginAPI.user_data_dir` now uses `paths.data_dir()`.
- Test fixture `_isolated_config_dir` monkeypatches both
  `config_dir` and `data_dir` so the bundled-plugin smoke test
  stops leaking into the real `~/.local/share/pyagent/`. (Same gap
  existed pre-change; just becomes visible now that the property
  resolves through a second function.)
- Docs updated to say `<data-dir>` instead of `<config-dir>` in:
  `plugin-design.md`, `plugin-feature-summary.md`, `write-plugin/SKILL.md`,
  example `memory_markdown/plugin.py`.

**No migration code.** Per offline discussion, existing
memory-markdown data at the old config-dir location is being nuked
rather than relocated. Future plugins start fresh at the correct
location.

## Test plan

- [x] `tests/smoke_plugins.py` — all 17 cases pass
- [x] Sanity-check resolved paths:
  - `config_dir() = ~/.config/pyagent`
  - `data_dir() = ~/.local/share/pyagent`
- [ ] After merge: nuke `~/.config/pyagent/plugins/memory-markdown/`
  on local machine (per plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)