### PR TITLE
Fix pyagent-plugins reset: target data_dir, not config_dir

### DIFF
--- a/pyagent/plugins_cli.py
+++ b/pyagent/plugins_cli.py
@@ -95,14 +95,14 @@ def _print_tier_paths() -> None:
 def reset_cmd(name: str, assume_yes: bool) -> None:
     """Wipe a plugin's user data dir.
 
-    Removes <config-dir>/plugins/<name>/ entirely. The plugin's
+    Removes <data-dir>/plugins/<name>/ entirely. The plugin's
     on_session_start re-seeds defaults next time pyagent runs.
 
     Common case: `pyagent-plugins reset memory-markdown` to wipe
     USER and MEMORY ledgers (replaces the old --reset-user /
     --reset-memory CLI flags).
     """
-    target = paths.config_dir() / "plugins" / name
+    target = paths.data_dir() / "plugins" / name
     if not target.exists():
         click.echo(
             f"no plugin data at {target} — nothing to reset.",


### PR DESCRIPTION
## Summary

Regression from #27. `reset_cmd` still resolves via
`paths.config_dir()`, so after #27 it points at an empty
`~/.config/pyagent/plugins/<name>/` while the real plugin data sits
at `~/.local/share/pyagent/plugins/<name>/`. The user would see
"nothing to reset — nothing to reset" and the data would still be
on disk at the old location.

One-line swap to `paths.data_dir()`, plus the matching docstring fix.

## Test plan

- [x] `git diff` reviewed; only the resolved path and the doc string
  reference change.
- [ ] After merge: `pyagent-plugins reset memory-markdown` should
  successfully wipe `~/.local/share/pyagent/plugins/memory-markdown/`.
- [ ] Old data at `~/.config/pyagent/plugins/memory-markdown/` is
  intentionally left for manual cleanup (per the no-migration call
  on #27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)