### PR TITLE
memory-markdown: index + per-memory files

### DIFF
--- a/pyagent/plugins/memory_markdown/__init__.py
+++ b/pyagent/plugins/memory_markdown/__init__.py
@@ -1,19 +1,19 @@
 """memory-markdown — bundled markdown ledger backend.
 
-The original USER.md / MEMORY.md system, expressed through the v1
-plugin API. Two tools, two prompt sections, one lifecycle hook.
+USER ledger  — splatted: auto-loaded into every system prompt
+                (small, always-relevant: preferences, conventions,
+                name, timezone). One file.
 
-Memory model preserved from pre-plugin pyagent:
-  USER ledger    — splatted: auto-loaded into every system prompt
-                   (small, always-relevant: preferences, conventions,
-                   name, timezone).
-  MEMORY ledger  — recalled on demand: agent calls read_ledger("MEMORY")
-                   when it judges the answer might be there. Avoids
-                   ballooning the prompt with potentially-large content.
+MEMORY       — index + per-memory files. MEMORY.md is the catalog
+                (auto-loaded into every prompt); each memory is its
+                own markdown file under memories/ in the plugin's
+                data dir. Agent reads the catalog in the prompt,
+                fetches a specific file with read_ledger("MEMORY",
+                file="foo.md") only when it needs the body.
 
 Companion files in this directory:
   manifest.toml
-  defaults/MEMORY.md   — seed template for the long-term memory file
+  defaults/MEMORY.md   — seed template for the index file
   defaults/USER.md     — seed template for the per-user notes file
   defaults/PROMPT.md   — the "how to use the ledgers" instructional
                          prose, lifted from SOUL.md
@@ -25,6 +25,23 @@ import shutil
 from pathlib import Path
 
 _LEDGERS = {"USER": "USER.md", "MEMORY": "MEMORY.md"}
+_MEMORIES_DIRNAME = "memories"
+
+
+def _validate_memory_filename(file: str) -> str | None:
+    """Return None if `file` is a safe bare memory filename, else an
+    error string suitable to return to the LLM. Rejects path traversal,
+    absolute paths, hidden files, and non-`.md` extensions."""
+    if not file:
+        return "<memory filename is empty>"
+    p = Path(file)
+    if p.is_absolute() or len(p.parts) != 1:
+        return f"<memory filename must be a bare name (no slashes): {file!r}>"
+    if file.startswith(".") or ".." in file:
+        return f"<invalid memory filename: {file!r}>"
+    if not file.endswith(".md"):
+        return f"<memory filename must end with .md: {file!r}>"
+    return None
 
 
 def register(api):
@@ -40,6 +57,9 @@ def register(api):
     def _ledger_path(name: str) -> Path:
         return storage / _LEDGERS[name]
 
+    def _memory_file_path(file: str) -> Path:
+        return storage / _MEMORIES_DIRNAME / file
+
     def _seed_if_missing(name: str) -> None:
         target = _ledger_path(name)
         if target.exists():
@@ -51,47 +71,75 @@ def register(api):
 
     # ---- Tools ------------------------------------------------------
 
-    def read_ledger(name: str) -> str:
-        """Read one of the agent's ledgers.
+    def read_ledger(name: str, file: str | None = None) -> str:
+        """Read one of the agent's ledgers, or a specific memory file.
 
-        Ledgers are the agent's persistent notebooks — `USER` (notes
-        about the person being helped) and `MEMORY` (long-term
-        memorable facts). Their on-disk locations are resolved
-        automatically; do not use `read_file` for these.
+        Ledgers are the agent's persistent notebooks. `USER` is a
+        single-file ledger (notes about the person being helped).
+        `MEMORY` is an index + per-memory files: MEMORY.md is the
+        catalog, each memory is its own file under `memories/`.
 
         Args:
             name: Ledger to read. One of: "USER", "MEMORY".
+            file: For MEMORY only — name of a specific memory file
+                under `memories/` (e.g. "stack_choices.md"). Omit to
+                read the MEMORY.md index. Not supported for USER.
 
         Returns:
-            The ledger's contents, or an empty string if unwritten.
+            File contents, or an empty string if unwritten. Returns
+            an error string in `<...>` form for invalid inputs.
         """
         key = name.upper()
         if key not in _LEDGERS:
             valid = ", ".join(sorted(_LEDGERS))
             return f"<unknown ledger: {name!r}; valid: {valid}>"
+        if file is not None:
+            if key == "USER":
+                return "<USER is a single-file ledger; file argument not supported>"
+            err = _validate_memory_filename(file)
+            if err:
+                return err
+            target = _memory_file_path(file)
+            if not target.exists():
+                return f"<memory not found: memories/{file}>"
+            return target.read_text()
         _seed_if_missing(key)
         target = _ledger_path(key)
         if not target.exists():
             return ""
         return target.read_text()
 
-    def write_ledger(name: str, content: str) -> str:
-        """Overwrite one of the agent's ledgers with new content.
+    def write_ledger(
+        name: str, content: str, file: str | None = None
+    ) -> str:
+        """Overwrite a ledger or a specific memory file.
 
-        Ledgers are the agent's persistent notebooks — `USER` and
-        `MEMORY`. Their on-disk locations are resolved automatically;
-        do not use `write_file` for these. Writes overwrite; if you
-        only want to add, `read_ledger` first, edit, then
-        `write_ledger`.
+        For USER, omit `file` — USER is a single-file ledger.
+        For MEMORY, omit `file` to overwrite the MEMORY.md index;
+        pass `file="foo.md"` to write `memories/foo.md`. After
+        creating a new memory file, also update MEMORY.md to add a
+        pointer in the index — agents see only the index by default.
 
         Args:
             name: Ledger to write. One of: "USER", "MEMORY".
-            content: Full new content of the ledger.
+            content: Full new content.
+            file: For MEMORY only — name of a memory file under
+                `memories/`. Omit to write the MEMORY.md index.
         """
         key = name.upper()
         if key not in _LEDGERS:
             valid = ", ".join(sorted(_LEDGERS))
             return f"<unknown ledger: {name!r}; valid: {valid}>"
+        if file is not None:
+            if key == "USER":
+                return "<USER is a single-file ledger; file argument not supported>"
+            err = _validate_memory_filename(file)
+            if err:
+                return err
+            target = _memory_file_path(file)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content)
+            return f"Wrote {len(content)} bytes to {target}"
         target = _ledger_path(key)
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(content)
@@ -102,9 +150,10 @@ def register(api):
 
     # ---- Prompt sections --------------------------------------------
     #
-    # Two sections, both volatile=False (stable across turns; cache
-    # stays warm). The USER section's content changes when the agent
-    # writes to it — that breaks the cache for one turn, then re-warms.
+    # Three sections, all volatile=False (stable across turns; cache
+    # stays warm). USER and MEMORY-INDEX content changes when the
+    # agent writes to them — that breaks the cache for one turn,
+    # then re-warms.
 
     prompt_path = seeds / "PROMPT.md"
 
@@ -124,11 +173,25 @@ def register(api):
             return ""
         return target.read_text()
 
+    def render_memory_index(ctx) -> str:
+        """Auto-load the MEMORY.md index into every prompt so the
+        agent always sees the catalog without a tool call. Body
+        files under memories/ are fetched on demand via
+        read_ledger("MEMORY", file=...)."""
+        _seed_if_missing("MEMORY")
+        target = _ledger_path("MEMORY")
+        if not target.exists():
+            return ""
+        return target.read_text()
+
     api.register_prompt_section(
         "memory-guidance", render_memory_guidance, volatile=False
     )
     api.register_prompt_section(
         "user-ledger", render_user_ledger, volatile=False
+    )
+    api.register_prompt_section(
+        "memory-index", render_memory_index, volatile=False
     )
 
     # ---- Lifecycle hooks --------------------------------------------

--- a/pyagent/plugins/memory_markdown/defaults/MEMORY.md
+++ b/pyagent/plugins/memory_markdown/defaults/MEMORY.md
@@ -1,12 +1,16 @@
 # Memory
 
-Long-term notes worth carrying across sessions. Each entry stands on
-its own; prune by removing whole entries rather than blending them.
+Index of long-term notes worth carrying across sessions. Each entry
+is a one-line pointer to a file in `memories/`. This index is
+auto-loaded into every system prompt; bodies are fetched on demand
+with `read_ledger("MEMORY", file="…")`.
 
-Shape that works well:
+Group by topic with H2 headings. Keep each pointer under ~150
+characters so the index stays quick to scan.
 
-  ## <short title — what this is about>
-  <one or two sentences: the fact, preference, or decision and why
-  it matters. Italic date at the end if useful.>
+Shape:
+
+  ## <topic group>
+  - [Short title](filename.md) — one-line hook explaining when to load this
 
 (no memories yet)

--- a/pyagent/plugins/memory_markdown/defaults/PROMPT.md
+++ b/pyagent/plugins/memory_markdown/defaults/PROMPT.md
@@ -35,13 +35,23 @@ they'll keep you from scattering stray copies across the filesystem.
   into USER it goes, no fanfare. Questions come when the next move
   turns on the answer, not on a beat of silence — and even then, one
   at a time.
-- **Memorable goes in MEMORY.** *Truly* memorable. *Truly* important —
-  recurring projects they care about, hard-won decisions that
-  shouldn't be re-litigated, tools and conventions they reach for,
-  facts about their world a future-you would need to be useful. Not
-  every preference (those go to USER); not every passing remark. Keep
-  it organized. When you prune, remove whole memories — never blend
-  them, never frankenstein two together. You may also save on request.
+- **Memorable goes in MEMORY — as files, not as paragraphs.**
+  MEMORY.md is an *index*: grouped headings of one-line pointers to
+  bodies that live under `memories/`. The index is in your prompt;
+  the bodies are not. To read a body: `read_ledger("MEMORY",
+  file="filename.md")`. To save one: `write_ledger("MEMORY",
+  content, file="filename.md")`, *then* update MEMORY.md to add the
+  pointer line — a body without an index entry is invisible. Pick
+  filenames that read like the topic (`stack_choices.md`,
+  `client_naming_convention.md`); the hook beside the link is what
+  future-you reads when deciding whether to fetch.
+  Save *truly* memorable, *truly* important things — recurring
+  projects they care about, hard-won decisions that shouldn't be
+  re-litigated, tools and conventions they reach for, facts about
+  their world a future-you would need to be useful. Not every
+  preference (those go to USER); not every passing remark. When you
+  prune, remove the file *and* its index line — never blend memories,
+  never frankenstein two together. You may also save on request.
 - **Discretion is part of the deposit.** The USER ledger holds what
   makes them easier to help — preferences, conventions, how they
   think. Casual mentions of sensitive matters (health, money, other

--- a/pyagent/plugins/memory_markdown/manifest.toml
+++ b/pyagent/plugins/memory_markdown/manifest.toml
@@ -10,7 +10,7 @@ api_version = "1"
 # pyagent can name the plugin that provided it.
 [provides]
 tools = ["read_ledger", "write_ledger"]
-prompt_sections = ["memory-guidance", "user-ledger"]
+prompt_sections = ["memory-guidance", "user-ledger", "memory-index"]
 
 # Spawn-tree behavior. Default true: the plugin loads in every agent
 # process, including subagents. memory-markdown does full-overwrite

--- a/tests/smoke_plugins.py
+++ b/tests/smoke_plugins.py
@@ -648,12 +648,75 @@ def test_bundled_memory_markdown_loads() -> None:
         section_names = {s.name for s in loaded.sections()}
         assert "memory-guidance" in section_names
         assert "user-ledger" in section_names
+        assert "memory-index" in section_names
 
         # Subagent mode skips it (in_subagents=false).
         sub_loaded = plugins_mod.load(is_subagent=True)
         sub_names = [s.manifest.name for s in sub_loaded.states]
         assert "memory-markdown" not in sub_names
         print("✓ bundled memory-markdown loads in root, skipped in subagent")
+    finally:
+        restore()
+
+
+def test_memory_per_file_round_trip() -> None:
+    """write_ledger("MEMORY", content, file=...) creates
+    memories/<file>; read_ledger("MEMORY", file=...) returns it.
+    Validates filename rejection and USER+file refusal too."""
+    cfg, restore = _isolated_config_dir()
+    try:
+        (cfg / "config.toml").write_text(
+            'built_in_plugins_enabled = ["memory-markdown"]\n'
+        )
+        loaded = plugins_mod.load(is_subagent=False)
+        _, read_ledger = loaded.tools()["read_ledger"]
+        _, write_ledger = loaded.tools()["write_ledger"]
+
+        # Round trip.
+        result = write_ledger(
+            name="MEMORY",
+            content="# stack choices\nWe use Postgres.\n",
+            file="stack_choices.md",
+        )
+        assert "Wrote" in result, result
+        body = read_ledger(name="MEMORY", file="stack_choices.md")
+        assert "We use Postgres" in body, body
+
+        # The file landed under memories/.
+        memories_dir = cfg / "plugins" / "memory-markdown" / "memories"
+        assert (memories_dir / "stack_choices.md").exists()
+
+        # Missing memory returns a clear error string.
+        missing = read_ledger(name="MEMORY", file="not_there.md")
+        assert missing.startswith("<memory not found"), missing
+
+        # USER + file is rejected.
+        err_user_read = read_ledger(name="USER", file="x.md")
+        assert "single-file ledger" in err_user_read, err_user_read
+        err_user_write = write_ledger(
+            name="USER", content="x", file="x.md"
+        )
+        assert "single-file ledger" in err_user_write, err_user_write
+
+        # Path traversal rejected.
+        for bad in ("../escape.md", "sub/dir.md", "..", ".hidden.md"):
+            r = read_ledger(name="MEMORY", file=bad)
+            assert r.startswith("<"), (bad, r)
+
+        # Non-.md rejected.
+        no_ext = read_ledger(name="MEMORY", file="no_ext")
+        assert "must end with .md" in no_ext, no_ext
+
+        # Empty filename rejected.
+        empty = read_ledger(name="MEMORY", file="")
+        assert empty.startswith("<"), empty
+
+        # Reading MEMORY without file returns the index (the seeded
+        # template, since we haven't overwritten it).
+        index = read_ledger(name="MEMORY")
+        assert "Index" in index or "memory" in index.lower(), index
+
+        print("✓ memory per-file round trip + validation")
     finally:
         restore()
 
@@ -708,6 +771,7 @@ def main() -> None:
     test_immutable_returns()
     test_builtin_tool_takes_precedence_in_agent()
     test_bundled_memory_markdown_loads()
+    test_memory_per_file_round_trip()
     test_graceful_degradation_when_memory_disabled()
     print("\nALL CHECKS PASSED")
 


### PR DESCRIPTION
## Summary

MEMORY.md is now an index file — grouped H2 headings with one-line
pointers to bodies that live under `memories/`. The index is
auto-loaded into every system prompt (new `memory-index` prompt
section), so the agent always sees the catalog without a tool call;
bodies are fetched on demand.

USER ledger is unchanged: still a single file, still splatted into
the prompt.

### Storage layout

```
<data-dir>/plugins/memory-markdown/
├── USER.md              (unchanged)
├── MEMORY.md            (now an index)
└── memories/            (new — individual memory bodies)
    └── *.md
```

### Tool surface

Extend `read_ledger` / `write_ledger` with optional `file`:

- `read_ledger("MEMORY")` → the index
- `read_ledger("MEMORY", file="foo.md")` → `memories/foo.md`
- `write_ledger("MEMORY", content, file="foo.md")` → `memories/foo.md`
- `read_ledger("USER", file=...)` → error (USER is single-file)

Filenames are validated: bare names only (no slashes, no `..`, no
hidden), must end `.md`. Errors return as `<...>` strings to match
the existing tool error pattern.

### Prompt guidance

PROMPT.md updated: when saving a memory, write the body **then**
update MEMORY.md to add a pointer — bodies without an index entry
are invisible to future-you. When pruning, remove the file *and*
its index line.

`defaults/MEMORY.md` is now an index template; existing user files
are left alone (`_seed_if_missing` only seeds when target is missing).

## Test plan

- [x] `tests/smoke_plugins.py` — all 18 cases pass, including new
  `test_memory_per_file_round_trip` covering write+read, USER+file
  rejection, path-traversal rejection, no-`.md` rejection.
- [x] `memory-index` section asserted in the bundled-load test.

## Follow-ups (not in this PR)

- After nuking, real-world feel for whether the agent actually uses
  `file=` instead of dumping everything into the index.
- Eventually: a sweep helper for orphaned memory files (body exists
  but not in index, or index line points at missing file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)