### PR TITLE
memory-vector: bundled plugin for semantic recall

### DIFF
--- a/pyagent/plugins/memory_vector/__init__.py
+++ b/pyagent/plugins/memory_vector/__init__.py
@@ -1,0 +1,279 @@
+"""memory-vector — semantic recall over memory-markdown's ledger.
+
+Reads MEMORY.md (the index file) and memories/*.md (bodies) from
+memory-markdown's data dir, embeds them with fastembed, and serves
+top-K cosine matches for a query string.
+
+Index storage in this plugin's own data dir:
+  vectors.npy   numpy array of L2-normalized embeddings, one row per
+                indexed chunk
+  index.json    parallel list of {"kind": "hook"|"body", "filename":
+                "<file>.md"} for each row
+
+Cache invalidation is mtime-based: if any source file (MEMORY.md or
+a body in memories/) is newer than the saved index, we rebuild from
+scratch. At personal-memory scale (tens to hundreds of files),
+rebuild is sub-second after the model is loaded.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+
+from pyagent import paths
+
+logger = logging.getLogger(__name__)
+
+_MODEL_NAME = "BAAI/bge-small-en-v1.5"
+_INDEX_LINE_RE = re.compile(
+    r"\s*[-*+]\s*\[(?P<title>[^\]]+)\]\((?P<file>[^)]+\.md)\)"
+    r"(?:\s*[—\-:]\s*(?P<hook>.+))?\s*$"
+)
+
+# Module-level cache so multiple recalls in one session don't reload.
+_model = None
+
+
+def _get_model():
+    global _model
+    if _model is None:
+        from fastembed import TextEmbedding
+
+        _model = TextEmbedding(model_name=_MODEL_NAME)
+    return _model
+
+
+def register(api):
+    try:
+        import fastembed  # noqa: F401
+        import numpy as np  # noqa: F401
+    except ImportError as exc:
+        api.log(
+            "warning",
+            f"memory-vector: missing dependency ({exc.name}); "
+            "install with `pip install 'pyagent[vector]'`. "
+            "Plugin disabled.",
+        )
+        # register() returns without registering recall_memory; the
+        # plugin loader sees the [provides] mismatch and skips the
+        # plugin loud.
+        return
+
+    storage = api.user_data_dir
+    source = paths.data_dir() / "plugins" / "memory-markdown"
+
+    def _index_paths() -> tuple[Path, Path]:
+        return storage / "vectors.npy", storage / "index.json"
+
+    def _parse_index_hooks() -> list[tuple[str, str, str]]:
+        """Return list of (title, filename, hook) tuples parsed from
+        MEMORY.md. hook may be empty if the index entry omits it."""
+        index_path = source / "MEMORY.md"
+        if not index_path.exists():
+            return []
+        out = []
+        for line in index_path.read_text().splitlines():
+            m = _INDEX_LINE_RE.match(line)
+            if not m:
+                continue
+            out.append(
+                (
+                    m.group("title").strip(),
+                    m.group("file").strip(),
+                    (m.group("hook") or "").strip(),
+                )
+            )
+        return out
+
+    def _gather_chunks() -> list[dict]:
+        """Walk MEMORY.md + memories/*.md; return list of chunks
+        ready to embed. Each chunk has {kind, filename, text}."""
+        chunks: list[dict] = []
+        for title, filename, hook in _parse_index_hooks():
+            text = f"{title}: {hook}" if hook else title
+            chunks.append({"kind": "hook", "filename": filename, "text": text})
+        memories_dir = source / "memories"
+        if memories_dir.exists():
+            for body_path in sorted(memories_dir.glob("*.md")):
+                chunks.append(
+                    {
+                        "kind": "body",
+                        "filename": body_path.name,
+                        "text": body_path.read_text(),
+                    }
+                )
+        return chunks
+
+    def _is_index_stale() -> bool:
+        vec_path, idx_path = _index_paths()
+        if not vec_path.exists() or not idx_path.exists():
+            return True
+        idx_mtime = min(
+            vec_path.stat().st_mtime, idx_path.stat().st_mtime
+        )
+        index_path = source / "MEMORY.md"
+        if (
+            index_path.exists()
+            and index_path.stat().st_mtime > idx_mtime
+        ):
+            return True
+        memories_dir = source / "memories"
+        if memories_dir.exists():
+            for f in memories_dir.glob("*.md"):
+                if f.stat().st_mtime > idx_mtime:
+                    return True
+        return False
+
+    def _build_and_save():
+        import numpy as np
+
+        chunks = _gather_chunks()
+        vec_path, idx_path = _index_paths()
+        vec_path.parent.mkdir(parents=True, exist_ok=True)
+        if not chunks:
+            # Wipe stale on-disk artifacts so an empty store doesn't
+            # serve old hits.
+            for p in (vec_path, idx_path):
+                if p.exists():
+                    p.unlink()
+            return None, []
+        model = _get_model()
+        texts = [c["text"] for c in chunks]
+        vectors = np.asarray(list(model.embed(texts)), dtype=np.float32)
+        norms = np.linalg.norm(vectors, axis=1, keepdims=True)
+        vectors = vectors / np.maximum(norms, 1e-9)
+        np.save(vec_path, vectors)
+        # Strip the embedded text before saving — we re-derive snippets
+        # from source files at query time, no need to store twice.
+        meta = [{"kind": c["kind"], "filename": c["filename"]} for c in chunks]
+        idx_path.write_text(json.dumps(meta))
+        return vectors, meta
+
+    def _load_or_build():
+        import numpy as np
+
+        vec_path, idx_path = _index_paths()
+        if _is_index_stale():
+            return _build_and_save()
+        try:
+            vectors = np.load(vec_path)
+            meta = json.loads(idx_path.read_text())
+            return vectors, meta
+        except Exception as exc:
+            logger.warning(
+                "memory-vector: failed to load saved index (%s); "
+                "rebuilding",
+                exc,
+            )
+            return _build_and_save()
+
+    def _snippet_for(meta: dict, hook_lookup: dict[str, str]) -> str:
+        """Return a human-readable snippet for a hit. For hook hits,
+        the hook line; for body hits, the first non-blank lines of
+        the body."""
+        if meta["kind"] == "hook":
+            return hook_lookup.get(meta["filename"], "")
+        body_path = source / "memories" / meta["filename"]
+        if not body_path.exists():
+            return ""
+        lines = [
+            ln for ln in body_path.read_text().splitlines() if ln.strip()
+        ]
+        return "\n".join(lines[:3])
+
+    def recall_memory(query: str, k: int = 5) -> str:
+        """Semantic search over the memory ledger.
+
+        Returns the top-k memory files matching `query`, scored by
+        cosine similarity over both index-hook lines and body
+        contents. Use this when scanning the MEMORY.md index in your
+        prompt isn't enough — e.g. when you remember the gist of
+        what you wrote down but not the title or filename.
+
+        Each hit names a file under `memories/` and a short snippet.
+        Fetch the full body with `read_ledger("MEMORY",
+        file="<filename>")` only when you need it.
+
+        Args:
+            query: What you're looking for, in natural language.
+            k: How many top hits to return. Default 5.
+
+        Returns:
+            A formatted list of hits, or a `<...>` error string.
+        """
+        import numpy as np
+
+        if not query or not query.strip():
+            return "<empty query>"
+        if k < 1:
+            return "<k must be >= 1>"
+        vectors, meta = _load_or_build()
+        if vectors is None or len(meta) == 0:
+            return "<no memories indexed yet>"
+        model = _get_model()
+        q_vec = np.asarray(
+            next(iter(model.embed([query]))), dtype=np.float32
+        )
+        q_vec = q_vec / max(float(np.linalg.norm(q_vec)), 1e-9)
+        scores = vectors @ q_vec  # cosine since normalized
+        # Group by filename: keep highest-scoring chunk per file so a
+        # body and its hook don't both show up.
+        best: dict[str, tuple[float, dict]] = {}
+        for i, m in enumerate(meta):
+            score = float(scores[i])
+            existing = best.get(m["filename"])
+            if existing is None or score > existing[0]:
+                best[m["filename"]] = (score, m)
+        ranked = sorted(best.items(), key=lambda kv: -kv[1][0])[:k]
+        hook_lookup = {
+            f: h for _, f, h in _parse_index_hooks() if h
+        }
+        lines = [f"Top {len(ranked)} matches for {query!r}:"]
+        for filename, (score, m) in ranked:
+            lines.append(
+                f"  • memories/{filename}  "
+                f"(score={score:.3f}, via {m['kind']})"
+            )
+            snippet = _snippet_for(m, hook_lookup)
+            for s_line in snippet.splitlines()[:3]:
+                lines.append(f"      {s_line}")
+        lines.append("")
+        lines.append(
+            'Fetch a body with: read_ledger("MEMORY", file="<filename>")'
+        )
+        return "\n".join(lines)
+
+    api.register_tool("recall_memory", recall_memory)
+
+    # ---- Prompt section --------------------------------------------
+    #
+    # Spells out the index→read_ledger / fishing→recall_memory
+    # decision tree so the agent isn't left to infer it from two
+    # disconnected tool docstrings.
+
+    def render_guidance(ctx) -> str:
+        return (
+            "## Recalling memories by similarity\n"
+            "\n"
+            "When the MEMORY.md index in your prompt has what you "
+            'need — you can see the title and hook — call '
+            '`read_ledger("MEMORY", file="…")` directly to fetch the '
+            "body.\n"
+            "\n"
+            "Reach for `recall_memory(query)` instead when scanning "
+            "the index isn't enough: the catalog is long, the topic "
+            "cuts across multiple memories, or you remember the "
+            "*gist* of what you wrote down but not the filename. "
+            "recall_memory returns the top matching files with "
+            "snippets; fetch the ones you want with read_ledger.\n"
+            "\n"
+            "Rule of thumb: **index → read_ledger** for direct "
+            "fetches; **recall_memory** for fishing."
+        )
+
+    api.register_prompt_section(
+        "memory-vector-guidance", render_guidance, volatile=False
+    )

--- a/pyagent/plugins/memory_vector/manifest.toml
+++ b/pyagent/plugins/memory_vector/manifest.toml
@@ -1,0 +1,21 @@
+name = "memory-vector"
+version = "0.1.0"
+description = "Semantic recall over memory-markdown's MEMORY.md index and memories/ bodies via fastembed."
+api_version = "1"
+
+[provides]
+tools = ["recall_memory"]
+prompt_sections = ["memory-vector-guidance"]
+
+# Single tool. Loosely coupled to memory-markdown — reads from its
+# data dir at runtime; doesn't import its code. If memory-markdown
+# isn't installed/enabled, recall_memory just returns "no memories
+# indexed yet".
+#
+# Optional runtime dependency: fastembed (see pyproject
+# [project.optional-dependencies] vector). If fastembed is missing
+# the plugin logs a warning and skips registration; the agent
+# continues without semantic recall.
+
+[load]
+in_subagents = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,13 @@ dependencies = [
     "tree-sitter-language-pack>=0.10",
 ]
 
+[project.optional-dependencies]
+# Enables the bundled `memory-vector` plugin. fastembed pulls in
+# onnxruntime + tokenizers (~150MB on disk) plus a one-time ~130MB
+# embedding-model download on first use. Skip if you don't need
+# semantic memory recall.
+vector = ["fastembed>=0.4"]
+
 [project.scripts]
 pyagent = "pyagent.cli:main"
 pyagent-config = "pyagent.config_cli:main"

--- a/tests/smoke_plugins.py
+++ b/tests/smoke_plugins.py
@@ -721,6 +721,75 @@ def test_memory_per_file_round_trip() -> None:
         restore()
 
 
+def test_memory_vector_recall() -> None:
+    """End-to-end: plant memories in memory-markdown's data dir,
+    enable both bundled plugins, and confirm recall_memory finds
+    the semantically-matching file. Skipped if fastembed isn't
+    installed."""
+    try:
+        import fastembed  # noqa: F401
+    except ImportError:
+        print("⊘ fastembed not installed; skipping memory-vector test")
+        return
+
+    cfg, restore = _isolated_config_dir()
+    try:
+        (cfg / "config.toml").write_text(
+            'built_in_plugins_enabled = '
+            '["memory-markdown", "memory-vector"]\n'
+        )
+        # Plant memories directly on disk under memory-markdown's
+        # storage (paths.data_dir() is monkeypatched to cfg).
+        mm_storage = cfg / "plugins" / "memory-markdown"
+        memories_dir = mm_storage / "memories"
+        memories_dir.mkdir(parents=True, exist_ok=True)
+        (mm_storage / "MEMORY.md").write_text(
+            "# Memory\n\n## Stack\n"
+            "- [Stack choices](stack.md) — what database we picked\n"
+            "## Style\n"
+            "- [Naming](naming.md) — variable and class casing\n"
+        )
+        (memories_dir / "stack.md").write_text(
+            "# Stack\n\nWe use Postgres for primary storage. "
+            "Redis for caches.\n"
+        )
+        (memories_dir / "naming.md").write_text(
+            "# Naming\n\nVariables: snake_case. Classes: PascalCase. "
+            "Constants: UPPER_SNAKE.\n"
+        )
+
+        loaded = plugins_mod.load(is_subagent=False)
+        names = [s.manifest.name for s in loaded.states]
+        assert "memory-vector" in names, (
+            f"expected memory-vector to load: states={names}"
+        )
+        assert "recall_memory" in loaded.tools()
+
+        _, recall = loaded.tools()["recall_memory"]
+
+        # A database-flavored query should rank stack.md above naming.md.
+        result = recall(query="what database do we use", k=2)
+        assert "stack.md" in result, result
+        # The first hit (top of ranked output) should be stack.md.
+        first_hit_line = next(
+            ln for ln in result.splitlines() if "memories/" in ln
+        )
+        assert "stack.md" in first_hit_line, first_hit_line
+
+        # An empty query returns a clear error.
+        empty = recall(query="")
+        assert empty.startswith("<"), empty
+
+        # Subagent mode skips it.
+        sub_loaded = plugins_mod.load(is_subagent=True)
+        sub_names = [s.manifest.name for s in sub_loaded.states]
+        assert "memory-vector" not in sub_names
+
+        print("✓ memory-vector recall: semantic ranking works end-to-end")
+    finally:
+        restore()
+
+
 def test_graceful_degradation_when_memory_disabled() -> None:
     """With built_in_plugins_enabled=[], the agent has no ledger
     tools and no ledger prose, but its declared_tool_provenance
@@ -772,6 +841,7 @@ def main() -> None:
     test_builtin_tool_takes_precedence_in_agent()
     test_bundled_memory_markdown_loads()
     test_memory_per_file_round_trip()
+    test_memory_vector_recall()
     test_graceful_degradation_when_memory_disabled()
     print("\nALL CHECKS PASSED")
 


### PR DESCRIPTION
## Summary

Adds a bundled `memory-vector` plugin that does vector search over
memory-markdown's MEMORY.md index hooks and `memories/` body files.
Single tool: `recall_memory(query, k=5)`.

Two-tool workflow, deliberately split:
- **index in prompt + known filename** → `read_ledger("MEMORY", file=...)`
- **long catalog or fuzzy memory** → `recall_memory(query)` then `read_ledger`

A new `memory-vector-guidance` prompt section spells out the
decision tree so the agent doesn't have to infer it from two
disconnected tool docstrings.

## What recall_memory returns

Just metadata + a peek per hit. Bodies stay out of context unless
the agent explicitly fetches with `read_ledger`:

```
Top 2 matches for 'what database do we use':
  • memories/stack.md  (score=0.762, via hook)
      what database we picked
  • memories/naming.md  (score=0.214, via body)
      Variables: snake_case. Classes: PascalCase.

Fetch a body with: read_ledger("MEMORY", file="<filename>")
```

3-line snippet per hit (hook line for hook hits; first 3 non-blank
body lines for body hits).

## Implementation

- **Embeddings:** `fastembed` with `BAAI/bge-small-en-v1.5`
  (384-dim, ONNX, no torch).
- **Storage:** `vectors.npy` (L2-normalized) + parallel
  `index.json` (kind, filename) in the plugin's own data dir.
- **Cache invalidation:** mtime-based — rebuild on next call if any
  source file is newer than the saved index. Sub-second at
  personal-memory scale.
- **Loose coupling:** reads from
  `<data-dir>/plugins/memory-markdown/` at runtime; doesn't import
  memory-markdown code.

## Optional dep + lazy load

`fastembed` is in `[project.optional-dependencies]`:

```bash
pip install 'pyagent[vector]'
```

If not installed, `register()` returns without registering the
tool; loader fails the plugin loud, agent continues without
semantic recall.

Model download is deferred:
1. Plugin registration: imports fastembed only, no download.
2. Empty store: short-circuits without instantiating the model.
3. First non-empty `recall_memory`: instantiates `TextEmbedding`,
   downloads ~130MB to `~/.cache/fastembed/` once.

Plugin is **not** added to default `built_in_plugins_enabled`. To
enable in `~/.config/pyagent/config.toml`:

```toml
built_in_plugins_enabled = [
    "memory-markdown",
    "memory-vector",
    # ...
]
```

## Test plan

- [x] All 19 smoke_plugins cases pass, including new
  `test_memory_vector_recall` that plants Postgres +
  naming-convention memories, queries "what database do we use",
  and asserts `stack.md` ranks first.
- [x] Subagent mode skips the plugin (`in_subagents = false`).
- [x] Empty-query rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)