### PR TITLE
memory: lower the save bar for the new index+files+vector world

### DIFF
--- a/pyagent/plugins/memory_markdown/defaults/PROMPT.md
+++ b/pyagent/plugins/memory_markdown/defaults/PROMPT.md
@@ -44,14 +44,23 @@ they'll keep you from scattering stray copies across the filesystem.
   pointer line — a body without an index entry is invisible. Pick
   filenames that read like the topic (`stack_choices.md`,
   `client_naming_convention.md`); the hook beside the link is what
-  future-you reads when deciding whether to fetch.
-  Save *truly* memorable, *truly* important things — recurring
-  projects they care about, hard-won decisions that shouldn't be
-  re-litigated, tools and conventions they reach for, facts about
-  their world a future-you would need to be useful. Not every
-  preference (those go to USER); not every passing remark. When you
-  prune, remove the file *and* its index line — never blend memories,
-  never frankenstein two together. You may also save on request.
+  future-you reads when deciding whether to fetch. When you prune,
+  remove the file *and* its index line — never blend memories,
+  never frankenstein two together.
+- **Save more readily than the old bar suggested.** A memory now
+  costs one short index line and a file on disk; the body never
+  enters context unless asked. The old "*truly* memorable" framing
+  was a hedge against context bloat that no longer applies. The
+  test now: *would future-me, scanning the catalog or running a
+  vector query, want to find this?* If yes — file it. Things now
+  worth saving that the old bar rejected: non-obvious gotchas,
+  decisions that took real thought, quirks of a system not in the
+  README, references to docs/dashboards/channels, tools or
+  libraries reached for once that future-you might reach for
+  again. Preferences and conventions still go to USER, not MEMORY.
+  A looser save bar means a tighter prune rhythm — fix stale
+  memories in the moment, sweep the catalog occasionally. You may
+  also save on request.
 - **Discretion is part of the deposit.** The USER ledger holds what
   makes them easier to help — preferences, conventions, how they
   think. Casual mentions of sensitive matters (health, money, other


### PR DESCRIPTION
## Summary

Splits the "Memorable goes in MEMORY" bullet in
`memory-markdown/defaults/PROMPT.md` into two: the existing
mechanics, plus a new explicit invitation to save more readily.

The old phrasing ("*truly* memorable, *truly* important") was a
hedge against context bloat from the pre-#29 single-file layout.
After #29 (per-file storage) and #30 (vector recall), a memory
costs one short index line + a file on disk; the body never enters
context unless explicitly fetched. The save bar should drop
accordingly.

### What the new bullet says

- **Test:** *would future-me, scanning the catalog or running a
  vector query, want to find this?* If yes — file it.
- **Things now worth saving** that the old bar rejected:
  non-obvious gotchas, decisions that took real thought, system
  quirks not in the README, references to docs/dashboards/channels,
  tools or libraries reached for once.
- **USER unchanged:** preferences and conventions still route to
  USER, which is splatted into prompt and stays small.
- **Looser save bar implies tighter prune rhythm:** fix stale
  memories in the moment, sweep the catalog occasionally.

### What stays

The mechanics bullet keeps everything load-bearing: write body
*then* update index, pick topical filenames, prune by removing
both file and index line, no frankensteining. The "discretion"
guardrail at the bottom of PROMPT.md is unchanged.

## Test plan

- [x] `tests/smoke_plugins.py` — all cases pass (no logic changed,
  just template prose)
- [ ] Watch a few real sessions to see whether the agent actually
  saves more under the new framing (the real test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)