### PR TITLE
memory-markdown: add_memory tool — one-call save, no full-index re-emit

### DIFF
--- a/pyagent/plugins/memory_markdown/__init__.py
+++ b/pyagent/plugins/memory_markdown/__init__.py
@@ -44,6 +44,60 @@ def _validate_memory_filename(file: str) -> str | None:
     return None
 
 
+def _insert_index_bullet(
+    index_text: str, category: str, bullet: str
+) -> str:
+    """Insert `bullet` under `## <category>` in `index_text`.
+
+    Match category case-insensitively against existing H2 headings.
+    If the heading is absent, append a new `## <category>` section
+    at the end of the file. Strips the `(no memories yet)` seed
+    placeholder if present. Returns the new full text.
+    """
+    lines = [
+        ln for ln in index_text.splitlines()
+        if ln.strip() != "(no memories yet)"
+    ]
+
+    target_idx = None
+    for i, line in enumerate(lines):
+        stripped = line.lstrip()
+        if stripped.startswith("## "):
+            heading = stripped[3:].strip()
+            if heading.lower() == category.lower():
+                target_idx = i
+                break
+
+    if target_idx is not None:
+        # Find end of this section: next H2, or EOF.
+        insert_at = len(lines)
+        for j in range(target_idx + 1, len(lines)):
+            if lines[j].lstrip().startswith("## "):
+                insert_at = j
+                break
+        # Step back past trailing blanks so bullets cluster directly
+        # under the heading.
+        while (
+            insert_at > target_idx + 1
+            and lines[insert_at - 1].strip() == ""
+        ):
+            insert_at -= 1
+        lines.insert(insert_at, bullet)
+    else:
+        # New category goes at the end.
+        while lines and lines[-1].strip() == "":
+            lines.pop()
+        if lines:
+            lines.append("")
+        lines.append(f"## {category}")
+        lines.append(bullet)
+
+    text = "\n".join(lines)
+    if not text.endswith("\n"):
+        text += "\n"
+    return text
+
+
 def register(api):
     """Plugin entrypoint."""
 
@@ -145,8 +199,90 @@ def register(api):
         target.write_text(content)
         return f"Wrote {len(content)} bytes to {target}"
 
+    def add_memory(
+        category: str,
+        title: str,
+        filename: str,
+        hook: str,
+        content: str,
+    ) -> str:
+        """Add a new memory in one call — body file plus index entry.
+
+        Writes `memories/<filename>` with `content`, then surgically
+        inserts a bullet line under `## <category>` in MEMORY.md
+        (creating the heading if absent, case-insensitive match for
+        existing). Saves the round-trip cost of re-emitting the
+        full index every time you save a memory.
+
+        Use this for *new* memories. To update an existing body in
+        place, use `write_ledger("MEMORY", content, file=...)`. To
+        prune, edit MEMORY.md and delete the body file directly.
+
+        Args:
+            category: H2 section to file under (e.g. "Database",
+                "Style", "Gotchas"). Matched case-insensitively
+                against existing headings; new heading created at
+                the end of the index if no match.
+            title: Short topical name used as the link text.
+            filename: Bare filename under `memories/`, must end
+                in `.md`. Cannot collide with an existing file.
+            hook: One-line description shown after the title in
+                the index — what future-you reads to decide
+                whether to fetch. May be empty if the title alone
+                is enough.
+            content: Full body markdown for the new memory file.
+
+        Returns:
+            A confirmation string with both written paths, or an
+            error in `<...>` form.
+        """
+        if not category or not category.strip():
+            return "<category is empty>"
+        if not title or not title.strip():
+            return "<title is empty>"
+        err = _validate_memory_filename(filename)
+        if err:
+            return err
+        body_path = _memory_file_path(filename)
+        _seed_if_missing("MEMORY")
+        index_path = _ledger_path("MEMORY")
+        index_text = (
+            index_path.read_text() if index_path.exists() else ""
+        )
+        # Same disambiguation guidance whether the collision is on
+        # disk, in the index, or both: pick a different filename, or
+        # inspect the existing memory before deciding what to do.
+        if body_path.exists() or f"]({filename})" in index_text:
+            return (
+                f"<filename collision: memories/{filename} is "
+                "already taken; pick a more specific filename, "
+                f'or call read_ledger("MEMORY", file="{filename}") '
+                "to inspect what is already there>"
+            )
+
+        # Write the body first — if the index update fails, the
+        # body is at least findable via recall_memory and the agent
+        # can re-link.
+        body_path.parent.mkdir(parents=True, exist_ok=True)
+        body_path.write_text(content)
+
+        bullet = (
+            f"- [{title.strip()}]({filename})"
+            + (f" — {hook.strip()}" if hook and hook.strip() else "")
+        )
+        new_index = _insert_index_bullet(
+            index_text, category.strip(), bullet
+        )
+        index_path.parent.mkdir(parents=True, exist_ok=True)
+        index_path.write_text(new_index)
+        return (
+            f"Wrote {len(content)} bytes to {body_path}; "
+            f"added index entry under '## {category.strip()}'."
+        )
+
     api.register_tool("read_ledger", read_ledger)
     api.register_tool("write_ledger", write_ledger)
+    api.register_tool("add_memory", add_memory)
 
     # ---- Prompt sections --------------------------------------------
     #

--- a/pyagent/plugins/memory_markdown/defaults/PROMPT.md
+++ b/pyagent/plugins/memory_markdown/defaults/PROMPT.md
@@ -39,14 +39,17 @@ they'll keep you from scattering stray copies across the filesystem.
   MEMORY.md is an *index*: grouped headings of one-line pointers to
   bodies that live under `memories/`. The index is in your prompt;
   the bodies are not. To read a body: `read_ledger("MEMORY",
-  file="filename.md")`. To save one: `write_ledger("MEMORY",
-  content, file="filename.md")`, *then* update MEMORY.md to add the
-  pointer line — a body without an index entry is invisible. Pick
-  filenames that read like the topic (`stack_choices.md`,
-  `client_naming_convention.md`); the hook beside the link is what
-  future-you reads when deciding whether to fetch. When you prune,
-  remove the file *and* its index line — never blend memories,
-  never frankenstein two together.
+  file="filename.md")`. To save a new memory:
+  `add_memory(category, title, filename, hook, content)` — writes
+  the body and inserts the index line in one call so you don't
+  have to re-emit the whole index. (Use `write_ledger("MEMORY",
+  content, file=...)` for in-place updates to an existing body;
+  reach for direct MEMORY.md edits only when add_memory doesn't
+  fit.) Pick filenames that read like the topic
+  (`stack_choices.md`, `client_naming_convention.md`); the hook is
+  what future-you reads when deciding whether to fetch. When you
+  prune, remove the file *and* its index line — never blend
+  memories, never frankenstein two together.
 - **Save more readily than the old bar suggested.** A memory now
   costs one short index line and a file on disk; the body never
   enters context unless asked. The old "*truly* memorable" framing

--- a/pyagent/plugins/memory_markdown/manifest.toml
+++ b/pyagent/plugins/memory_markdown/manifest.toml
@@ -9,7 +9,7 @@ api_version = "1"
 # rich missing-tool error — when the LLM calls a tool that's gone,
 # pyagent can name the plugin that provided it.
 [provides]
-tools = ["read_ledger", "write_ledger"]
+tools = ["read_ledger", "write_ledger", "add_memory"]
 prompt_sections = ["memory-guidance", "user-ledger", "memory-index"]
 
 # Spawn-tree behavior. Default true: the plugin loads in every agent

--- a/tests/smoke_plugins.py
+++ b/tests/smoke_plugins.py
@@ -790,6 +790,148 @@ def test_memory_vector_recall() -> None:
         restore()
 
 
+def test_add_memory_tool() -> None:
+    """add_memory writes body + inserts the index line in one call.
+    Covers: new category creation, case-insensitive append to
+    existing, "(no memories yet)" placeholder strip, filename
+    collision rejection, empty hook, round trip with read_ledger."""
+    cfg, restore = _isolated_config_dir()
+    try:
+        (cfg / "config.toml").write_text(
+            'built_in_plugins_enabled = ["memory-markdown"]\n'
+        )
+        loaded = plugins_mod.load(is_subagent=False)
+        _, add_memory = loaded.tools()["add_memory"]
+        _, read_ledger = loaded.tools()["read_ledger"]
+
+        # First add — creates the category, strips "(no memories yet)".
+        result = add_memory(
+            category="Database",
+            title="Postgres deadlock from FK locking",
+            filename="pg_deadlock.md",
+            hook="FK + concurrent update → SHARE-lock deadlock; retry with backoff",
+            content="# Postgres deadlock\n\nDeterministic update order or retry-with-backoff.\n",
+        )
+        assert "Wrote" in result and "Database" in result, result
+
+        index = read_ledger(name="MEMORY")
+        assert "## Database" in index, index
+        assert "(no memories yet)" not in index, index
+        assert "[Postgres deadlock from FK locking](pg_deadlock.md)" in index
+        assert "SHARE-lock deadlock" in index
+
+        body = read_ledger(name="MEMORY", file="pg_deadlock.md")
+        assert "retry-with-backoff" in body, body
+
+        # Second add — case-insensitive match to existing category;
+        # bullet appends under the same heading.
+        add_memory(
+            category="database",  # lowercase
+            title="Connection pool sizing",
+            filename="pool_sizing.md",
+            hook="rule of thumb: cpu_count * 2 + spindle_count",
+            content="# pool sizing\n\nrule of thumb...\n",
+        )
+        index2 = read_ledger(name="MEMORY")
+        # No duplicate "## Database" / "## database" headings.
+        db_headings = [
+            ln for ln in index2.splitlines()
+            if ln.lstrip().lower().startswith("## database")
+        ]
+        assert len(db_headings) == 1, db_headings
+        assert "pg_deadlock.md" in index2
+        assert "pool_sizing.md" in index2
+
+        # Filename collision: the on-disk body already exists.
+        err = add_memory(
+            category="Database",
+            title="duplicate try",
+            filename="pg_deadlock.md",
+            hook="should fail",
+            content="x",
+        )
+        assert err.startswith("<filename collision"), err
+        assert "pick a more specific filename" in err, err
+
+        # Empty hook is allowed; bullet just has no dash-and-text.
+        add_memory(
+            category="Style",
+            title="Naming",
+            filename="naming.md",
+            hook="",
+            content="# Naming\n\nsnake_case.\n",
+        )
+        index3 = read_ledger(name="MEMORY")
+        assert "[Naming](naming.md)" in index3, index3
+        # No "— " for empty hook.
+        for ln in index3.splitlines():
+            if "naming.md" in ln:
+                assert "—" not in ln, ln
+
+        # Filename validation flows through.
+        bad = add_memory(
+            category="X",
+            title="x",
+            filename="../escape.md",
+            hook="",
+            content="x",
+        )
+        assert bad.startswith("<"), bad
+
+        # Empty category rejected.
+        empty_cat = add_memory(
+            category="",
+            title="x",
+            filename="x.md",
+            hook="",
+            content="x",
+        )
+        assert empty_cat.startswith("<"), empty_cat
+
+        print("✓ add_memory: body + index in one call, no re-emit")
+    finally:
+        restore()
+
+
+def test_insert_index_bullet_unit() -> None:
+    """_insert_index_bullet covers the placement edge cases:
+    new section, existing section, multi-section, EOF append."""
+    from pyagent.plugins.memory_markdown import _insert_index_bullet
+
+    # Empty + placeholder → strip, append new section.
+    seed = "# Memory\n\n(no memories yet)\n"
+    out = _insert_index_bullet(seed, "Database", "- [a](a.md) — hook")
+    assert "(no memories yet)" not in out
+    assert "## Database\n- [a](a.md) — hook" in out
+
+    # Existing section, multiple sections, blank between → bullet
+    # joins the right cluster.
+    existing = (
+        "# Memory\n\n## Database\n- [foo](foo.md) — bar\n\n"
+        "## Style\n- [naming](naming.md)\n"
+    )
+    out = _insert_index_bullet(existing, "Database", "- [new](new.md)")
+    db_block = out.split("## Style")[0]
+    assert "- [new](new.md)" in db_block, out
+    assert "[naming](naming.md)" in out
+
+    # Case-insensitive heading match — no duplicate H2 inserted.
+    out2 = _insert_index_bullet(existing, "DATABASE", "- [up](up.md)")
+    assert "- [up](up.md)" in out2.split("## Style")[0]
+    assert out2.lower().count("## database") == 1, out2
+
+    # No matching heading → append at end.
+    out3 = _insert_index_bullet(existing, "Gotchas", "- [g](g.md)")
+    tail = out3.rstrip().splitlines()[-2:]
+    assert tail == ["## Gotchas", "- [g](g.md)"], tail
+
+    # Empty input → just heading + bullet.
+    out4 = _insert_index_bullet("", "Cat", "- [a](a.md)")
+    assert out4.startswith("## Cat\n- [a](a.md)"), out4
+
+    print("✓ _insert_index_bullet: placement edge cases")
+
+
 def test_graceful_degradation_when_memory_disabled() -> None:
     """With built_in_plugins_enabled=[], the agent has no ledger
     tools and no ledger prose, but its declared_tool_provenance
@@ -842,6 +984,8 @@ def main() -> None:
     test_bundled_memory_markdown_loads()
     test_memory_per_file_round_trip()
     test_memory_vector_recall()
+    test_add_memory_tool()
+    test_insert_index_bullet_unit()
     test_graceful_degradation_when_memory_disabled()
     print("\nALL CHECKS PASSED")
 


### PR DESCRIPTION
## Summary

Saving a new memory used to cost two writes: the body, plus an
LLM-emitted full re-write of MEMORY.md to add the index line. As
the index grows, the second one is pure token waste.

`add_memory(category, title, filename, hook, content)` does both
in one call — the plugin writes the body and surgically inserts
the index line under the right H2 heading. The agent never
re-emits the existing index.

### What `add_memory` does

```
add_memory(
    category="Database",
    title="Postgres deadlock from FK locking",
    filename="pg_deadlock.md",
    hook="FK + concurrent update → SHARE-lock deadlock; retry with backoff",
    content="<full body markdown>",
)
```

1. Validates filename (no path traversal, must end `.md`).
2. Writes `memories/pg_deadlock.md`.
3. Inserts `- [Postgres deadlock from FK locking](pg_deadlock.md)
   — FK + concurrent…` under `## Database` in MEMORY.md.
   - Heading match is case-insensitive.
   - New heading appended at end of file if no match.
   - `(no memories yet)` seed placeholder is stripped on first add.
4. Body-first ordering: if the index update somehow fails, the
   body is still findable via `recall_memory` (memory-vector
   indexes bodies too) and the agent can re-link.

### Collisions

- Filename already on disk → rejected with a clear message; use
  `write_ledger` to overwrite explicitly.
- Filename already in the index → rejected (recall ambiguity).
- Empty hook → allowed (bullet shows just the title link).
- Empty category or title → rejected.

### What stays

`write_ledger("MEMORY", content, file=...)` remains for in-place
body updates and explicit overwrites. Direct MEMORY.md edits via
`write_ledger("MEMORY", content)` still available when the agent
wants to reorganize the catalog wholesale.

PROMPT.md points at `add_memory` as the default new-memory path;
`write_ledger` is framed as the in-place fallback.

## Test plan

- [x] `tests/smoke_plugins.py` — all cases pass, including new:
  - `test_add_memory_tool` — end-to-end: new category, case-insensitive
    append, placeholder strip, collision rejection, empty hook,
    filename validation.
  - `test_insert_index_bullet_unit` — direct unit test of the
    placement helper for empty, existing, case-insensitive,
    multi-section, EOF-append edge cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)