### PR TITLE
memory-vector: enable by default

### DIFF
--- a/pyagent/config.py
+++ b/pyagent/config.py
@@ -51,7 +51,12 @@ LOCAL_CONFIG_DIR = Path(".pyagent")
 DEFAULTS: dict[str, Any] = {
     "default_model": "",
     "built_in_skills_enabled": ["write-skill", "write-plugin"],
-    "built_in_plugins_enabled": ["memory-markdown", "html-tools", "code-mapper"],
+    "built_in_plugins_enabled": [
+        "memory-markdown",
+        "memory-vector",
+        "html-tools",
+        "code-mapper",
+    ],
     "subagents": {
         "max_depth": 3,
         "max_fanout": 5,

--- a/pyagent/plugins/memory_vector/__init__.py
+++ b/pyagent/plugins/memory_vector/__init__.py
@@ -51,15 +51,14 @@ def register(api):
         import fastembed  # noqa: F401
         import numpy as np  # noqa: F401
     except ImportError as exc:
+        # fastembed is a hard dep in pyproject.toml — if it's missing
+        # the install is broken. Log clearly and skip registration so
+        # the loader fails the plugin loud rather than crashing.
         api.log(
             "warning",
-            f"memory-vector: missing dependency ({exc.name}); "
-            "install with `pip install 'pyagent[vector]'`. "
-            "Plugin disabled.",
+            f"memory-vector: required dependency missing ({exc.name}); "
+            "reinstall pyagent. Plugin disabled.",
         )
-        # register() returns without registering recall_memory; the
-        # plugin loader sees the [provides] mismatch and skips the
-        # plugin loud.
         return
 
     storage = api.user_data_dir

--- a/pyagent/plugins/memory_vector/manifest.toml
+++ b/pyagent/plugins/memory_vector/manifest.toml
@@ -9,13 +9,13 @@ prompt_sections = ["memory-vector-guidance"]
 
 # Single tool. Loosely coupled to memory-markdown — reads from its
 # data dir at runtime; doesn't import its code. If memory-markdown
-# isn't installed/enabled, recall_memory just returns "no memories
-# indexed yet".
+# isn't enabled, recall_memory just returns "no memories indexed
+# yet".
 #
-# Optional runtime dependency: fastembed (see pyproject
-# [project.optional-dependencies] vector). If fastembed is missing
-# the plugin logs a warning and skips registration; the agent
-# continues without semantic recall.
+# Runtime dependency: fastembed (declared as a hard dep in
+# pyproject.toml). The plugin still guards the import defensively
+# so a broken environment fails clearly instead of crashing the
+# agent loop.
 
 [load]
 in_subagents = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,11 @@ dependencies = [
     "beautifulsoup4>=4.12",
     "click>=8.1",
     "docstring_parser>=0.16",
+    # Powers the bundled memory-vector plugin's recall_memory tool.
+    # Pulls in onnxruntime + tokenizers (~150MB on disk) plus a
+    # one-time ~130MB embedding-model download on first non-empty
+    # recall.
+    "fastembed>=0.4",
     "google-genai>=0.8",
     "markdownify>=0.11",
     "openai>=1.50",
@@ -21,13 +26,6 @@ dependencies = [
     "tree-sitter>=0.25",
     "tree-sitter-language-pack>=0.10",
 ]
-
-[project.optional-dependencies]
-# Enables the bundled `memory-vector` plugin. fastembed pulls in
-# onnxruntime + tokenizers (~150MB on disk) plus a one-time ~130MB
-# embedding-model download on first use. Skip if you don't need
-# semantic memory recall.
-vector = ["fastembed>=0.4"]
 
 [project.scripts]
 pyagent = "pyagent.cli:main"


### PR DESCRIPTION
## Summary

Promotes `fastembed` from an optional dependency to a hard
dependency, and adds `memory-vector` to the default
`built_in_plugins_enabled`. Semantic recall is on out of the box —
no `pip install 'pyagent[vector]'`, no config edit.

## Changes

- **pyproject.toml** — `fastembed>=0.4` moves from
  `[project.optional-dependencies] vector` into `[project]
  dependencies`. The optional-dependencies block is dropped.
- **pyagent/config.py** — `"memory-vector"` appended to default
  `built_in_plugins_enabled`.
- **memory_vector/manifest.toml** — comment block updated;
  fastembed is no longer optional.
- **memory_vector/__init__.py** — defensive `ImportError` guard
  stays (a broken env shouldn't crash the agent loop), but the
  message no longer points at `pip install 'pyagent[vector]'` —
  it just says "reinstall pyagent" since the dep is required now.

## Cost

- **+~150MB on disk** (`onnxruntime` + `tokenizers` + `huggingface-hub`
  + transitive deps) on `pip install pyagent`.
- **+~130MB one-time download** on first non-empty `recall_memory`
  (the BGE-small model into `~/.cache/fastembed/`).

Both were already true for opted-in users. This change just
removes the manual step.

## Test plan

- [x] `tests/smoke_plugins.py` — all cases pass, including
  `test_memory_vector_recall` end-to-end.
- [x] `tests/smoke_bench_defaults.py` — bench config defaults
  unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)