### PR TITLE
memory: separate creation from consolidation in tool framing

### DIFF
--- a/pyagent/plugins/memory_markdown/__init__.py
+++ b/pyagent/plugins/memory_markdown/__init__.py
@@ -126,12 +126,19 @@ def register(api):
     # ---- Tools ------------------------------------------------------
 
     def read_ledger(name: str, file: str | None = None) -> str:
-        """Read one of the agent's ledgers, or a specific memory file.
+        """Read a ledger or a specific memory file.
 
         Ledgers are the agent's persistent notebooks. `USER` is a
         single-file ledger (notes about the person being helped).
         `MEMORY` is an index + per-memory files: MEMORY.md is the
-        catalog, each memory is its own file under `memories/`.
+        catalog (auto-loaded into your prompt), each memory is its
+        own file under `memories/` (loaded only on demand).
+
+        Primary use: fetching a *known* memory body once you've
+        identified it — by scanning the index in your prompt or via
+        `recall_memory(query)` if it's available. Reading the MEMORY.md
+        index directly is rarely needed since it's already in the
+        prompt.
 
         Args:
             name: Ledger to read. One of: "USER", "MEMORY".
@@ -166,13 +173,21 @@ def register(api):
     def write_ledger(
         name: str, content: str, file: str | None = None
     ) -> str:
-        """Overwrite a ledger or a specific memory file.
+        """Overwrite a ledger or a specific memory file (in-place
+        edits and consolidation).
+
+        For *new* memories, prefer `add_memory(...)` — it writes
+        the body and updates the index in one call. write_ledger is
+        for editing what's already there: revising a body, pruning
+        an entry, merging fragmentary memories, moving one to a
+        different category, or sweeping the catalog. It's also how
+        you write USER, which is a single-file ledger and has no
+        add_memory equivalent.
 
         For USER, omit `file` — USER is a single-file ledger.
-        For MEMORY, omit `file` to overwrite the MEMORY.md index;
-        pass `file="foo.md"` to write `memories/foo.md`. After
-        creating a new memory file, also update MEMORY.md to add a
-        pointer in the index — agents see only the index by default.
+        For MEMORY, omit `file` to overwrite the MEMORY.md index
+        directly (e.g. when reorganizing); pass `file="foo.md"` to
+        overwrite `memories/foo.md`.
 
         Args:
             name: Ledger to write. One of: "USER", "MEMORY".

--- a/pyagent/plugins/memory_markdown/defaults/PROMPT.md
+++ b/pyagent/plugins/memory_markdown/defaults/PROMPT.md
@@ -1,10 +1,13 @@
 ## The Ledgers
 
 `USER` and `MEMORY` are how you stay in tune with the people you work
-with. Tend them like a detective tends his case files. Read them with
-`read_ledger`; update them with `write_ledger`. Don't reach for generic
-file tools to touch them — the ledger tools know where they live, and
-they'll keep you from scattering stray copies across the filesystem.
+with. Tend them like a detective tends his case files. Save new
+memories with `add_memory`; fish for old ones with `recall_memory`
+(when available); fetch known bodies with `read_ledger`; consolidate
+the catalog — edit, prune, restructure — with `write_ledger`. Don't
+reach for generic file tools to touch them — the ledger tools know
+where they live, and they'll keep you from scattering stray copies
+across the filesystem.
 
 - **Read the user as you work for them.** Preferences, conventions,
   the way they think — into the USER ledger as you find them. No
@@ -38,18 +41,26 @@ they'll keep you from scattering stray copies across the filesystem.
 - **Memorable goes in MEMORY — as files, not as paragraphs.**
   MEMORY.md is an *index*: grouped headings of one-line pointers to
   bodies that live under `memories/`. The index is in your prompt;
-  the bodies are not. To read a body: `read_ledger("MEMORY",
-  file="filename.md")`. To save a new memory:
-  `add_memory(category, title, filename, hook, content)` — writes
-  the body and inserts the index line in one call so you don't
-  have to re-emit the whole index. (Use `write_ledger("MEMORY",
-  content, file=...)` for in-place updates to an existing body;
-  reach for direct MEMORY.md edits only when add_memory doesn't
-  fit.) Pick filenames that read like the topic
-  (`stack_choices.md`, `client_naming_convention.md`); the hook is
-  what future-you reads when deciding whether to fetch. When you
-  prune, remove the file *and* its index line — never blend
-  memories, never frankenstein two together.
+  the bodies are not. Two everyday paths:
+  - **Save a new memory:** `add_memory(category, title, filename,
+    hook, content)` — writes the body and inserts the index line
+    in one call.
+  - **Fetch a known body:** `read_ledger("MEMORY",
+    file="filename.md")` once you've spotted it in the index or
+    located it with `recall_memory(query)`.
+
+  Pick filenames that read like the topic (`stack_choices.md`,
+  `client_naming_convention.md`); the hook beside the link is what
+  future-you reads when deciding whether to fetch.
+- **`read_ledger` + `write_ledger` are for consolidation, not
+  creation.** Reach for them when you're *editing* what's already
+  there — revising a body that's gone stale, pruning a memory you
+  no longer need (delete the file *and* remove the index line),
+  merging two fragmentary entries into one, moving a memory to a
+  different category, or sweeping the catalog. Never blend
+  memories, never frankenstein two together. New memories go
+  through `add_memory`; reach for `write_ledger` only when you're
+  changing what already exists.
 - **Save more readily than the old bar suggested.** A memory now
   costs one short index line and a file on disk; the body never
   enters context unless asked. The old "*truly* memorable" framing


### PR DESCRIPTION
## Summary

The mental model around memory tools has shifted across the
recent PRs:

- #29 split MEMORY into index + per-file bodies
- #30 added `recall_memory` for semantic discovery
- #32 added `add_memory` as the one-call save path

The everyday flows are now:

| | Tool |
| --- | --- |
| Save a new memory | `add_memory` |
| Fish for memories by topic | `recall_memory` |
| Fetch a known body | `read_ledger` |
| Edit / prune / merge / restructure | `write_ledger` |

The PROMPT.md prose and the `read_ledger` / `write_ledger`
docstrings hadn't caught up. An agent reading them today gets
mixed signals — `write_ledger`'s docstring still says "after
creating a new memory file, also update MEMORY.md to add a
pointer in the index," which is the pre-add_memory workflow.

## Changes

### `defaults/PROMPT.md`

- **Opening paragraph**: rewrite to name all four tools by role
  ("Save new memories with `add_memory`; fish for old ones with
  `recall_memory`; fetch known bodies with `read_ledger`;
  consolidate the catalog — edit, prune, restructure — with
  `write_ledger`"). Keeps the literary tone.
- **Mechanics bullet**: restructure into two clean sub-bullets
  (Save / Fetch) so the everyday paths are unmissable.
- **New "consolidation" bullet**: explicitly frames
  `read_ledger` + `write_ledger` as for *editing* — revising a
  body that's gone stale, pruning, merging fragmentary entries,
  moving categories, periodic sweeps. Preserves the "never blend,
  never frankenstein" guardrail.

### `__init__.py` docstrings

- **`write_ledger`**: leads with "in-place edits and
  consolidation"; redirects new-memory saves to `add_memory`.
  Drops the now-stale "After creating a new memory file, also
  update MEMORY.md to add a pointer in the index" line — that was
  a vestige of the pre-add_memory workflow and would actively
  mislead an agent reading the doc today.
- **`read_ledger`**: small touch-up. Notes that the MEMORY.md
  index is auto-loaded (reading it directly is rarely needed),
  and frames primary use as "fetching a *known* memory body."

## Test plan

- [x] `tests/smoke_plugins.py` — all cases pass; no behavior
  changed, only prose.
- [ ] Agent behavior in real sessions: confirm the cleaner
  framing actually moves agents toward `add_memory` for saves and
  `write_ledger` only for edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)