### PR TITLE
glob: file-pattern lookup primitive (#36)

### DIFF
--- a/pyagent/agent_proc.py
+++ b/pyagent/agent_proc.py
@@ -415,6 +415,7 @@ def _register_tools(
     _add("edit_file", agent_tools.edit_file)
     _add("list_directory", agent_tools.list_directory)
     _add("grep", agent_tools.grep)
+    _add("glob", agent_tools.glob, auto_offload=False)
     _add("execute", agent_tools.execute)
     _add("fetch_url", agent_tools.fetch_url)
     # read_ledger / write_ledger are now provided by the bundled

--- a/pyagent/defaults/TOOLS.md
+++ b/pyagent/defaults/TOOLS.md
@@ -12,6 +12,11 @@ how to read errors, and the discretion the user is trusting you with.
   files just to skim them. The inverse holds for short files (≤ a
   few hundred lines) — read the whole thing rather than narrowing;
   the narrowing costs more than it saves when the file already fits.
+- **Discovering files by name → `glob`, not `find` via `execute`.**
+  `glob("**/*.py")` returns the same list `find` would, sorted, with
+  `.git` / `__pycache__` / `node_modules` already excluded and a hard
+  result cap. Pass a list (`["**/*.py", "**/*.pyi"]`) when you want
+  multiple extensions in one call.
 - **Parallelize when calls are independent.** Two `read_file`s on
   different paths can go in the same turn.
 - **Don't dump large outputs.** Logs, test runs, and binary blobs eat

--- a/pyagent/tools.py
+++ b/pyagent/tools.py
@@ -1,5 +1,6 @@
 """Built-in tools for the agent."""
 
+import fnmatch
 import os
 import re
 import signal
@@ -331,6 +332,130 @@ def grep(pattern: str, path: str) -> list[str]:
             if regex.search(line):
                 results.append(f"{f}:{i}:{line}")
     return results
+
+
+# Default exclusion globs for `glob`. Mirrors the
+# shutil.ignore_patterns set bench_cli uses when seeding workspaces
+# (see pyagent/bench_cli.py) so users see the same rules across pyagent.
+# We deliberately don't parse `.gitignore` — that's scope creep; ad-hoc
+# overrides should pass an explicit `root` and a tighter pattern.
+_GLOB_DEFAULT_EXCLUDES: tuple[str, ...] = (
+    ".git",
+    ".venv",
+    "venv",
+    "node_modules",
+    "__pycache__",
+    "*.pyc",
+    ".pytest_cache",
+    ".mypy_cache",
+    "dist",
+    "build",
+    "*.egg-info",
+)
+
+
+def _is_excluded(rel_parts: tuple[str, ...]) -> bool:
+    """Return True if any path component matches a default exclusion."""
+    for part in rel_parts:
+        for pat in _GLOB_DEFAULT_EXCLUDES:
+            if fnmatch.fnmatch(part, pat):
+                return True
+    return False
+
+
+def glob(
+    pattern: "str | list[str]",
+    *,
+    root: str = ".",
+    limit: int = 200,
+) -> list[str]:
+    """Find files by name pattern under `root`.
+
+    Reach for this whenever you'd otherwise call `execute("find ...")`
+    to discover files by name — it's faster, billed as read-only
+    metadata, and dodges the shell-quoting failure modes of `find`.
+    `grep` covers content search; `list_directory` covers a single
+    level; `glob` is the recursive name-match peer.
+
+    Patterns use Python `pathlib`-style semantics: `**/*.py` matches
+    every `.py` file at any depth, `src/*.ts` matches one level deep
+    under `src/`, etc. Output paths are relative to `root` so they can
+    be fed straight back into `read_file` / `grep`.
+
+    Default exclusions skip `.git`, `.venv`, `venv`, `node_modules`,
+    `__pycache__`, `*.pyc`, `.pytest_cache`, `.mypy_cache`, `dist`,
+    `build`, `*.egg-info` — same set bench_cli uses when seeding
+    workspaces. Pass a more specific `root` if you need to look inside
+    one of those (e.g. `root="node_modules/some-pkg"`).
+
+    Args:
+        pattern: Glob pattern to match, or a list of patterns. Lists
+            save a round trip when you want both source and stub
+            extensions (`["**/*.py", "**/*.pyi"]`); their results are
+            merged and de-duplicated.
+        root: Directory to search under. Defaults to `.`.
+        limit: Maximum number of paths to return. Defaults to 200.
+            When the cap fires, the result includes a trailing
+            `<truncated: NNN total matches; tighten the pattern>`
+            marker so you know to narrow.
+
+    Returns:
+        Sorted list of relative paths (relative to `root`). Predictable
+        failures (root missing, root not a directory, root outside the
+        workspace) come back as a single-element list with a leading
+        `<...>` marker.
+    """
+    try:
+        limit = int(limit)
+    except (TypeError, ValueError):
+        return [f"<error: limit must be an integer, got {limit!r}>"]
+    if limit <= 0:
+        return [f"<error: limit must be positive, got {limit}>"]
+
+    if isinstance(pattern, str):
+        patterns = [pattern]
+    elif isinstance(pattern, list):
+        patterns = [str(p) for p in pattern]
+    else:
+        return [f"<error: pattern must be str or list[str], got {type(pattern).__name__}>"]
+    if not patterns:
+        return ["<error: pattern list is empty>"]
+
+    if not permissions.require_access(root):
+        return [_denied(root)]
+
+    root_path = Path(root)
+    if not root_path.exists():
+        return [f"<path not found: {root}>"]
+    if not root_path.is_dir():
+        return [f"<not a directory: {root}>"]
+
+    matches: set[Path] = set()
+    for pat in patterns:
+        try:
+            for hit in root_path.glob(pat):
+                if not hit.is_file():
+                    continue
+                try:
+                    rel = hit.relative_to(root_path)
+                except ValueError:
+                    # Pattern escaped the root via "..", skip.
+                    continue
+                if _is_excluded(rel.parts):
+                    continue
+                matches.add(rel)
+        except (NotImplementedError, ValueError) as e:
+            return [f"<error: invalid pattern {pat!r}: {e}>"]
+
+    sorted_rel = sorted(str(p) for p in matches)
+    total = len(sorted_rel)
+    if total > limit:
+        capped = sorted_rel[:limit]
+        capped.append(
+            f"<truncated: {total} total matches; tighten the pattern>"
+        )
+        return capped
+    return sorted_rel
 
 
 # Patterns that should never run unattended. This is a speed bump

--- a/tests/smoke_glob.py
+++ b/tests/smoke_glob.py
@@ -1,0 +1,152 @@
+"""Smoke for glob.
+
+Exercises (in-process):
+  1. Single-pattern recursive match returns sorted relative paths.
+  2. Multi-pattern (list) merges and de-duplicates results.
+  3. Default exclusions skip `.git` / `__pycache__` / `node_modules`.
+  4. Limit truncation appends a `<truncated: NNN ...>` marker.
+  5. Output is sorted.
+  6. Permission gate refuses a `root` outside the workspace.
+  7. Missing root surfaces `<path not found: ...>`.
+  8. File-as-root surfaces `<not a directory: ...>`.
+  9. Empty pattern list / wrong type returns an `<error: ...>` marker.
+ 10. Bad limit returns an `<error: ...>` marker.
+ 11. Relative paths are relative to `root`, not the cwd.
+
+Run with:
+
+    .venv/bin/python -m tests.smoke_glob
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from pyagent import permissions
+from pyagent.tools import glob
+
+
+def _seed(tmp: Path) -> None:
+    """Build a tree exercising real and excluded paths."""
+    (tmp / "src").mkdir()
+    (tmp / "src" / "alpha.py").write_text("x")
+    (tmp / "src" / "beta.py").write_text("x")
+    (tmp / "src" / "gamma.pyi").write_text("x")
+    (tmp / "tests").mkdir()
+    (tmp / "tests" / "test_alpha.py").write_text("x")
+    (tmp / "README.md").write_text("x")
+    # Excluded trees — must never appear in default-exclusion runs.
+    (tmp / ".git").mkdir()
+    (tmp / ".git" / "config").write_text("x")
+    (tmp / ".git" / "HEAD").write_text("x")
+    (tmp / "__pycache__").mkdir()
+    (tmp / "__pycache__" / "cached.pyc").write_text("x")
+    (tmp / "node_modules").mkdir()
+    (tmp / "node_modules" / "pkg").mkdir()
+    (tmp / "node_modules" / "pkg" / "index.js").write_text("x")
+    # Loose .pyc (file-pattern exclude, not just dir-name).
+    (tmp / "src" / "stale.pyc").write_text("x")
+
+
+def main() -> None:
+    tmp = Path(tempfile.mkdtemp(prefix="pyagent-smoke-glob-")).resolve()
+    permissions.set_workspace(tmp)
+    _seed(tmp)
+
+    # 1. Single-pattern recursive match.
+    out = glob("**/*.py", root=str(tmp))
+    assert out == ["src/alpha.py", "src/beta.py", "tests/test_alpha.py"], out
+    print(f"✓ single-pattern recursive match: {out}")
+
+    # 2. Multi-pattern merges and de-duplicates.
+    out = glob(["**/*.py", "**/*.pyi"], root=str(tmp))
+    assert out == [
+        "src/alpha.py",
+        "src/beta.py",
+        "src/gamma.pyi",
+        "tests/test_alpha.py",
+    ], out
+    print(f"✓ multi-pattern merge: {out}")
+
+    # Overlapping patterns must not double-count.
+    out = glob(["**/*.py", "src/*.py"], root=str(tmp))
+    assert out == ["src/alpha.py", "src/beta.py", "tests/test_alpha.py"], out
+    print(f"✓ multi-pattern dedupe: {out}")
+
+    # 3. Default exclusions: .git / __pycache__ / node_modules / *.pyc all
+    # absent from a wide-open recursive match.
+    out = glob("**/*", root=str(tmp))
+    joined = "\n".join(out)
+    assert ".git/" not in joined and "/.git" not in joined, out
+    assert not any(p.startswith(".git") for p in out), out
+    assert not any("__pycache__" in p for p in out), out
+    assert not any(p.startswith("node_modules") for p in out), out
+    assert not any(p.endswith(".pyc") for p in out), out
+    # Real files still present.
+    assert "README.md" in out, out
+    assert "src/alpha.py" in out, out
+    print(f"✓ default exclusions filtered: {len(out)} entries")
+
+    # 4. Limit truncation marker.
+    out = glob("**/*.py", root=str(tmp), limit=2)
+    assert len(out) == 3, out  # 2 hits + 1 marker
+    assert out[0] == "src/alpha.py" and out[1] == "src/beta.py", out
+    assert out[2].startswith("<truncated:"), out
+    assert "3 total matches" in out[2], out
+    assert "tighten the pattern" in out[2], out
+    print(f"✓ limit truncation marker: {out[2]!r}")
+
+    # 5. Sorted output (already covered by 1/2/3 equality, plus an
+    # explicit lexical-order check on a known set).
+    out = glob("**/*.py", root=str(tmp))
+    assert out == sorted(out), out
+    print(f"✓ sorted output")
+
+    # 6. Permission gate: root outside the workspace.
+    outside = Path(tempfile.mkdtemp(prefix="pyagent-smoke-glob-outside-")).resolve()
+    (outside / "leaked.py").write_text("x")
+    out = glob("*.py", root=str(outside))
+    assert len(out) == 1, out
+    assert out[0].startswith("<permission denied (outside workspace)"), out
+    print(f"✓ workspace-gate refusal: {out[0]!r}")
+
+    # 7. Missing root surfaces a marker.
+    out = glob("*.py", root=str(tmp / "no-such-dir"))
+    assert len(out) == 1 and out[0].startswith("<path not found:"), out
+    print(f"✓ missing root marker: {out[0]!r}")
+
+    # 8. File-as-root surfaces a marker.
+    out = glob("*.py", root=str(tmp / "README.md"))
+    assert len(out) == 1 and out[0].startswith("<not a directory:"), out
+    print(f"✓ not-a-directory marker: {out[0]!r}")
+
+    # 9. Empty list / wrong type.
+    out = glob([], root=str(tmp))
+    assert len(out) == 1 and out[0] == "<error: pattern list is empty>", out
+    print(f"✓ empty pattern list: {out[0]!r}")
+
+    out = glob(123, root=str(tmp))  # type: ignore[arg-type]
+    assert len(out) == 1 and out[0].startswith("<error: pattern must be"), out
+    print(f"✓ wrong pattern type: {out[0]!r}")
+
+    # 10. Bad limit.
+    out = glob("*.py", root=str(tmp), limit=0)
+    assert len(out) == 1 and out[0].startswith("<error: limit must be positive"), out
+    print(f"✓ non-positive limit: {out[0]!r}")
+
+    out = glob("*.py", root=str(tmp), limit="not-a-number")  # type: ignore[arg-type]
+    assert len(out) == 1 and out[0].startswith("<error: limit must be an integer"), out
+    print(f"✓ non-int limit: {out[0]!r}")
+
+    # 11. Paths are relative to `root`, not cwd. Searching with
+    # root=tmp/src should yield bare filenames, not "src/alpha.py".
+    out = glob("*.py", root=str(tmp / "src"))
+    assert out == ["alpha.py", "beta.py"], out
+    print(f"✓ paths relative to root: {out}")
+
+    print("\nALL CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds `glob(pattern, *, root=\".\", limit=200) -> list[str]` as a peer of `read_file` / `grep` / `list_directory` in `pyagent/tools.py`. Replaces ad-hoc `execute(\"find ...\")` discovery — same listing semantics, but typed, capped, deterministic, and billed as read-only metadata instead of riding the shell-safety path.

## Behavior

- `pattern: str | list[str]`. Single pattern is the common case; lists are merged + de-duplicated so the agent can ask for `[\"**/*.py\", \"**/*.pyi\"]` in one round trip.
- Default exclusions skip `.git`, `.venv`, `venv`, `node_modules`, `__pycache__`, `*.pyc`, `.pytest_cache`, `.mypy_cache`, `dist`, `build`, `*.egg-info` — matches the `shutil.ignore_patterns` set `bench_cli` uses when seeding workspaces, so users see one rule across pyagent. No `.gitignore` parsing (scope creep).
- Permission gate via the existing `permissions.require_access` / `_denied` path. `root` outside the workspace prompts (or denies non-interactively) just like `read_file`.
- Output is sorted, relative to `root` (so results feed straight into `read_file`/`grep`), hard-capped at `limit`. When the cap fires, a `<truncated: N total matches; tighten the pattern>` marker is appended so the agent knows to narrow.
- Registered with `auto_offload=False` — output is small string lists.
- `pyagent/defaults/TOOLS.md` gets a one-bullet pointer in \"Working efficiently\" steering the agent at `glob` instead of `find`-via-`execute`.
- No new `Attachment(...)` construction site; `glob` returns `list[str]`, so `smoke_session_replay._check_attachment_construction_sites` invariant holds.

## Test plan

- [x] `tests/smoke_glob.py` (new) — single-pattern recursive match, multi-pattern merge + dedupe, default-exclusion filtering of `.git` / `__pycache__` / `node_modules` / `*.pyc`, sorted output, limit truncation marker, workspace-gate refusal, missing-root marker, file-as-root marker, empty/wrong-type pattern, bad-limit, paths-relative-to-root.
- [x] Full smoke suite (26 files): all pass; `smoke_ctrlc` skips in the worktree environment (no installed `pyagent` shim) — unrelated.

Closes #36.