### PR TITLE
web-search: bundle as default-enabled plugin (#39)

### DIFF
--- a/pyagent/config.py
+++ b/pyagent/config.py
@@ -56,6 +56,7 @@ DEFAULTS: dict[str, Any] = {
         "memory-vector",
         "html-tools",
         "code-mapper",
+        "web-search",
     ],
     "subagents": {
         "max_depth": 3,

--- a/pyagent/plugins/web_search/__init__.py
+++ b/pyagent/plugins/web_search/__init__.py
@@ -1,0 +1,107 @@
+"""web-search — bundled plugin for DuckDuckGo-backed web search.
+
+Two tools:
+
+  - `web_search(query, n=10)` — list-style search. Returns a markdown
+    numbered list of results. Returned as a plain string; the agent's
+    standard auto-offload threshold (8K chars) takes over for runaway
+    `n` values, so a 50-result call won't bloat the conversation log.
+  - `web_search_instant(query, related=False)` — DDG instant-answer
+    API. Short string reply by definition.
+
+Tool framing pushes the model toward a search-then-fetch loop rather
+than search-as-default — most queries the model thinks "I should
+search" can be answered from training data, and a network round trip
+costs the user real time and money.
+
+Lifted from the user-scope `web-search` skill at
+~/.config/pyagent/skills/web-search/. The skill is left in place so
+older installs still work; the plugin shadows it in the catalog
+because plugin tools call directly while skill scripts go through
+`read_skill` + `execute`.
+"""
+
+from __future__ import annotations
+
+from pyagent.plugins.web_search import search as _search
+
+
+# Maximum results the agent is allowed to ask for in one call. DDG
+# starts rate-limiting around the high 20s in practice; cap is a
+# safety belt rather than the everyday limit.
+_MAX_RESULTS = 25
+
+
+def register(api):
+    def web_search(query: str, n: int = 10) -> str:
+        """Search the web via DuckDuckGo; return up to `n` results.
+
+        Reach for this when `fetch_url` alone isn't enough — i.e. you
+        don't have a URL yet, or you need to compare multiple sources.
+        Most factual questions are better answered from training data;
+        a search burns a network round trip and adds latency. When you
+        do search, treat the result list as a *menu*: pair with
+        `fetch_url` on the most promising URL rather than reading every
+        snippet.
+
+        Args:
+            query: Search query. Plain text; DDG handles quoting and
+                operators.
+            n: Number of results (default 10, max 25). Higher values
+                may auto-offload as an attachment.
+
+        Returns:
+            A markdown numbered list of `title — url` lines with
+            snippets. `<no results ...>` if DDG returned nothing;
+            `<search error: ...>` on network/parser failure. Large
+            outputs auto-offload via the standard tool-result path.
+        """
+        if not query or not query.strip():
+            return "<query is empty>"
+        try:
+            n_int = int(n)
+        except (TypeError, ValueError):
+            return f"<error: n must be an integer, got {n!r}>"
+        if n_int < 1:
+            return "<error: n must be >= 1>"
+        if n_int > _MAX_RESULTS:
+            n_int = _MAX_RESULTS
+        try:
+            results = _search.ddg_text_search(query, n=n_int)
+        except ImportError:
+            return (
+                "<search error: ddgs package not installed — "
+                "run: pip install ddgs>"
+            )
+        except Exception as e:
+            return f"<search error: {e}>"
+        return _search.format_search_results(results, query)
+
+    def web_search_instant(query: str, related: bool = False) -> str:
+        """Hit DuckDuckGo's instant-answer API for a short factual reply.
+
+        Use for definitions, well-known entities, and quick lookups
+        where a list of links would be overkill. Coverage is narrow:
+        most queries return `<no instant answer ...>` — that's the
+        cue to fall back to `web_search` (or to answer from training
+        data without searching at all).
+
+        Args:
+            query: Search query.
+            related: If True, append up to 10 related-topic links.
+                Default False — keeps the reply terse.
+
+        Returns:
+            A short markdown reply, or `<no instant answer ...>` /
+            `<instant-answer error: ...>` on miss/failure.
+        """
+        if not query or not query.strip():
+            return "<query is empty>"
+        try:
+            ans = _search.ddg_instant_answer(query)
+        except Exception as e:
+            return f"<instant-answer error: {e}>"
+        return _search.format_instant_answer(ans, query, related=related)
+
+    api.register_tool("web_search", web_search)
+    api.register_tool("web_search_instant", web_search_instant)

--- a/pyagent/plugins/web_search/manifest.toml
+++ b/pyagent/plugins/web_search/manifest.toml
@@ -1,0 +1,15 @@
+name = "web-search"
+version = "0.1.0"
+description = "DuckDuckGo-backed web search — list results and instant answers."
+api_version = "1"
+
+# Two tools:
+#   web_search          — list-style search; returns markdown results
+#                         (auto-offloaded by the agent when large).
+#   web_search_instant  — DDG instant-answer API; short string reply.
+[provides]
+tools = ["web_search", "web_search_instant"]
+
+# Stateless and read-only — safe to load in subagents.
+[load]
+in_subagents = true

--- a/pyagent/plugins/web_search/search.py
+++ b/pyagent/plugins/web_search/search.py
@@ -1,0 +1,220 @@
+"""DuckDuckGo search backend.
+
+Two entrypoints, both pure functions returning structured data so the
+plugin's tool wrappers can render them however they like (and tests can
+mock the network at one well-defined seam):
+
+  - `ddg_text_search(query, n)`  — list-style results (title, url,
+    snippet) via the `ddgs` library, which scrapes the DDG HTML
+    endpoint. Lifted from the user-scope `web-search` skill.
+  - `ddg_instant_answer(query)`  — the JSON instant-answer API at
+    api.duckduckgo.com. Returns a parsed dict with the abstract,
+    direct answer, definition, and related topics.
+
+The seam is intentionally narrow: `ddg_text_search` returns a list of
+`SearchResult` and `ddg_instant_answer` returns an `InstantAnswer` —
+both plain dataclasses. Tool framing (markdown formatting, related-
+topic toggle, etc.) lives in __init__.py.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+
+
+_INSTANT_ANSWER_URL = "https://api.duckduckgo.com/"
+_USER_AGENT = "Mozilla/5.0 (compatible; pyagent-web-search)"
+_INSTANT_TIMEOUT = 10
+
+
+@dataclass(frozen=True)
+class SearchResult:
+    """One DuckDuckGo search result."""
+
+    title: str
+    url: str
+    snippet: str
+
+
+@dataclass(frozen=True)
+class InstantAnswer:
+    """Parsed payload from the DuckDuckGo instant-answer API.
+
+    Most fields are empty for most queries — DDG's instant-answer
+    coverage is narrow (definitions, calculations, well-known
+    entities). Callers should pick the first non-empty field in
+    preference order: `answer` → `abstract` → `definition`. If all
+    three are empty, fall back to `related` or to `web_search`.
+    """
+
+    answer: str = ""
+    abstract: str = ""
+    abstract_source: str = ""
+    abstract_url: str = ""
+    definition: str = ""
+    definition_source: str = ""
+    definition_url: str = ""
+    heading: str = ""
+    related: tuple[tuple[str, str], ...] = field(default_factory=tuple)
+
+
+def ddg_text_search(query: str, n: int = 10) -> list[SearchResult]:
+    """Run a DDG text search and return up to `n` results.
+
+    Uses the `ddgs` library (DuckDuckGo HTML endpoint scraper). May
+    raise on network failure or parser breakage — callers translate
+    those into a tool-result error string rather than letting them
+    bubble to the agent loop.
+    """
+    # Local import so an environment missing `ddgs` still loads the
+    # plugin module (the tool will return a clean error when called).
+    from ddgs import DDGS
+
+    results = DDGS().text(query, max_results=n)
+    out: list[SearchResult] = []
+    for r in results or []:
+        out.append(
+            SearchResult(
+                title=str(r.get("title") or "").strip(),
+                url=str(r.get("href") or "").strip(),
+                snippet=str(r.get("body") or "").strip(),
+            )
+        )
+    return out
+
+
+def _parse_instant_payload(data: dict) -> InstantAnswer:
+    """Pull the small set of fields we care about out of the DDG
+    instant-answer JSON. Tolerant of missing keys — DDG omits anything
+    it doesn't have for a given query."""
+    related_raw = data.get("RelatedTopics") or []
+    related: list[tuple[str, str]] = []
+    for entry in related_raw:
+        if not isinstance(entry, dict):
+            continue
+        # Top-level entries are either {Text, FirstURL} or
+        # {Name, Topics: [...]} groupings. We flatten one level.
+        if "Topics" in entry and isinstance(entry["Topics"], list):
+            for sub in entry["Topics"]:
+                if isinstance(sub, dict):
+                    text = str(sub.get("Text") or "").strip()
+                    url = str(sub.get("FirstURL") or "").strip()
+                    if text and url:
+                        related.append((text, url))
+        else:
+            text = str(entry.get("Text") or "").strip()
+            url = str(entry.get("FirstURL") or "").strip()
+            if text and url:
+                related.append((text, url))
+
+    return InstantAnswer(
+        answer=str(data.get("Answer") or "").strip(),
+        abstract=str(data.get("AbstractText") or "").strip(),
+        abstract_source=str(data.get("AbstractSource") or "").strip(),
+        abstract_url=str(data.get("AbstractURL") or "").strip(),
+        definition=str(data.get("Definition") or "").strip(),
+        definition_source=str(data.get("DefinitionSource") or "").strip(),
+        definition_url=str(data.get("DefinitionURL") or "").strip(),
+        heading=str(data.get("Heading") or "").strip(),
+        related=tuple(related),
+    )
+
+
+def ddg_instant_answer(query: str) -> InstantAnswer:
+    """Hit the DDG instant-answer JSON API.
+
+    May raise on network/HTTP failure or JSON-decode failure — the
+    tool wrapper translates those into a tool-result error string.
+    """
+    params = urllib.parse.urlencode(
+        {
+            "q": query,
+            "format": "json",
+            "no_html": "1",
+            "no_redirect": "1",
+            "skip_disambig": "1",
+        }
+    )
+    url = f"{_INSTANT_ANSWER_URL}?{params}"
+    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    with urllib.request.urlopen(req, timeout=_INSTANT_TIMEOUT) as resp:
+        raw = resp.read()
+        encoding = resp.headers.get_content_charset("utf-8")
+        text = raw.decode(encoding, errors="replace")
+    data = json.loads(text)
+    if not isinstance(data, dict):
+        return InstantAnswer()
+    return _parse_instant_payload(data)
+
+
+def format_search_results(
+    results: list[SearchResult], query: str
+) -> str:
+    """Render a list of `SearchResult` as a markdown numbered list.
+
+    Empty input yields a `<no results ...>` marker so the agent can
+    distinguish "search ran, found nothing" from a tool error.
+    """
+    if not results:
+        return f"<no results for {query!r}>"
+    lines: list[str] = [f"# Search results for {query!r}", ""]
+    for i, r in enumerate(results, 1):
+        title = r.title or "(no title)"
+        lines.append(f"{i}. **{title}** — {r.url}")
+        if r.snippet:
+            lines.append(f"   {r.snippet}")
+        lines.append("")
+    # Drop a trailing blank line for cleanliness.
+    while lines and lines[-1] == "":
+        lines.pop()
+    return "\n".join(lines)
+
+
+def format_instant_answer(
+    ans: InstantAnswer, query: str, related: bool = False
+) -> str:
+    """Render an `InstantAnswer` for the agent.
+
+    Picks the highest-signal field available; appends related-topic
+    links only when `related=True`. Returns a `<no instant answer>`
+    marker when DDG had nothing — most queries fall here, and the
+    marker is the agent's cue to fall back to `web_search`.
+    """
+    primary = ""
+    if ans.answer:
+        primary = ans.answer
+    elif ans.abstract:
+        src = (
+            f" (source: {ans.abstract_source})"
+            if ans.abstract_source
+            else ""
+        )
+        primary = f"{ans.abstract}{src}"
+    elif ans.definition:
+        src = (
+            f" (definition: {ans.definition_source})"
+            if ans.definition_source
+            else ""
+        )
+        primary = f"{ans.definition}{src}"
+
+    if not primary and not (related and ans.related):
+        return f"<no instant answer for {query!r}>"
+
+    parts: list[str] = []
+    if ans.heading and primary:
+        parts.append(f"**{ans.heading}**")
+    if primary:
+        parts.append(primary)
+
+    if related and ans.related:
+        if parts:
+            parts.append("")
+        parts.append("Related:")
+        for text, url in ans.related[:10]:
+            parts.append(f"- {text} — {url}")
+
+    return "\n".join(parts).strip()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ dependencies = [
     "anthropic>=0.40",
     "beautifulsoup4>=4.12",
     "click>=8.1",
+    # DuckDuckGo HTML scraper used by the bundled `web-search` plugin.
+    "ddgs>=9",
     "docstring_parser>=0.16",
     # Powers the bundled memory-vector plugin's recall_memory tool.
     # Pulls in onnxruntime + tokenizers (~150MB on disk) plus a

--- a/tests/smoke_web_search.py
+++ b/tests/smoke_web_search.py
@@ -1,0 +1,325 @@
+"""End-to-end smoke for the web-search plugin.
+
+Four concerns:
+
+  1. **Plugin loads under the default config.** With "web-search" in
+     `built_in_plugins_enabled`, `discover()` and `load()` produce
+     both tools (`web_search`, `web_search_instant`).
+  2. **Search formatter renders structured results as markdown.**
+     `format_search_results` over a fixture list yields the
+     numbered-list shape the agent sees, with title/url/snippet
+     ordering preserved.
+  3. **Instant-answer formatter picks the right field.** Answer
+     beats abstract beats definition; missing data yields the
+     `<no instant answer ...>` marker; `related=True` appends
+     related-topic links.
+  4. **Tool wrappers translate exceptions and return string shape.**
+     The agent's auto-offload path expects strings; both tools must
+     return `str` on success and on every error path. A `web_search`
+     network failure becomes `<search error: ...>` rather than
+     bubbling out of the tool.
+
+Run with:
+
+    .venv/bin/python -m tests.smoke_web_search
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+from pyagent import config as config_mod, paths as paths_mod, plugins
+from pyagent.plugins.web_search import search as web_search_mod
+
+
+_FIXTURE_RESULTS_RAW = [
+    {
+        "title": "Best Python HTTP libraries 2025",
+        "href": "https://example.com/python-http",
+        "body": "A roundup of requests, httpx, and aiohttp for typical workloads.",
+    },
+    {
+        "title": "httpx documentation",
+        "href": "https://www.python-httpx.org/",
+        "body": "HTTPX is a fully featured HTTP client for Python 3.",
+    },
+    {
+        "title": "(no title)",
+        "href": "https://example.com/missing",
+        "body": "",
+    },
+]
+
+# A representative DDG instant-answer payload — narrow but enough to
+# exercise the parser and formatter. Real responses are larger.
+_FIXTURE_INSTANT_PAYLOAD = {
+    "Heading": "Python (programming language)",
+    "AbstractText": (
+        "Python is a high-level, general-purpose programming language."
+    ),
+    "AbstractSource": "Wikipedia",
+    "AbstractURL": "https://en.wikipedia.org/wiki/Python_(programming_language)",
+    "Answer": "",
+    "AnswerType": "",
+    "Definition": "",
+    "DefinitionSource": "",
+    "DefinitionURL": "",
+    "RelatedTopics": [
+        {
+            "Text": "CPython - the reference implementation",
+            "FirstURL": "https://duckduckgo.com/CPython",
+        },
+        {
+            "Name": "By type",
+            "Topics": [
+                {
+                    "Text": "Pythonista (mobile IDE)",
+                    "FirstURL": "https://duckduckgo.com/Pythonista",
+                }
+            ],
+        },
+    ],
+}
+
+
+def _check_search_formatter() -> None:
+    """`format_search_results` produces the numbered-list shape."""
+    results = [
+        web_search_mod.SearchResult(
+            title=r["title"], url=r["href"], snippet=r["body"]
+        )
+        for r in _FIXTURE_RESULTS_RAW
+    ]
+    md = web_search_mod.format_search_results(results, "python http")
+    assert "# Search results for 'python http'" in md, md
+    # Numbering preserved.
+    assert "1. **Best Python HTTP libraries 2025**" in md, md
+    assert "2. **httpx documentation**" in md, md
+    assert "3. **(no title)**" in md, md
+    # Snippets carried through (where present).
+    assert "requests, httpx, and aiohttp" in md, md
+    # URLs survive on the heading line.
+    assert "https://example.com/python-http" in md, md
+    print("✓ format_search_results renders numbered markdown list")
+
+
+def _check_search_formatter_empty() -> None:
+    md = web_search_mod.format_search_results([], "no hits")
+    assert md.startswith("<no results"), md
+    assert "no hits" in md, md
+    print("✓ format_search_results: empty list → <no results ...> marker")
+
+
+def _check_instant_parser_picks_abstract() -> None:
+    ans = web_search_mod._parse_instant_payload(_FIXTURE_INSTANT_PAYLOAD)
+    assert ans.heading == "Python (programming language)", ans
+    assert "high-level" in ans.abstract, ans
+    assert ans.abstract_source == "Wikipedia", ans
+    # Related topics flattened across plain entries and grouped Topics.
+    related_texts = [t for t, _ in ans.related]
+    assert any("CPython" in t for t in related_texts), related_texts
+    assert any("Pythonista" in t for t in related_texts), related_texts
+    print("✓ _parse_instant_payload extracts abstract + flattens related")
+
+
+def _check_instant_formatter_default() -> None:
+    ans = web_search_mod._parse_instant_payload(_FIXTURE_INSTANT_PAYLOAD)
+    out = web_search_mod.format_instant_answer(ans, "python", related=False)
+    assert "Python (programming language)" in out, out
+    assert "high-level" in out, out
+    assert "Wikipedia" in out, out
+    # related=False: no related-topic block.
+    assert "Related:" not in out, out
+    print("✓ format_instant_answer(default) emits abstract + source")
+
+
+def _check_instant_formatter_with_related() -> None:
+    ans = web_search_mod._parse_instant_payload(_FIXTURE_INSTANT_PAYLOAD)
+    out = web_search_mod.format_instant_answer(ans, "python", related=True)
+    assert "Related:" in out, out
+    assert "CPython" in out, out
+    assert "Pythonista" in out, out
+    print("✓ format_instant_answer(related=True) appends related links")
+
+
+def _check_instant_formatter_answer_beats_abstract() -> None:
+    ans = web_search_mod.InstantAnswer(
+        answer="42",
+        abstract="The Hitchhiker's Guide to the Galaxy",
+        abstract_source="Wikipedia",
+    )
+    out = web_search_mod.format_instant_answer(ans, "meaning of life")
+    assert out.strip() == "42", out
+    print("✓ format_instant_answer prefers Answer over Abstract")
+
+
+def _check_instant_formatter_no_data() -> None:
+    ans = web_search_mod.InstantAnswer()
+    out = web_search_mod.format_instant_answer(ans, "obscure query")
+    assert out.startswith("<no instant answer"), out
+    assert "obscure query" in out, out
+    print("✓ format_instant_answer: empty → <no instant answer ...> marker")
+
+
+def _check_plugin_loads_under_default_config() -> None:
+    """With the default config, web-search is in
+    built_in_plugins_enabled and load() exposes both tools."""
+    tmp = Path(tempfile.mkdtemp(prefix="pyagent-smoke-websearch-"))
+    with mock.patch.object(paths_mod, "config_dir", return_value=tmp):
+        with mock.patch.object(
+            plugins, "LOCAL_PLUGINS_DIR", Path(tmp / "no_local_plugins")
+        ):
+            cfg = config_mod.load()
+            assert "web-search" in cfg["built_in_plugins_enabled"], (
+                cfg["built_in_plugins_enabled"]
+            )
+            loaded = plugins.load()
+            tool_names = set(loaded.tools().keys())
+    assert "web_search" in tool_names, tool_names
+    assert "web_search_instant" in tool_names, tool_names
+    print(f"✓ plugin loads by default; web-search tools present")
+
+
+def _check_tool_wrapper_returns_string() -> None:
+    """`web_search` returns str on success — no Attachment construction
+    in the plugin (the auto-offload path handles large outputs)."""
+    # Re-register through a fake API so we can capture the tool fn.
+    captured: dict[str, callable] = {}
+
+    class _FakeAPI:
+        def register_tool(self, name, fn):
+            captured[name] = fn
+
+    from pyagent.plugins.web_search import register
+
+    register(_FakeAPI())
+    assert set(captured.keys()) == {"web_search", "web_search_instant"}, captured
+
+    web_search = captured["web_search"]
+
+    fixture = [
+        web_search_mod.SearchResult(
+            title=r["title"], url=r["href"], snippet=r["body"]
+        )
+        for r in _FIXTURE_RESULTS_RAW
+    ]
+    with mock.patch.object(
+        web_search_mod, "ddg_text_search", return_value=fixture
+    ) as m:
+        out = web_search("python http", n=3)
+    m.assert_called_once_with("python http", n=3)
+    assert isinstance(out, str), type(out)
+    assert "Best Python HTTP libraries 2025" in out, out
+    print("✓ web_search tool returns str (auto-offload path)")
+
+
+def _check_tool_wrapper_translates_errors() -> None:
+    """Network/parser failure → `<search error: ...>`, not a raise."""
+    captured: dict[str, callable] = {}
+
+    class _FakeAPI:
+        def register_tool(self, name, fn):
+            captured[name] = fn
+
+    from pyagent.plugins.web_search import register
+
+    register(_FakeAPI())
+    web_search = captured["web_search"]
+    web_search_instant = captured["web_search_instant"]
+
+    def _boom(*a, **kw):
+        raise RuntimeError("network down")
+
+    with mock.patch.object(web_search_mod, "ddg_text_search", side_effect=_boom):
+        out = web_search("anything")
+    assert isinstance(out, str), type(out)
+    assert out.startswith("<search error:"), out
+    assert "network down" in out, out
+
+    with mock.patch.object(
+        web_search_mod, "ddg_instant_answer", side_effect=_boom
+    ):
+        out = web_search_instant("anything")
+    assert isinstance(out, str), type(out)
+    assert out.startswith("<instant-answer error:"), out
+    print("✓ tool wrappers translate exceptions to <... error: ...>")
+
+
+def _check_tool_wrapper_validates_inputs() -> None:
+    """Empty query, bad `n` → tool-result error string, not a raise."""
+    captured: dict[str, callable] = {}
+
+    class _FakeAPI:
+        def register_tool(self, name, fn):
+            captured[name] = fn
+
+    from pyagent.plugins.web_search import register
+
+    register(_FakeAPI())
+    web_search = captured["web_search"]
+    web_search_instant = captured["web_search_instant"]
+
+    assert web_search("") == "<query is empty>"
+    assert web_search("   ") == "<query is empty>"
+    assert web_search_instant("") == "<query is empty>"
+    bad_n = web_search("hi", n="not-a-number")
+    assert bad_n.startswith("<error: n must be an integer"), bad_n
+    bad_n2 = web_search("hi", n=0)
+    assert bad_n2 == "<error: n must be >= 1>", bad_n2
+    print("✓ tool wrappers reject empty query / bad n cleanly")
+
+
+def _check_instant_answer_uses_fixture_http() -> None:
+    """`ddg_instant_answer` parses a fixture HTTP body without touching
+    the network. Mocks at urllib.request.urlopen."""
+    body = json.dumps(_FIXTURE_INSTANT_PAYLOAD).encode("utf-8")
+
+    class _FakeResp:
+        def __init__(self, payload: bytes) -> None:
+            self._payload = payload
+            self.headers = self  # has get_content_charset()
+
+        def get_content_charset(self, default="utf-8"):
+            return "utf-8"
+
+        def read(self):
+            return self._payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    with mock.patch.object(
+        web_search_mod.urllib.request,
+        "urlopen",
+        return_value=_FakeResp(body),
+    ):
+        ans = web_search_mod.ddg_instant_answer("python")
+    assert ans.heading == "Python (programming language)", ans
+    assert "high-level" in ans.abstract, ans
+    print("✓ ddg_instant_answer parses fixture HTTP body")
+
+
+def main() -> None:
+    _check_search_formatter()
+    _check_search_formatter_empty()
+    _check_instant_parser_picks_abstract()
+    _check_instant_formatter_default()
+    _check_instant_formatter_with_related()
+    _check_instant_formatter_answer_beats_abstract()
+    _check_instant_formatter_no_data()
+    _check_plugin_loads_under_default_config()
+    _check_tool_wrapper_returns_string()
+    _check_tool_wrapper_translates_errors()
+    _check_tool_wrapper_validates_inputs()
+    _check_instant_answer_uses_fixture_http()
+    print("smoke_web_search: all checks passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Promotes the user-scope `web-search` skill (at `~/.config/pyagent/skills/web-search/`) to a bundled plugin under `pyagent/plugins/web_search/`, enabled by default. Third leg of the fetch-and-research toolkit (with `fetch_url` / `html_to_md`), all sitting at the plugin tier so the agent's mental model stays consistent.

Two tools:

- `web_search(query, n=10)` — DDG text search via the `ddgs` library. Renders results as a numbered markdown list. Capped at `n=25` to stay polite with DDG.
- `web_search_instant(query, related=False)` — DDG instant-answer JSON API. Picks `Answer` > `Abstract` > `Definition`; appends related links only when asked. Misses return a `<no instant answer ...>` marker — the agent's cue to fall back to `web_search` (or skip the search entirely).

Tool docstrings push the model toward search-then-fetch rather than search-as-default. Most factual questions are better answered from training data; a network round trip costs real latency, and the framing keeps the model from reaching for `web_search` reflexively.

## Decisions

- **Strings, not Attachments.** `smoke_session_replay._check_attachment_construction_sites` enforces that `Attachment(...)` is only constructed in `pyagent/tools.py`. Both tools return `str`; the agent's standard auto-offload threshold (8K chars) takes over for runaway `n` values. A 10-result list at ~200 chars/result lands ~2K, comfortably inline; an `n=50` call crosses the threshold and the standard offload path handles it.
- **`ddgs` library, not direct HTML scraping.** Lifts the existing skill logic verbatim and adds `ddgs>=9` to `pyproject.toml` dependencies. The skill was already shipping this; pulling it into the dependency set means the plugin works out of the box rather than failing on first call.
- **Backend seam.** `search.py` exposes pure functions (`ddg_text_search`, `ddg_instant_answer`, formatters) with plain dataclasses (`SearchResult`, `InstantAnswer`) at the boundary. A future Brave/Tavily/Serper plugin can ship as a separate package without touching this one.
- **`[load] in_subagents = true`.** Stateless and read-only.

## Migration

The user-scope skill at `~/.config/pyagent/skills/web-search/` is **left alone** so older installs still work. The plugin shadows it in practice because plugin tools call directly while skill scripts go through `read_skill` + `execute`. Users can delete `~/.config/pyagent/skills/web-search/` after this lands.

## Test plan

- [x] New `tests/smoke_web_search.py` (12 checks): formatter renders numbered list / handles empty results / parses instant-answer payload (including grouped `RelatedTopics` flattening) / formatter prefers `Answer` over `Abstract` / `related=True` appends links / plugin loads under default config / tool wrappers return `str` on success and `<... error: ...>` on failure / input validation rejects empty query and bad `n` / `ddg_instant_answer` parses a fixture HTTP body via mocked `urlopen`.
- [x] Full smoke suite (25 of 26): all pass. `smoke_ctrlc` skipped per worktree convention.
- [x] No new `Attachment(...)` construction site (verified by `smoke_session_replay`).

Closes #39.