### PR TITLE
execute: background processes via run_background / read_output / wait_for / kill_process (#37)

### DIFF
--- a/pyagent/agent_proc.py
+++ b/pyagent/agent_proc.py
@@ -417,6 +417,14 @@ def _register_tools(
     _add("grep", agent_tools.grep)
     _add("glob", agent_tools.glob, auto_offload=False)
     _add("execute", agent_tools.execute)
+    # Long-running shell. `read_output` can return a lot of bytes —
+    # let auto_offload move oversized reads to attachments. The other
+    # three return short status strings; offloading them just adds
+    # noise to the conversation.
+    _add("run_background", agent_tools.run_background, auto_offload=False)
+    _add("read_output", agent_tools.read_output)
+    _add("wait_for", agent_tools.wait_for, auto_offload=False)
+    _add("kill_process", agent_tools.kill_process, auto_offload=False)
     _add("fetch_url", agent_tools.fetch_url)
     # read_ledger / write_ledger are now provided by the bundled
     # memory-markdown plugin (see pyagent/plugins/memory_markdown/).
@@ -824,6 +832,18 @@ def child_main(config: dict[str, Any], conn: Connection) -> None:
             prompt=event["prompt"],
             persist=event.get("persist", True),
         )
+
+    # Tear down background shell processes started by run_background
+    # so a clean exit doesn't leave the user's dev server / watcher
+    # lingering. SIGTERM with a 2s grace, then SIGKILL.
+    try:
+        signalled = agent_tools.shutdown_background(grace_s=2.0)
+        if signalled:
+            logger.info(
+                "shutdown: signalled %d background process(es)", signalled
+            )
+    except Exception:
+        logger.exception("shutdown: error tearing down background procs")
 
     # Tear down subagents first, then fire on_session_end. End-hooks
     # might write to disk or call APIs; they shouldn't race with

--- a/pyagent/defaults/TOOLS.md
+++ b/pyagent/defaults/TOOLS.md
@@ -33,6 +33,40 @@ how to read errors, and the discretion the user is trusting you with.
   into the conversation forever. `append=True` creates the file
   if missing, so the first chunk can use it too.
 
+## Long-running shell
+
+`execute` has a hard 60s timeout — fine for git, scripts, builds that
+finish in seconds, and one-shot HTTP. For dev servers, file watchers,
+long builds, or anything you want to *check on* later, switch to the
+background quartet.
+
+- **Start with `run_background(command, name="...")`.** Returns a
+  `bg-XXXXXXXX` handle. Pass `name="dev-server"` (or similar) so the
+  status reports name something the agent can recognize, not just a
+  hex id.
+- **`read_output(handle, since=N, max_chars=4000)`** to peek. The
+  first read uses `since=0`; subsequent reads pass the previous
+  call's `next_since:` value to tail-follow without re-reading bytes
+  you've already seen. Stderr (when non-empty) appears under a
+  `[stderr]` divider.
+- **`wait_for(handle, until="...", timeout_s=...)`** when you need to
+  block on a condition before continuing. `until` accepts:
+  - `"exit"` — process finished (returns the rc).
+  - `"output_contains:STRING"` / `"output_matches:REGEX"` — the
+    output mentions a startup banner, a port number, an error, etc.
+  - `"silence:Ns"` — N seconds with no new output. Good for "the
+    build settled" without picking an exact ready-string.
+- **`kill_process(handle)`** to stop a process you started. Idempotent;
+  a stale handle returns the standard `<error: handle ... is not
+  active>` marker. The agent's normal teardown flushes any leftover
+  background processes (SIGTERM with a 2s grace, then SIGKILL), and
+  Esc / cancel kills foreground + background together.
+
+Buffers cap at 1MB per stream; overflow drops the oldest 256KB and
+prepends `...truncated NN bytes...` on the next read. Don't keep a
+chatty `tail -f` running indefinitely if you only need to confirm a
+thing started.
+
 ## Web pages and HTML
 
 - **Don't write your own HTML scrub.** `fetch_url` saves the raw page

--- a/pyagent/tools.py
+++ b/pyagent/tools.py
@@ -3,9 +3,12 @@
 import fnmatch
 import os
 import re
+import secrets
 import signal
 import subprocess
 import threading
+import time
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import requests
@@ -20,6 +23,41 @@ from pyagent.session import Attachment
 _ACTIVE_EXEC_PROCS: list[subprocess.Popen] = []
 _ACTIVE_EXEC_LOCK = threading.Lock()
 
+# Per-stream rolling cap for background-process output. When either
+# stdout or stderr crosses this size, the oldest 256KB are dropped and
+# a `...truncated NN bytes...` notice rides the next read so the agent
+# knows the tail is incomplete.
+_BG_BUF_CAP = 1024 * 1024
+_BG_BUF_DROP = 256 * 1024
+
+
+@dataclass
+class _BackgroundProc:
+    """Live state for one `run_background` shell subprocess.
+
+    The reader threads pump bytes into stdout_buf / stderr_buf under
+    `lock`; tools that read or wait take the same lock when peeking.
+    `dropped_*` tracks bytes evicted by the rolling cap so a subsequent
+    `read_output` can prepend `...truncated NN bytes...`.
+    """
+
+    handle: str
+    name: str
+    command: str
+    proc: subprocess.Popen
+    start_time: float
+    lock: threading.Lock = field(default_factory=threading.Lock)
+    stdout_buf: bytearray = field(default_factory=bytearray)
+    stderr_buf: bytearray = field(default_factory=bytearray)
+    dropped_stdout: int = 0
+    dropped_stderr: int = 0
+    last_write: float = 0.0
+    threads: list[threading.Thread] = field(default_factory=list)
+
+
+_ACTIVE_BG_PROCS: dict[str, _BackgroundProc] = {}
+_ACTIVE_BG_LOCK = threading.Lock()
+
 
 def kill_active() -> int:
     """SIGKILL every in-flight execute() shell subprocess group.
@@ -29,6 +67,10 @@ def kill_active() -> int:
     sees the proc exit and returns whatever output was buffered, so
     the tool reports a normal-looking result (exit_code: -9) and the
     agent loop reaches its next safe-point cancel check immediately.
+
+    Also flushes every entry in `_ACTIVE_BG_PROCS` — background procs
+    started by `run_background` share the same fate: a single Esc
+    should leave nothing lingering.
 
     Returns the number of process groups signalled.
     """
@@ -41,7 +83,51 @@ def kill_active() -> int:
             except ProcessLookupError:
                 # Already exited between the lock and the kill.
                 pass
+    with _ACTIVE_BG_LOCK:
+        bg_entries = list(_ACTIVE_BG_PROCS.values())
+    for bg in bg_entries:
+        try:
+            os.killpg(bg.proc.pid, signal.SIGKILL)
+            killed += 1
+        except ProcessLookupError:
+            pass
     return killed
+
+
+def shutdown_background(grace_s: float = 2.0) -> int:
+    """Clean-shutdown path for background procs.
+
+    Sends SIGTERM to every active background-proc group, waits up to
+    `grace_s` seconds total for them to exit, then SIGKILLs whatever
+    remains. Called by the agent process's normal teardown so a
+    `pyagent` exit doesn't leave the user's dev server lingering.
+
+    Returns the number of process groups signalled (term + kill).
+    """
+    with _ACTIVE_BG_LOCK:
+        bg_entries = list(_ACTIVE_BG_PROCS.values())
+    if not bg_entries:
+        return 0
+    signalled = 0
+    for bg in bg_entries:
+        try:
+            os.killpg(bg.proc.pid, signal.SIGTERM)
+            signalled += 1
+        except ProcessLookupError:
+            pass
+    deadline = time.monotonic() + max(grace_s, 0.0)
+    while time.monotonic() < deadline:
+        if all(bg.proc.poll() is not None for bg in bg_entries):
+            return signalled
+        time.sleep(0.05)
+    for bg in bg_entries:
+        if bg.proc.poll() is None:
+            try:
+                os.killpg(bg.proc.pid, signal.SIGKILL)
+                signalled += 1
+            except ProcessLookupError:
+                pass
+    return signalled
 
 
 def _denied(path: str) -> str:
@@ -567,6 +653,476 @@ def execute(command: str) -> str:
         f"exit_code: {returncode}\n"
         f"stdout:\n{stdout}"
         f"stderr:\n{stderr}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Background shell processes — run_background / read_output / wait_for /
+# kill_process. Lifecycle:
+#   run_background   spawns + registers a handle, returns the handle id.
+#   read_output      decodes the captured bytes since an offset.
+#   wait_for         blocks (with timeout) until exit / output match /
+#                    silence settles.
+#   kill_process     SIGKILLs the group and removes the handle.
+# kill_active() (above) flushes BOTH foreground and background sets so
+# the cancel pathway leaves a clean slate.
+
+
+def _bg_handle() -> str:
+    return f"bg-{secrets.token_hex(4)}"
+
+
+def _bg_reader(bg: _BackgroundProc, stream, which: str) -> None:
+    """Pump bytes from `stream` into the per-handle buffer.
+
+    Holds the lock only across the buffer mutation so concurrent
+    `read_output` / `wait_for` can keep observing while bytes flow.
+    The 1MB rolling cap drops the oldest 256KB instead of growing
+    unbounded — agents rarely care about start-of-stream once the
+    process has been running for a while, but they do need recent
+    output to be intact.
+    """
+    try:
+        while True:
+            # `read1` returns whatever is currently buffered up to the
+            # cap — `read(4096)` would block until 4096 bytes (or EOF),
+            # which interacts badly with line-buffered tools that emit
+            # short bursts and then sleep. Tail-follow needs the
+            # bytes-out-now semantics.
+            chunk = stream.read1(4096)
+            if not chunk:
+                break
+            with bg.lock:
+                buf = bg.stdout_buf if which == "stdout" else bg.stderr_buf
+                buf.extend(chunk)
+                if len(buf) > _BG_BUF_CAP:
+                    overflow = len(buf) - (_BG_BUF_CAP - _BG_BUF_DROP)
+                    del buf[:overflow]
+                    if which == "stdout":
+                        bg.dropped_stdout += overflow
+                    else:
+                        bg.dropped_stderr += overflow
+                bg.last_write = time.monotonic()
+    except (ValueError, OSError):
+        # Stream closed underneath us (proc died, fd reaped). The
+        # main reader exits — wait_for / read_output handle the
+        # post-mortem state via proc.poll().
+        pass
+    finally:
+        try:
+            stream.close()
+        except Exception:
+            pass
+
+
+def _coerce_handle(handle: str) -> "_BackgroundProc | str":
+    """Look up a handle, returning either the entry or a `<...>` marker.
+
+    Stale-handle responses follow the project's predictable-failure
+    convention so the agent can pattern-match them just like a missing
+    file or a permission denial.
+    """
+    if not isinstance(handle, str) or not handle:
+        return f"<error: handle must be a non-empty string, got {handle!r}>"
+    with _ACTIVE_BG_LOCK:
+        bg = _ACTIVE_BG_PROCS.get(handle)
+    if bg is None:
+        return f"<error: handle {handle} is not active in this session>"
+    return bg
+
+
+def run_background(command: str, *, name: str | None = None) -> str:
+    """Start a long-running shell command without blocking the turn.
+
+    Use this for dev servers, file watchers, builds, test watchers, or
+    anything you'd kick off and check on later. The handle returned
+    here is what `read_output`, `wait_for`, and `kill_process` operate
+    against. Foreground `execute` is still the right tool for short
+    one-shot commands — keep using it for git, scripts, tests that
+    finish in seconds, and HTTP one-offs.
+
+    Same dangerous-pattern blocklist as `execute` (recursive rm at
+    root, fork bombs, piping curl|sh, force push to main, etc.). The
+    process runs in its own session so a later `kill_process` (or Esc
+    via `kill_active`) takes the whole tree.
+
+    Args:
+        command: Shell command to run.
+        name: Optional human-readable label (shows up in error markers
+            and the wait_for status report). Defaults to None.
+
+    Returns:
+        A short confirmation line including the handle (`bg-XXXXXXXX`)
+        and pid, or a `<refused: ...>` marker if the command matches a
+        blocked pattern.
+    """
+    blocked = _safety_check(command)
+    if blocked:
+        return (
+            f"<refused: matches dangerous pattern ({blocked}); "
+            f"ask the human to run it manually if intended>"
+        )
+    proc = subprocess.Popen(
+        command,
+        shell=True,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=True,
+    )
+    handle = _bg_handle()
+    label = name or handle
+    bg = _BackgroundProc(
+        handle=handle,
+        name=label,
+        command=command,
+        proc=proc,
+        start_time=time.monotonic(),
+        last_write=time.monotonic(),
+    )
+    t_out = threading.Thread(
+        target=_bg_reader,
+        args=(bg, proc.stdout, "stdout"),
+        name=f"bg-{handle}-out",
+        daemon=True,
+    )
+    t_err = threading.Thread(
+        target=_bg_reader,
+        args=(bg, proc.stderr, "stderr"),
+        name=f"bg-{handle}-err",
+        daemon=True,
+    )
+    bg.threads = [t_out, t_err]
+    t_out.start()
+    t_err.start()
+    with _ACTIVE_BG_LOCK:
+        _ACTIVE_BG_PROCS[handle] = bg
+    return (
+        f"started {handle} (pid {proc.pid}, name={label}): {command}\n"
+        f"use read_output({handle!r}) / wait_for({handle!r}) / "
+        f"kill_process({handle!r})"
+    )
+
+
+def _decode_with_drop(buf: bytearray, since: int, dropped: int) -> tuple[str, int]:
+    """Decode `buf[since:]` to text, prepending a drop-notice if any
+    bytes have been evicted by the rolling cap.
+
+    `since` is an absolute byte offset (counts every byte ever written
+    to the stream, including ones the cap has since dropped). The
+    buffer's index 0 corresponds to absolute byte `dropped`. We clamp
+    the read forward when `since < dropped` and emit a
+    `...truncated NN bytes...` notice so the agent knows it lost a
+    prefix.
+
+    Returns (text, total_seen) — `total_seen` is the absolute byte
+    count for the next call to pass as `since` for tail-follow.
+    """
+    total_seen = dropped + len(buf)
+    start = max(0, since - dropped)
+    chunk = bytes(buf[start:])
+    text = chunk.decode("utf-8", errors="replace")
+    notice = ""
+    if dropped > 0 and since < dropped:
+        skipped = dropped - since
+        notice = f"...truncated {skipped} bytes...\n"
+    return notice + text, total_seen
+
+
+def read_output(handle: str, *, since: int = 0, max_chars: int = 4000) -> str:
+    """Read captured stdout+stderr from a background process.
+
+    Returns whatever has been captured since byte offset `since`,
+    capped at `max_chars`. Use the offset returned in the trailing
+    `next_since:` line to tail-follow on subsequent calls without
+    re-reading bytes you've already seen. Stderr (when non-empty)
+    follows stdout under a `[stderr]` divider so the agent can tell
+    them apart — exact interleaving across streams is intentionally
+    not preserved.
+
+    Args:
+        handle: Handle returned by `run_background`.
+        since: Byte offset to start reading from. Defaults to 0 (the
+            start of the buffer, accounting for any rolling-cap drops).
+        max_chars: Hard cap on the inline output. Defaults to 4000.
+            Truncation appends a `...[N more chars; raise max_chars
+            or read again with since=...]` marker.
+
+    Returns:
+        Multi-line block: a header naming the handle and process
+        status, the captured output, and a `next_since:` line for
+        tail-follow. Stale handles and bad arguments come back as
+        `<...>` markers.
+    """
+    try:
+        since = int(since)
+    except (TypeError, ValueError):
+        return f"<error: since must be an integer, got {since!r}>"
+    try:
+        max_chars = int(max_chars)
+    except (TypeError, ValueError):
+        return f"<error: max_chars must be an integer, got {max_chars!r}>"
+    if max_chars <= 0:
+        return f"<error: max_chars must be positive, got {max_chars}>"
+
+    bg = _coerce_handle(handle)
+    if isinstance(bg, str):
+        return bg
+
+    with bg.lock:
+        out_text, out_next = _decode_with_drop(
+            bg.stdout_buf, since, bg.dropped_stdout
+        )
+        err_text, err_next = _decode_with_drop(
+            bg.stderr_buf, since, bg.dropped_stderr
+        )
+    rc = bg.proc.poll()
+    status = "running" if rc is None else f"exited (rc={rc})"
+
+    body = out_text
+    if err_text.strip():
+        body = f"{out_text.rstrip()}\n[stderr]\n{err_text}"
+
+    truncated_chars = 0
+    if len(body) > max_chars:
+        truncated_chars = len(body) - max_chars
+        body = body[:max_chars]
+
+    header = f"{bg.handle} ({bg.name}) {status}"
+    footer_lines = [f"next_since: {max(out_next, err_next)}"]
+    if truncated_chars:
+        footer_lines.append(
+            f"...[{truncated_chars} more chars; raise max_chars "
+            f"or call again with a higher since]"
+        )
+    return f"{header}\n{body}\n" + "\n".join(footer_lines)
+
+
+def _combined_text(bg: _BackgroundProc) -> str:
+    """Snapshot the current combined output as text. Stderr is
+    appended after stdout — exact interleaving isn't preserved but
+    substring/regex matches against either land correctly."""
+    with bg.lock:
+        out = bytes(bg.stdout_buf)
+        err = bytes(bg.stderr_buf)
+    return out.decode("utf-8", errors="replace") + err.decode(
+        "utf-8", errors="replace"
+    )
+
+
+def _tail(text: str, n: int = 400) -> str:
+    if len(text) <= n:
+        return text
+    return "..." + text[-n:]
+
+
+def wait_for(
+    handle: str,
+    *,
+    timeout_s: float = 30,
+    until: str = "exit",
+) -> str:
+    """Block (with timeout) until a background process meets a condition.
+
+    `until` syntax:
+      - `"exit"` — wait for the process to exit; returns the exit code.
+      - `"output_contains:STRING"` — return when STRING appears in
+        combined stdout+stderr.
+      - `"output_matches:REGEX"` — same, but `re.search` against the
+        combined output.
+      - `"silence:Ns"` — return once N seconds have passed with no new
+        bytes written. Useful for "the build settled."
+
+    All conditions respect `timeout_s`; exceeding it returns
+    `<timed out: ...>` with a tail of the captured output.
+
+    Args:
+        handle: Handle returned by `run_background`.
+        timeout_s: Maximum seconds to block. Defaults to 30.
+        until: Condition expression (see syntax above). Defaults to
+            `"exit"`.
+
+    Returns:
+        Short status report (`matched`, `exited`, etc.) plus a tail of
+        the captured output. Stale handles and bad arguments come back
+        as `<...>` markers.
+    """
+    try:
+        timeout_s = float(timeout_s)
+    except (TypeError, ValueError):
+        return f"<error: timeout_s must be a number, got {timeout_s!r}>"
+    if not isinstance(until, str) or not until:
+        return f"<error: until must be a non-empty string, got {until!r}>"
+
+    bg = _coerce_handle(handle)
+    if isinstance(bg, str):
+        return bg
+
+    deadline = time.monotonic() + max(timeout_s, 0.0)
+    poll_interval = 0.05
+
+    if until == "exit":
+        try:
+            rc = bg.proc.wait(timeout=max(timeout_s, 0.0))
+        except subprocess.TimeoutExpired:
+            tail = _tail(_combined_text(bg))
+            return (
+                f"<timed out: {bg.handle} ({bg.name}) still running after "
+                f"{timeout_s}s; tail:\n{tail}>"
+            )
+        tail = _tail(_combined_text(bg))
+        return (
+            f"exited {bg.handle} ({bg.name}) rc={rc}\ntail:\n{tail}"
+        )
+
+    if until.startswith("output_contains:"):
+        needle = until[len("output_contains:"):]
+        if not needle:
+            return "<error: output_contains needs a non-empty substring>"
+        while time.monotonic() < deadline:
+            if needle in _combined_text(bg):
+                tail = _tail(_combined_text(bg))
+                return (
+                    f"matched {bg.handle} ({bg.name}) on substring "
+                    f"{needle!r}\ntail:\n{tail}"
+                )
+            if bg.proc.poll() is not None:
+                # Process exited before we matched. Check one more time
+                # in case the final bytes landed under the lock.
+                if needle in _combined_text(bg):
+                    tail = _tail(_combined_text(bg))
+                    return (
+                        f"matched {bg.handle} ({bg.name}) on substring "
+                        f"{needle!r} (after exit)\ntail:\n{tail}"
+                    )
+                tail = _tail(_combined_text(bg))
+                return (
+                    f"<exited before match: {bg.handle} ({bg.name}) "
+                    f"exited rc={bg.proc.returncode} without producing "
+                    f"{needle!r}; tail:\n{tail}>"
+                )
+            time.sleep(poll_interval)
+        tail = _tail(_combined_text(bg))
+        return (
+            f"<timed out: {bg.handle} ({bg.name}) did not produce "
+            f"{needle!r} within {timeout_s}s; tail:\n{tail}>"
+        )
+
+    if until.startswith("output_matches:"):
+        pattern = until[len("output_matches:"):]
+        if not pattern:
+            return "<error: output_matches needs a non-empty regex>"
+        try:
+            regex = re.compile(pattern)
+        except re.error as e:
+            return f"<error: invalid regex {pattern!r}: {e}>"
+        while time.monotonic() < deadline:
+            text = _combined_text(bg)
+            m = regex.search(text)
+            if m:
+                tail = _tail(text)
+                return (
+                    f"matched {bg.handle} ({bg.name}) on regex "
+                    f"{pattern!r} (match: {m.group(0)!r})\ntail:\n{tail}"
+                )
+            if bg.proc.poll() is not None:
+                text = _combined_text(bg)
+                m = regex.search(text)
+                if m:
+                    tail = _tail(text)
+                    return (
+                        f"matched {bg.handle} ({bg.name}) on regex "
+                        f"{pattern!r} (after exit, match: "
+                        f"{m.group(0)!r})\ntail:\n{tail}"
+                    )
+                tail = _tail(text)
+                return (
+                    f"<exited before match: {bg.handle} ({bg.name}) "
+                    f"exited rc={bg.proc.returncode} without matching "
+                    f"{pattern!r}; tail:\n{tail}>"
+                )
+            time.sleep(poll_interval)
+        tail = _tail(_combined_text(bg))
+        return (
+            f"<timed out: {bg.handle} ({bg.name}) did not match "
+            f"{pattern!r} within {timeout_s}s; tail:\n{tail}>"
+        )
+
+    if until.startswith("silence:"):
+        spec = until[len("silence:"):]
+        if spec.endswith("s"):
+            spec = spec[:-1]
+        try:
+            quiet_s = float(spec)
+        except ValueError:
+            return f"<error: silence:Ns expected a number, got {spec!r}>"
+        if quiet_s <= 0:
+            return f"<error: silence:Ns must be positive, got {quiet_s}>"
+        while time.monotonic() < deadline:
+            now = time.monotonic()
+            with bg.lock:
+                last = bg.last_write
+            if (now - last) >= quiet_s:
+                tail = _tail(_combined_text(bg))
+                return (
+                    f"settled {bg.handle} ({bg.name}) — "
+                    f"{quiet_s}s without new output\ntail:\n{tail}"
+                )
+            if bg.proc.poll() is not None:
+                # Exited; treat the remaining quiet window as instantly
+                # satisfied — no more output is coming.
+                tail = _tail(_combined_text(bg))
+                return (
+                    f"settled {bg.handle} ({bg.name}) — process exited "
+                    f"rc={bg.proc.returncode}\ntail:\n{tail}"
+                )
+            time.sleep(poll_interval)
+        tail = _tail(_combined_text(bg))
+        return (
+            f"<timed out: {bg.handle} ({bg.name}) kept producing output "
+            f"for {timeout_s}s without a {quiet_s}s quiet window; "
+            f"tail:\n{tail}>"
+        )
+
+    return (
+        f"<error: unknown until={until!r}; expected one of "
+        f"'exit', 'output_contains:STRING', 'output_matches:REGEX', "
+        f"'silence:Ns'>"
+    )
+
+
+def kill_process(handle: str) -> str:
+    """SIGKILL a background process and forget the handle.
+
+    Idempotent in spirit: a stale handle returns the standard
+    `<error: handle ... is not active in this session>` marker. After
+    a successful kill the handle is removed from the registry, so a
+    follow-up `read_output` against it also returns the stale marker.
+
+    Args:
+        handle: Handle returned by `run_background`.
+
+    Returns:
+        Confirmation line with the final exit code (or `unknown` if
+        the wait raced the kill). Stale handles come back as `<...>`.
+    """
+    bg = _coerce_handle(handle)
+    if isinstance(bg, str):
+        return bg
+    try:
+        os.killpg(bg.proc.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        # Already exited; fall through and clean up.
+        pass
+    try:
+        rc = bg.proc.wait(timeout=2.0)
+        rc_str = str(rc)
+    except subprocess.TimeoutExpired:
+        rc_str = "unknown (wait timed out)"
+    with _ACTIVE_BG_LOCK:
+        _ACTIVE_BG_PROCS.pop(bg.handle, None)
+    return (
+        f"killed {bg.handle} ({bg.name}) rc={rc_str}"
     )
 
 

--- a/pyagent/tools.py
+++ b/pyagent/tools.py
@@ -35,10 +35,18 @@ _BG_BUF_DROP = 256 * 1024
 class _BackgroundProc:
     """Live state for one `run_background` shell subprocess.
 
-    The reader threads pump bytes into stdout_buf / stderr_buf under
-    `lock`; tools that read or wait take the same lock when peeking.
-    `dropped_*` tracks bytes evicted by the rolling cap so a subsequent
+    Both reader threads pump bytes into a single combined `output_buf`
+    under `lock`; tools that read or wait take the same lock when
+    peeking. A `[stderr]\\n` / `[stdout]\\n` marker is inserted on
+    stream transitions so the agent can tell sources apart even
+    though exact temporal interleaving across streams isn't preserved.
+    `dropped` counts bytes evicted by the rolling cap so a subsequent
     `read_output` can prepend `...truncated NN bytes...`.
+
+    Single-buffer design (vs. one buffer per stream): `since` is then
+    a single absolute byte offset into a single sequence. With
+    separate buffers, the same `since` applied to two independent
+    cursors silently dropped data on the slower stream.
     """
 
     handle: str
@@ -47,10 +55,9 @@ class _BackgroundProc:
     proc: subprocess.Popen
     start_time: float
     lock: threading.Lock = field(default_factory=threading.Lock)
-    stdout_buf: bytearray = field(default_factory=bytearray)
-    stderr_buf: bytearray = field(default_factory=bytearray)
-    dropped_stdout: int = 0
-    dropped_stderr: int = 0
+    output_buf: bytearray = field(default_factory=bytearray)
+    dropped: int = 0
+    last_source: str = ""  # "stdout" | "stderr" | "" (initial)
     last_write: float = 0.0
     threads: list[threading.Thread] = field(default_factory=list)
 
@@ -673,7 +680,7 @@ def _bg_handle() -> str:
 
 
 def _bg_reader(bg: _BackgroundProc, stream, which: str) -> None:
-    """Pump bytes from `stream` into the per-handle buffer.
+    """Pump bytes from `stream` into the combined output buffer.
 
     Holds the lock only across the buffer mutation so concurrent
     `read_output` / `wait_for` can keep observing while bytes flow.
@@ -681,6 +688,11 @@ def _bg_reader(bg: _BackgroundProc, stream, which: str) -> None:
     unbounded — agents rarely care about start-of-stream once the
     process has been running for a while, but they do need recent
     output to be intact.
+
+    On a stream transition (stdout→stderr or back), inserts a
+    `[stderr]\\n` / `[stdout]\\n` marker so the agent can still tell
+    sources apart in the combined log. Stdout-only processes (the
+    common case) emit no markers.
     """
     try:
         while True:
@@ -693,15 +705,24 @@ def _bg_reader(bg: _BackgroundProc, stream, which: str) -> None:
             if not chunk:
                 break
             with bg.lock:
-                buf = bg.stdout_buf if which == "stdout" else bg.stderr_buf
-                buf.extend(chunk)
-                if len(buf) > _BG_BUF_CAP:
-                    overflow = len(buf) - (_BG_BUF_CAP - _BG_BUF_DROP)
-                    del buf[:overflow]
-                    if which == "stdout":
-                        bg.dropped_stdout += overflow
-                    else:
-                        bg.dropped_stderr += overflow
+                # Insert a transition marker only when the source
+                # actually changes; the initial state (last_source="")
+                # treats stdout as the implicit default — no leading
+                # `[stdout]` marker on processes that never use stderr.
+                if which != bg.last_source and (
+                    bg.last_source != "" or which != "stdout"
+                ):
+                    if bg.output_buf and not bg.output_buf.endswith(b"\n"):
+                        bg.output_buf.append(0x0A)  # newline
+                    bg.output_buf.extend(f"[{which}]\n".encode())
+                bg.last_source = which
+                bg.output_buf.extend(chunk)
+                if len(bg.output_buf) > _BG_BUF_CAP:
+                    overflow = len(bg.output_buf) - (
+                        _BG_BUF_CAP - _BG_BUF_DROP
+                    )
+                    del bg.output_buf[:overflow]
+                    bg.dropped += overflow
                 bg.last_write = time.monotonic()
     except (ValueError, OSError):
         # Stream closed underneath us (proc died, fd reaped). The
@@ -830,15 +851,18 @@ def _decode_with_drop(buf: bytearray, since: int, dropped: int) -> tuple[str, in
 
 
 def read_output(handle: str, *, since: int = 0, max_chars: int = 4000) -> str:
-    """Read captured stdout+stderr from a background process.
+    """Read captured output from a background process.
 
     Returns whatever has been captured since byte offset `since`,
     capped at `max_chars`. Use the offset returned in the trailing
     `next_since:` line to tail-follow on subsequent calls without
-    re-reading bytes you've already seen. Stderr (when non-empty)
-    follows stdout under a `[stderr]` divider so the agent can tell
-    them apart — exact interleaving across streams is intentionally
-    not preserved.
+    re-reading bytes you've already seen.
+
+    stdout and stderr share one buffer; on a stream transition the
+    reader inserts a `[stderr]\\n` / `[stdout]\\n` marker so the agent
+    can tell sources apart. Exact temporal interleaving across
+    streams isn't preserved — but the byte-position cursor is
+    unambiguous.
 
     Args:
         handle: Handle returned by `run_background`.
@@ -870,44 +894,33 @@ def read_output(handle: str, *, since: int = 0, max_chars: int = 4000) -> str:
         return bg
 
     with bg.lock:
-        out_text, out_next = _decode_with_drop(
-            bg.stdout_buf, since, bg.dropped_stdout
-        )
-        err_text, err_next = _decode_with_drop(
-            bg.stderr_buf, since, bg.dropped_stderr
+        text, next_since = _decode_with_drop(
+            bg.output_buf, since, bg.dropped
         )
     rc = bg.proc.poll()
     status = "running" if rc is None else f"exited (rc={rc})"
 
-    body = out_text
-    if err_text.strip():
-        body = f"{out_text.rstrip()}\n[stderr]\n{err_text}"
-
     truncated_chars = 0
-    if len(body) > max_chars:
-        truncated_chars = len(body) - max_chars
-        body = body[:max_chars]
+    if len(text) > max_chars:
+        truncated_chars = len(text) - max_chars
+        text = text[:max_chars]
 
     header = f"{bg.handle} ({bg.name}) {status}"
-    footer_lines = [f"next_since: {max(out_next, err_next)}"]
+    footer_lines = [f"next_since: {next_since}"]
     if truncated_chars:
         footer_lines.append(
             f"...[{truncated_chars} more chars; raise max_chars "
             f"or call again with a higher since]"
         )
-    return f"{header}\n{body}\n" + "\n".join(footer_lines)
+    return f"{header}\n{text}\n" + "\n".join(footer_lines)
 
 
 def _combined_text(bg: _BackgroundProc) -> str:
-    """Snapshot the current combined output as text. Stderr is
-    appended after stdout — exact interleaving isn't preserved but
-    substring/regex matches against either land correctly."""
+    """Snapshot the current combined output as text. With the
+    single-buffer design, this is just the buffer decoded — stream
+    transitions are already marked inline by the reader threads."""
     with bg.lock:
-        out = bytes(bg.stdout_buf)
-        err = bytes(bg.stderr_buf)
-    return out.decode("utf-8", errors="replace") + err.decode(
-        "utf-8", errors="replace"
-    )
+        return bytes(bg.output_buf).decode("utf-8", errors="replace")
 
 
 def _tail(text: str, n: int = 400) -> str:

--- a/tests/smoke_background_exec.py
+++ b/tests/smoke_background_exec.py
@@ -179,20 +179,77 @@ def _check_buffer_cap_truncation() -> None:
     res = agent_tools.wait_for(handle, until="exit", timeout_s=10.0)
     assert "rc=0" in res, res
     bg = agent_tools._ACTIVE_BG_PROCS[handle]
-    # The cap is 1MB; 1.5MB written should leave dropped_stdout > 0.
-    assert bg.dropped_stdout > 0, (
-        f"expected stdout drops, got dropped_stdout={bg.dropped_stdout}"
+    # The cap is 1MB; 1.5MB written should leave dropped > 0.
+    assert bg.dropped > 0, (
+        f"expected output drops, got dropped={bg.dropped}"
     )
     # And the buffer itself should be near (≤) the cap.
-    assert len(bg.stdout_buf) <= 1024 * 1024, (
-        f"buffer exceeded cap: {len(bg.stdout_buf)}"
+    assert len(bg.output_buf) <= 1024 * 1024, (
+        f"buffer exceeded cap: {len(bg.output_buf)}"
     )
     out = agent_tools.read_output(handle, since=0, max_chars=200)
     assert "...truncated" in out, out
+    # Post-truncation continuity: pulling next_since out of the first
+    # read and using it on the next call must not re-read the dropped
+    # prefix and must not silently skip any bytes available now. With
+    # an exited process the buffer is stable, so a second call with
+    # next_since should return an empty body and the same next_since.
+    next_since = int(re.search(r"next_since: (\d+)", out).group(1))
+    assert next_since > 0, out
+    second = agent_tools.read_output(
+        handle, since=next_since, max_chars=200
+    )
+    assert "...truncated" not in second, (
+        f"unexpected truncation notice on continuation: {second!r}"
+    )
+    second_next = int(re.search(r"next_since: (\d+)", second).group(1))
+    assert second_next == next_since, (
+        f"next_since regressed across post-truncation reads: "
+        f"first={next_since} second={second_next}"
+    )
     agent_tools.kill_process(handle)
     print(
-        f"  ok 1MB cap: dropped {bg.dropped_stdout} bytes, "
-        f"buf={len(bg.stdout_buf)}"
+        f"  ok 1MB cap: dropped {bg.dropped} bytes, "
+        f"buf={len(bg.output_buf)}, post-truncation continuity holds"
+    )
+
+
+def _check_dual_stream_read_output() -> None:
+    """A process that writes to BOTH stdout and stderr should not lose
+    bytes from either stream when the agent tail-follows via `since`.
+
+    Regression guard for the original two-buffer design where the same
+    `since` was applied independently to stdout_buf and stderr_buf —
+    if one stream had grown past the other's length, bytes on the
+    shorter stream were silently skipped on subsequent reads.
+    """
+    cmd = (
+        "echo OUT1; "
+        "echo ERR1 1>&2; "
+        "sleep 0.05; "
+        "echo OUT2; "
+        "echo ERR2 1>&2; "
+        "sleep 0.05; "
+        "echo OUT3; "
+        "echo ERR3 1>&2"
+    )
+    started = agent_tools.run_background(cmd)
+    handle = re.search(r"started (bg-[0-9a-f]+)", started).group(1)
+    agent_tools.wait_for(handle, until="exit", timeout_s=5.0)
+    full = agent_tools.read_output(handle, since=0, max_chars=4000)
+    # Every line landed in the combined log.
+    for marker in ("OUT1", "OUT2", "OUT3", "ERR1", "ERR2", "ERR3"):
+        assert marker in full, (
+            f"expected {marker} in combined output, got: {full!r}"
+        )
+    # `[stderr]` / `[stdout]` markers appear when the source switches —
+    # the exact count depends on read1 timing, but at least one of each
+    # must show up.
+    assert "[stderr]" in full, f"missing [stderr] marker: {full!r}"
+    agent_tools.kill_process(handle)
+    print(
+        "  ok dual-stream read_output: stdout+stderr both surfaced; "
+        "transition markers present"
     )
 
 
@@ -251,6 +308,7 @@ def main() -> None:
     _check_kill_active_flushes_both()
     _check_stale_handle_marker()
     _check_buffer_cap_truncation()
+    _check_dual_stream_read_output()
     _check_max_chars_truncation()
     _check_dangerous_pattern_refusal()
     _check_shutdown_background_grace()

--- a/tests/smoke_background_exec.py
+++ b/tests/smoke_background_exec.py
@@ -1,0 +1,261 @@
+"""Unit smoke for the background-shell tools.
+
+Covers the run_background / read_output / wait_for / kill_process
+quartet end-to-end, plus the kill_active extension that flushes BOTH
+foreground execute and background-proc registries.
+
+Run with:
+
+    .venv/bin/python -m tests.smoke_background_exec
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+import time
+
+from pyagent import permissions
+from pyagent import tools as agent_tools
+
+
+def _check_run_and_wait_exit() -> None:
+    """run_background + wait_for(exit) returns rc and tail."""
+    out = agent_tools.run_background(
+        "echo hello-bg && exit 0", name="quick-echo"
+    )
+    handle = re.search(r"started (bg-[0-9a-f]+)", out).group(1)
+    assert handle.startswith("bg-"), out
+    res = agent_tools.wait_for(handle, until="exit", timeout_s=5.0)
+    assert "exited" in res, res
+    assert "rc=0" in res, res
+    assert "hello-bg" in res, res
+    # Cleanup so other checks see a clean registry.
+    agent_tools.kill_process(handle)
+    print(f"  ok run_background + wait_for(exit): {handle}")
+
+
+def _check_incremental_read_output() -> None:
+    """read_output's `since` cursor lets the agent tail-follow."""
+    started = agent_tools.run_background(
+        "for i in 1 2 3 4 5; do echo line$i; sleep 0.05; done"
+    )
+    handle = re.search(r"started (bg-[0-9a-f]+)", started).group(1)
+    # Wait briefly for some output.
+    time.sleep(0.15)
+    first = agent_tools.read_output(handle, since=0, max_chars=4000)
+    assert "line1" in first, first
+    next_since = int(re.search(r"next_since: (\d+)", first).group(1))
+    assert next_since > 0, first
+    # Wait for the process to finish, then tail-follow.
+    agent_tools.wait_for(handle, until="exit", timeout_s=5.0)
+    second = agent_tools.read_output(handle, since=next_since, max_chars=4000)
+    # The follow-up read should NOT contain line1 (we already saw it).
+    body = second.split("\n", 1)[1]
+    assert "line1" not in body, f"tail re-emitted line1:\n{second}"
+    # And it should contain at least one of the later lines we hadn't
+    # seen at the time of the first read.
+    assert any(f"line{n}" in body for n in (4, 5)), second
+    agent_tools.kill_process(handle)
+    print(f"  ok incremental read_output (since cursor): {handle}")
+
+
+def _check_output_contains() -> None:
+    """wait_for(output_contains:STRING) returns when the substring lands."""
+    started = agent_tools.run_background(
+        "(sleep 0.2; echo READY-MARKER; sleep 5)"
+    )
+    handle = re.search(r"started (bg-[0-9a-f]+)", started).group(1)
+    t0 = time.monotonic()
+    res = agent_tools.wait_for(
+        handle, until="output_contains:READY-MARKER", timeout_s=5.0
+    )
+    elapsed = time.monotonic() - t0
+    assert "matched" in res, res
+    assert elapsed < 3.0, f"output_contains slow: {elapsed:.2f}s"
+    agent_tools.kill_process(handle)
+    print(f"  ok wait_for(output_contains:): {handle} matched in {elapsed:.2f}s")
+
+
+def _check_silence_wait() -> None:
+    """wait_for(silence:Ns) returns when output stops flowing."""
+    # Process emits 3 lines fast then goes quiet (sleeps 5s before
+    # the next line).
+    started = agent_tools.run_background(
+        "(echo a; echo b; echo c; sleep 5; echo d)"
+    )
+    handle = re.search(r"started (bg-[0-9a-f]+)", started).group(1)
+    t0 = time.monotonic()
+    res = agent_tools.wait_for(
+        handle, until="silence:0.5s", timeout_s=4.0
+    )
+    elapsed = time.monotonic() - t0
+    assert "settled" in res, res
+    # Should have settled within the 0.5s quiet window plus a little
+    # poll slack — well under the 5s sleep that comes next.
+    assert elapsed < 2.0, f"silence wait too slow: {elapsed:.2f}s"
+    agent_tools.kill_process(handle)
+    print(f"  ok wait_for(silence:0.5s): {handle} settled in {elapsed:.2f}s")
+
+
+def _check_kill_process_flow() -> None:
+    """kill_process SIGKILLs the proc, removes the handle, returns rc."""
+    started = agent_tools.run_background("sleep 30", name="napper")
+    handle = re.search(r"started (bg-[0-9a-f]+)", started).group(1)
+    assert handle in agent_tools._ACTIVE_BG_PROCS
+    res = agent_tools.kill_process(handle)
+    assert "killed" in res, res
+    assert "rc=" in res, res
+    assert handle not in agent_tools._ACTIVE_BG_PROCS, "handle not removed"
+    # Stale handle -> standard <...> marker.
+    again = agent_tools.kill_process(handle)
+    assert again.startswith("<error: handle"), again
+    print(f"  ok kill_process flow + stale-handle marker: {handle}")
+
+
+def _check_kill_active_flushes_both() -> None:
+    """kill_active() reaches into both foreground and background sets."""
+    # Background sleep.
+    started = agent_tools.run_background("sleep 30")
+    handle = re.search(r"started (bg-[0-9a-f]+)", started).group(1)
+    assert handle in agent_tools._ACTIVE_BG_PROCS
+
+    # Foreground sleep on a worker thread (mirrors smoke_kill_active).
+    fg_result: dict = {}
+
+    def runner() -> None:
+        fg_result["output"] = agent_tools.execute("sleep 30")
+
+    t = threading.Thread(target=runner, daemon=True)
+    t.start()
+
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline:
+        if agent_tools._ACTIVE_EXEC_PROCS:
+            break
+        time.sleep(0.01)
+    assert agent_tools._ACTIVE_EXEC_PROCS, "execute did not register a proc"
+
+    killed = agent_tools.kill_active()
+    assert killed >= 2, f"expected kill_active to kill both, got {killed}"
+    t.join(timeout=5.0)
+    assert not t.is_alive(), "execute did not return after kill_active"
+    # Foreground proc list cleaned up by execute()'s finally block.
+    assert not agent_tools._ACTIVE_EXEC_PROCS, "fg list not cleaned up"
+    # Background entry stays in the registry until kill_process /
+    # shutdown_background — but the proc itself is dead.
+    bg_entry = agent_tools._ACTIVE_BG_PROCS.get(handle)
+    assert bg_entry is not None
+    bg_entry.proc.wait(timeout=2.0)
+    assert bg_entry.proc.returncode is not None, "bg proc not reaped"
+    agent_tools.kill_process(handle)
+    print(f"  ok kill_active flushes fg + bg ({killed} signalled)")
+
+
+def _check_stale_handle_marker() -> None:
+    """Operating against an unknown handle returns the standard marker."""
+    bogus = "bg-deadbeef"
+    for fn, args in [
+        (agent_tools.read_output, (bogus,)),
+        (agent_tools.wait_for, (bogus,)),
+        (agent_tools.kill_process, (bogus,)),
+    ]:
+        res = fn(*args)
+        assert res.startswith(
+            f"<error: handle {bogus} is not active in this session>"
+        ), f"{fn.__name__} stale-handle marker wrong: {res!r}"
+    print("  ok stale-handle marker shape")
+
+
+def _check_buffer_cap_truncation() -> None:
+    """1MB cap drops oldest bytes and exposes `...truncated NN bytes...`."""
+    # Print ~1.5MB of `x`s in a single line (1.5M chars + newline)
+    # so the rolling cap fires at least once.
+    payload_bytes = 1_500_000
+    started = agent_tools.run_background(
+        f"head -c {payload_bytes} /dev/zero | tr '\\0' 'x'"
+    )
+    handle = re.search(r"started (bg-[0-9a-f]+)", started).group(1)
+    res = agent_tools.wait_for(handle, until="exit", timeout_s=10.0)
+    assert "rc=0" in res, res
+    bg = agent_tools._ACTIVE_BG_PROCS[handle]
+    # The cap is 1MB; 1.5MB written should leave dropped_stdout > 0.
+    assert bg.dropped_stdout > 0, (
+        f"expected stdout drops, got dropped_stdout={bg.dropped_stdout}"
+    )
+    # And the buffer itself should be near (≤) the cap.
+    assert len(bg.stdout_buf) <= 1024 * 1024, (
+        f"buffer exceeded cap: {len(bg.stdout_buf)}"
+    )
+    out = agent_tools.read_output(handle, since=0, max_chars=200)
+    assert "...truncated" in out, out
+    agent_tools.kill_process(handle)
+    print(
+        f"  ok 1MB cap: dropped {bg.dropped_stdout} bytes, "
+        f"buf={len(bg.stdout_buf)}"
+    )
+
+
+def _check_max_chars_truncation() -> None:
+    """read_output respects max_chars and emits a truncation marker."""
+    started = agent_tools.run_background("yes 'abcdefgh' | head -n 200")
+    handle = re.search(r"started (bg-[0-9a-f]+)", started).group(1)
+    agent_tools.wait_for(handle, until="exit", timeout_s=5.0)
+    res = agent_tools.read_output(handle, since=0, max_chars=200)
+    assert "more chars" in res, res
+    # Body itself (between header and footer) should be capped at
+    # roughly max_chars; we check the inline marker is there and that
+    # the response is short enough to be useful.
+    assert len(res) < 600, f"response not actually truncated: {len(res)} chars"
+    agent_tools.kill_process(handle)
+    print("  ok read_output max_chars truncation")
+
+
+def _check_dangerous_pattern_refusal() -> None:
+    """run_background applies the same safety blocklist as execute."""
+    res = agent_tools.run_background("rm -rf /")
+    assert res.startswith("<refused:"), res
+    print("  ok run_background dangerous-pattern refusal")
+
+
+def _check_shutdown_background_grace() -> None:
+    """shutdown_background SIGTERMs then SIGKILLs the lingerers."""
+    # Trap SIGTERM in the child so it has to wait for the SIGKILL
+    # branch (verifies we don't hang past grace_s).
+    started = agent_tools.run_background(
+        "trap '' TERM; sleep 30"
+    )
+    handle = re.search(r"started (bg-[0-9a-f]+)", started).group(1)
+    t0 = time.monotonic()
+    signalled = agent_tools.shutdown_background(grace_s=0.2)
+    elapsed = time.monotonic() - t0
+    assert signalled >= 1, f"expected ≥1 signalled, got {signalled}"
+    assert elapsed < 2.0, f"shutdown too slow: {elapsed:.2f}s"
+    bg = agent_tools._ACTIVE_BG_PROCS[handle]
+    bg.proc.wait(timeout=2.0)
+    assert bg.proc.returncode is not None
+    agent_tools._ACTIVE_BG_PROCS.pop(handle, None)
+    print(
+        f"  ok shutdown_background SIGTERM→SIGKILL in {elapsed:.2f}s "
+        f"({signalled} signals)"
+    )
+
+
+def main() -> None:
+    permissions.set_workspace(".")
+    _check_run_and_wait_exit()
+    _check_incremental_read_output()
+    _check_output_contains()
+    _check_silence_wait()
+    _check_kill_process_flow()
+    _check_kill_active_flushes_both()
+    _check_stale_handle_marker()
+    _check_buffer_cap_truncation()
+    _check_max_chars_truncation()
+    _check_dangerous_pattern_refusal()
+    _check_shutdown_background_grace()
+    print("\nALL CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/smoke_roles.py
+++ b/tests/smoke_roles.py
@@ -127,10 +127,12 @@ def test_register_tools_allowlist() -> None:
 
     a2 = Agent(client=EchoClient())
     agent_proc._register_tools(a2, allow_meta=False, allowlist=None)
-    # Default set: read/write file, list, grep, execute, fetch_url,
-    # read/write ledger, read_skill (no meta).
+    # Default set: read/write/edit file, list, grep, glob, execute,
+    # run_background, read_output, wait_for, kill_process, fetch_url,
+    # read_skill (no meta).
     assert "execute" in a2.tools and "spawn_subagent" not in a2.tools
-    assert len(a2.tools) == 9, sorted(a2.tools)
+    assert "run_background" in a2.tools and "kill_process" in a2.tools
+    assert len(a2.tools) == 13, sorted(a2.tools)
     print("✓ _register_tools allowlist=None → full default set, no meta")
 
 


### PR DESCRIPTION
## Summary

Adds four tools so the agent can start a long-running shell command — dev server, watcher, build — and continue working while it runs. Foreground `execute` keeps its 60s timeout for short one-shots; the new quartet picks up everything that needs to be checked on later.

## Tool surface

| Tool | Purpose |
| --- | --- |
| `run_background(command, name=None)` | Spawn detached, return a `bg-XXXXXXXX` handle. |
| `read_output(handle, since=0, max_chars=4000)` | Captured bytes since offset; `next_since:` footer for tail-follow; `[stderr]` divider when stderr is non-empty. |
| `wait_for(handle, timeout_s=30, until=...)` | Block on `"exit"` / `"output_contains:S"` / `"output_matches:RE"` / `"silence:Ns"`. |
| `kill_process(handle)` | SIGKILL the group, drop the handle. |

## Lifecycle

- State lives in module-level `_ACTIVE_BG_PROCS` keyed by handle.
- Two reader threads per process pump bytes via `read1` (so short bursts surface immediately rather than blocking for a 4KB fill).
- 1MB rolling buffer per stream; overflow drops the oldest 256KB and prepends `...truncated NN bytes...` on the next read. Bytes decoded per-read with `errors="replace"` so partial UTF-8 doesn't break reads.
- Same `_DANGEROUS_PATTERNS` blocklist as `execute` — `run_background` refuses an `rm -rf /` too.
- `kill_active()` now SIGKILLs both foreground and background sets, so a single Esc leaves nothing lingering.
- New `shutdown_background()` runs from `agent_proc.child_main` after the work loop exits: SIGTERM with a 2s grace, then SIGKILL.
- Persistence: none. Stale handles return the standard `<error: handle bg-X is not active in this session>` marker.

## Smoke

`tests/smoke_background_exec.py` — 11 checks: exit waits, incremental read with the `since` cursor, output_contains, silence settle, kill_process flow, kill_active flushing fg+bg together, stale-handle markers, 1MB buffer cap with truncation marker, max_chars truncation, dangerous-pattern refusal, SIGTERM→SIGKILL grace path. Updated `tests/smoke_roles.py` for the new default tool count (9→13).

Full suite: **28/28** passing.

## Test plan

- [x] `python -m tests.smoke_background_exec` — 11/11
- [x] `python -m tests.smoke_kill_active` — pre-existing fg cancel still works
- [x] All 28 smokes pass

Closes #37