### PR TITLE
prompts: surface OS, shell, and python in environment footer

### DIFF
--- a/pyagent/prompts.py
+++ b/pyagent/prompts.py
@@ -34,6 +34,7 @@ here. Disabling that plugin removes its sections cleanly.
 from __future__ import annotations
 
 import os
+import platform
 from datetime import date
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable
@@ -156,10 +157,16 @@ class SystemPromptBuilder:
 
     def _persona_footer(self) -> str:
         today = date.today()
+        shell_path = os.environ.get("SHELL") or os.environ.get("COMSPEC") or ""
+        shell = Path(shell_path).name if shell_path else "unknown"
+        os_label = f"{platform.system()} {platform.release()}".strip() or "unknown"
         return (
             "## Environment\n"
             f"- cwd: {os.getcwd()}\n"
             f"- date: {today.isoformat()} ({today.strftime('%A')})\n"
+            f"- os: {os_label}\n"
+            f"- shell: {shell}\n"
+            f"- python: {platform.python_version()}\n"
             "\n"
             "## Where your persona lives\n"
             "Your SOUL, TOOLS, and PRIMER are loaded from the paths "

--- a/tests/smoke_prompt_environment.py
+++ b/tests/smoke_prompt_environment.py
@@ -1,0 +1,54 @@
+"""Smoke test for the system-prompt environment footer.
+
+Asserts the persona footer surfaces enough host context (OS, shell,
+python) for the agent to pick the right shell idioms.
+
+Run with:
+
+    .venv/bin/python -m tests.smoke_prompt_environment
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import tempfile
+from pathlib import Path
+
+from pyagent.prompts import SystemPromptBuilder
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        soul = root / "SOUL.md"
+        tools = root / "TOOLS.md"
+        primer = root / "PRIMER.md"
+        soul.write_text("soul")
+        tools.write_text("tools")
+        primer.write_text("primer")
+
+        builder = SystemPromptBuilder(soul=soul, tools=tools, primer=primer)
+        stable, _volatile = builder.build_segments()
+
+    assert "## Environment" in stable, stable
+    assert "- cwd:" in stable, stable
+    assert "- date:" in stable, stable
+    assert "- os:" in stable, stable
+    assert "- shell:" in stable, stable
+    assert "- python:" in stable, stable
+
+    assert platform.system() in stable, stable
+    assert platform.python_version() in stable, stable
+
+    expected_shell = (
+        Path(os.environ.get("SHELL") or os.environ.get("COMSPEC") or "").name
+        or "unknown"
+    )
+    assert f"- shell: {expected_shell}" in stable, stable
+
+    print("✓ environment footer renders os/shell/python")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- The persona footer in `pyagent/prompts.py` told the agent its `cwd` and `date` but said nothing about the host. Without that context the model guesses between bash and cmd.exe, between GNU and BSD userland flavors, and between Python versions when picking shell idioms or syntax.
- Adds `os`, `shell`, and `python` lines to the same footer block so the agent can pick the right commands for the platform it is actually running on.
- Lives in the stable cache segment alongside `cwd`/`date`. Values are constant within a process, so cache behavior is unchanged.

## Test plan
- [x] `.venv/bin/python -m tests.smoke_prompt_environment` (new test)
- [x] `.venv/bin/python -m tests.smoke_plugins` (covers cache-stability assertions on the stable segment)