### PR TITLE
primer + execute: guard against polluting user-level Python

### DIFF
--- a/pyagent/defaults/PRIMER.md
+++ b/pyagent/defaults/PRIMER.md
@@ -21,6 +21,15 @@ rest is on you.
 - Read-only inspection (`ls`, `git status`, `cat` inside workspace)
   is fine without asking.
 
+## Python environments
+
+- **`pip install` belongs in a project-local venv** — not the system
+  interpreter, pyenv interpreters, or `--user`. `--break-system-packages`
+  is not an answer.
+- Use `$VIRTUAL_ENV` if set, else `.venv/` or `venv/` in the workspace;
+  create `.venv/` if needed.
+- One-shot CLI tools (formatters, linters): `pipx` or `uv tool run`.
+
 ## Don't invent
 
 - File paths, function names, flags, API shapes — verify first with

--- a/pyagent/tools.py
+++ b/pyagent/tools.py
@@ -578,6 +578,18 @@ _DANGEROUS_PATTERNS: list[tuple[str, str]] = [
         "force push to main/master",
     ),
     (r"\bchmod\s+-R\s+[0-7]{3,4}\s+/(?:\s|$)", "recursive chmod on /"),
+    (
+        r"\bpip\d?\s+install\b[^|;&]*\s--break-system-packages\b",
+        "pip install bypassing PEP 668 (--break-system-packages)",
+    ),
+    (
+        r"\bpip\d?\s+install\b[^|;&]*\s--user\b",
+        "pip install --user (writes to ~/.local; use a project venv)",
+    ),
+    (
+        r"\bsudo\b[^|;&]*\bpip\d?\s+install\b",
+        "pip install under sudo (escalates to a shared interpreter)",
+    ),
 ]
 
 

--- a/tests/smoke_pip_safety.py
+++ b/tests/smoke_pip_safety.py
@@ -1,0 +1,49 @@
+"""Smoke test for pip-pollution danger patterns.
+
+Asserts `_safety_check` flags installs that would pollute system or
+user-level Python and that benign pip use still passes.
+
+Run with:
+
+    .venv/bin/python -m tests.smoke_pip_safety
+"""
+
+from __future__ import annotations
+
+from pyagent.tools import _safety_check
+
+
+def main() -> None:
+    blocked = [
+        ("pip install foo --break-system-packages",
+         "--break-system-packages"),
+        ("pip3 install --break-system-packages requests",
+         "--break-system-packages"),
+        ("pip install --user httpx", "--user"),
+        ("pip3 install httpx --user", "--user"),
+        ("sudo pip install requests", "sudo"),
+        ("sudo -H pip3 install requests", "sudo"),
+    ]
+    for cmd, fragment in blocked:
+        reason = _safety_check(cmd)
+        assert reason is not None, f"expected block, got pass: {cmd!r}"
+        print(f"✓ blocked ({fragment}): {cmd!r} → {reason!r}")
+
+    allowed = [
+        ".venv/bin/pip install requests",
+        ".venv/bin/pip install -r requirements.txt",
+        "uv pip install httpx",
+        "pip install foo",
+        "pip download --user-agent custom foo",
+        "git log --user.email",
+    ]
+    for cmd in allowed:
+        reason = _safety_check(cmd)
+        assert reason is None, f"expected pass, got blocked: {cmd!r} → {reason!r}"
+        print(f"✓ allowed: {cmd!r}")
+
+    print("\nALL CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds a **Python environments** section to the default PRIMER so the agent's posture is pip-into-a-project-venv by default, not the system / pyenv / `--user` interpreter.
- Adds three patterns to `execute()`'s `_DANGEROUS_PATTERNS`: `--break-system-packages`, `--user`, and `sudo pip install`. These extend the posture beyond what PEP 668 already covers (which only fences `/usr/lib/python`).
- Belt-and-suspenders: PRIMER shapes default behavior; the regex guard catches the times the model forgets.

## Out of scope (tracked separately)
- Auto-creating a workspace `.venv/`, sharing it across subagents, and serializing installs via `flock`. Filed as a follow-up issue.
- Bidirectional / mid-task subagent ↔ parent communication (current model is one-shot per turn). Filed as a separate follow-up issue.

## Test plan
- [x] `.venv/bin/python -m tests.smoke_pip_safety` (new — 6 block + 6 allow cases incl. false-positive guards on `--user-agent` / `git log --user.email`)
- [x] `.venv/bin/python -m tests.smoke_kill_active` (touches the `execute` path through `_safety_check`)