### PR TITLE
checklist: agent-managed task list, surfaced in CLI footer (#38)

### DIFF
--- a/pyagent/agent_proc.py
+++ b/pyagent/agent_proc.py
@@ -46,6 +46,12 @@ from pyagent import skills as skills_mod
 from pyagent import subagent as subagent_mod
 from pyagent import tools as agent_tools
 from pyagent.agent import Agent
+from pyagent.checklist import (
+    Checklist,
+    make_add_task,
+    make_list_tasks,
+    make_update_task,
+)
 from pyagent.llms import get_client
 from pyagent.prompts import SystemPromptBuilder
 from pyagent.session import Session
@@ -393,6 +399,7 @@ def _register_tools(
     base_config: dict[str, Any] | None = None,
     allow_meta: bool = False,
     allowlist: list[str] | None = None,
+    checklist: Checklist | None = None,
 ) -> None:
     """Register the default tool set on `agent`.
 
@@ -442,6 +449,14 @@ def _register_tools(
         auto_offload=False,
         evict_after_use=True,
     )
+    if checklist is not None:
+        # Checklist tools share state with the CLI footer via a
+        # per-mutation `checklist` event. Roles can scope these out via
+        # the allowlist (e.g. a one-shot validator subagent shouldn't
+        # be maintaining a task list).
+        _add("add_task", make_add_task(checklist), auto_offload=False)
+        _add("update_task", make_update_task(checklist), auto_offload=False)
+        _add("list_tasks", make_list_tasks(checklist), auto_offload=False)
     if allow_meta:
         assert state is not None and parent_session is not None and base_config is not None
         _add(
@@ -562,6 +577,24 @@ def _bootstrap(
     # status (sync vs async mode) when routing turn_complete events.
     state.agent = agent
 
+    # Checklist tools live on the root agent only — a per-session
+    # construct, not per-agent. Subagents that try to track their
+    # own work would compete with the root's list for the user's
+    # one footer slot, and subagent runs are typically too short to
+    # warrant a checklist anyway.
+    if not is_subagent:
+        checklist = Checklist(
+            session.dir / "checklist.json",
+            on_change=lambda tasks: state.send("checklist", tasks=tasks),
+        )
+        # Replay the persisted snapshot to the CLI on resume so the
+        # footer reflects prior state immediately, before the model
+        # touches the list.
+        if checklist.tasks:
+            state.send("checklist", tasks=checklist.list())
+    else:
+        checklist = None
+
     # Meta-tools registered when the role allows further spawning.
     # Recursion is bounded by `max_depth` in config (the spawn tool
     # refuses if `agent.depth + 1 > max_depth`). Roles with
@@ -575,6 +608,7 @@ def _bootstrap(
         base_config=config,
         allow_meta=allow_meta,
         allowlist=allowlist,
+        checklist=checklist,
     )
 
     # Plugin introspection tool, available to the agent for self-

--- a/pyagent/checklist.py
+++ b/pyagent/checklist.py
@@ -1,0 +1,224 @@
+"""Agent-managed task checklist.
+
+A small, flat list of tasks the model maintains over the course of a
+multi-step turn. The model uses the `add_task` / `update_task` /
+`list_tasks` tools to drive it; the CLI reads the same state to render
+a progress segment in the status footer.
+
+State is per-session — persisted to `<session.dir>/checklist.json` so
+`--resume` brings the list back. Snapshots-on-mutation (atomic rename)
+rather than append-only JSONL because the typical task count is small
+(≤ ~20) and in-place mutation is the dominant op; replaying an event
+log to reconstruct state would be all cost, no benefit.
+
+Statuses are flat: `pending`, `in_progress`, `completed`, `cancelled`.
+There is intentionally no nesting — flat lists are what the model
+handles well and what the footer can render.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from pathlib import Path
+from typing import Any, Callable
+
+VALID_STATUSES = ("pending", "in_progress", "completed", "cancelled")
+
+
+class Checklist:
+    """Session-scoped checklist with atomic JSON persistence.
+
+    Thread-safe (a `_lock` serializes all mutations and the load/save
+    pair) so the agent's tool-execution thread can't race with anything
+    else looking at `tasks`. The instance owns its persistence path —
+    callers don't write the file directly.
+    """
+
+    def __init__(
+        self,
+        path: Path,
+        on_change: Callable[[list[dict[str, Any]]], None] | None = None,
+    ) -> None:
+        self.path = path
+        self._on_change = on_change
+        self._lock = threading.Lock()
+        self.tasks: list[dict[str, Any]] = []
+        self._next_id: int = 1
+        self._load()
+
+    def _load(self) -> None:
+        if not self.path.exists():
+            return
+        try:
+            data = json.loads(self.path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return
+        tasks = data.get("tasks") or []
+        if isinstance(tasks, list):
+            self.tasks = [t for t in tasks if isinstance(t, dict)]
+        nxt = data.get("next_id")
+        if isinstance(nxt, int) and nxt > 0:
+            self._next_id = nxt
+        else:
+            # Recover from a malformed file: pick max-id + 1 so a new
+            # add doesn't collide with an existing task.
+            mx = 0
+            for t in self.tasks:
+                tid = t.get("id", "")
+                if isinstance(tid, str) and tid.startswith("t-"):
+                    try:
+                        mx = max(mx, int(tid[2:]))
+                    except ValueError:
+                        pass
+            self._next_id = mx + 1
+
+    def _save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        payload = {"tasks": self.tasks, "next_id": self._next_id}
+        tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2))
+        os.replace(tmp, self.path)
+
+    def _notify(self) -> None:
+        if self._on_change is None:
+            return
+        try:
+            self._on_change(list(self.tasks))
+        except Exception:
+            # The change-listener (event emit) must never break a tool.
+            pass
+
+    def add(self, title: str) -> dict[str, Any]:
+        title = (title or "").strip()
+        if not title:
+            raise ValueError("title is required")
+        with self._lock:
+            tid = f"t-{self._next_id}"
+            self._next_id += 1
+            entry = {"id": tid, "title": title, "status": "pending", "note": ""}
+            self.tasks.append(entry)
+            self._save()
+        self._notify()
+        return dict(entry)
+
+    def update(
+        self, id: str, status: str, note: str | None = None
+    ) -> dict[str, Any]:
+        if status not in VALID_STATUSES:
+            raise ValueError(
+                f"status must be one of {VALID_STATUSES!r}, got {status!r}"
+            )
+        with self._lock:
+            for t in self.tasks:
+                if t.get("id") == id:
+                    t["status"] = status
+                    if note is not None:
+                        t["note"] = note
+                    self._save()
+                    found = dict(t)
+                    break
+            else:
+                raise KeyError(f"no task with id {id!r}")
+        self._notify()
+        return found
+
+    def list(self) -> list[dict[str, Any]]:
+        with self._lock:
+            return [dict(t) for t in self.tasks]
+
+    def summary(self) -> dict[str, Any] | None:
+        """Return the footer-friendly digest, or None for no surfaceable state.
+
+        Counts: `completed` and `total` ignore cancelled tasks (they're
+        neither in-progress nor a denominator the user cares about).
+        `current_title` picks the task `in_progress`; if none, the next
+        `pending`. Returns None when the list is empty or every task is
+        completed/cancelled — caller drops the segment.
+        """
+        with self._lock:
+            tasks = list(self.tasks)
+        if not tasks:
+            return None
+        total = sum(1 for t in tasks if t.get("status") != "cancelled")
+        completed = sum(1 for t in tasks if t.get("status") == "completed")
+        if total == 0 or completed == total:
+            return None
+        current = next(
+            (t for t in tasks if t.get("status") == "in_progress"),
+            None,
+        ) or next(
+            (t for t in tasks if t.get("status") == "pending"),
+            None,
+        )
+        current_title = current.get("title", "") if current else ""
+        return {
+            "completed": completed,
+            "total": total,
+            "current_title": current_title,
+        }
+
+
+def make_add_task(checklist: Checklist) -> Callable[..., dict[str, Any]]:
+    def add_task(title: str) -> dict[str, Any]:
+        """Append a new task to the session checklist.
+
+        Use this BEFORE starting a multi-step job (≥3 distinct
+        subtasks) so the user can see what you intend to do and you
+        can self-monitor across tool calls. Skip the checklist
+        entirely for one-shot work — a single file edit, a one-line
+        question, a quick lookup. Indiscriminate use is worse than
+        none.
+
+        Each task is a short imperative phrase (e.g. "write
+        migration", "run tests", "update README"), not a long
+        sentence — the title appears in a one-line footer. Returns
+        the new task's id; pass that id to `update_task` later to
+        change its status.
+        """
+        return checklist.add(title)
+
+    return add_task
+
+
+def make_update_task(checklist: Checklist) -> Callable[..., dict[str, Any]]:
+    def update_task(
+        id: str, status: str, note: str = ""
+    ) -> dict[str, Any]:
+        """Change a task's status (and optionally attach a note).
+
+        `status` is one of: `pending`, `in_progress`, `completed`,
+        `cancelled`. Discipline that makes the checklist work:
+
+        - **Exactly one task `in_progress` at a time.** Move the
+          previous one to `completed` (or `cancelled`) before
+          starting the next. Two tasks "in_progress" at once means
+          you're not really tracking either.
+        - **Mark `completed` immediately when done — don't batch.**
+          Updating five tasks at the end of a turn defeats the point;
+          the user can't see progress and you can't catch yourself
+          drifting.
+        - **Use `cancelled` (with a `note`) when you abandon a step**
+          — e.g. the approach turned out to be wrong. Don't silently
+          leave it `pending`.
+
+        `note` is freeform context: a blocker, a decision, why you
+        cancelled. Empty string leaves the existing note unchanged.
+        """
+        return checklist.update(id, status, note=note if note else None)
+
+    return update_task
+
+
+def make_list_tasks(checklist: Checklist) -> Callable[..., list[dict[str, Any]]]:
+    def list_tasks() -> list[dict[str, Any]]:
+        """Return the current checklist (id, title, status, note).
+
+        Useful when re-orienting after a long tool result or a
+        cancelled subagent — confirm what's still pending before
+        deciding what to do next.
+        """
+        return checklist.list()
+
+    return list_tasks

--- a/pyagent/cli.py
+++ b/pyagent/cli.py
@@ -167,6 +167,33 @@ def _agents_tokens(agents: dict) -> tuple[int, int, int, int]:
     return in_tot, out_tot, cw_tot, cr_tot
 
 
+_CHECKLIST_TITLE_MAX = 40
+
+
+def _checklist_segment(agents: dict) -> str:
+    """Return the footer's checklist segment ('· N/M · "title"') or empty.
+
+    Reads the most recent checklist snapshot stashed under
+    `agents["root"]["checklist"]` by `_update_agents_state`. Drops out
+    cleanly when there's no list, or when every task is done — the
+    point of the segment is *progress on something live*, not a
+    monument to past work.
+    """
+    cl = agents.get("root", {}).get("checklist")
+    if not cl:
+        return ""
+    total = cl.get("total", 0)
+    completed = cl.get("completed", 0)
+    if total <= 0 or completed >= total:
+        return ""
+    title = cl.get("current_title", "") or ""
+    if len(title) > _CHECKLIST_TITLE_MAX:
+        title = title[: _CHECKLIST_TITLE_MAX - 1] + "…"
+    if title:
+        return f" · {completed}/{total} · {title}"
+    return f" · {completed}/{total}"
+
+
 def _render_status(agents: dict, model: str = "") -> str:
     """Return the rich-markup string for the status footer.
 
@@ -178,18 +205,22 @@ def _render_status(agents: dict, model: str = "") -> str:
     drawing pipes. Order is insertion order (root first, then
     subagents in spawn order) which gives a stable left-to-right read.
     Token/cost suffix is the aggregate across the whole tree.
+
+    Both renderings get a checklist segment appended when the root
+    agent has a non-empty, not-yet-finished task list.
     """
     in_tot, out_tot, cw_tot, cr_tot = _agents_tokens(agents)
     suffix = _format_usage_suffix(in_tot, out_tot, model, cw_tot, cr_tot)
+    checklist = _checklist_segment(agents)
     if len(agents) <= 1:
         status = agents.get("root", {}).get("status", "thinking")
-        return f"[dim]{status}…{suffix}[/dim]"
+        return f"[dim]{status}…{checklist}{suffix}[/dim]"
     parts = []
     for key, info in agents.items():
         label = "root" if key == "root" else key
         parts.append(f"{label}([cyan]{info['status']}[/cyan])")
     body = " [/dim][dim]│[/dim] [dim]".join(parts)
-    return f"[dim]{body}{suffix}[/dim]"
+    return f"[dim]{body}{checklist}{suffix}[/dim]"
 
 
 def _update_agents_state(
@@ -232,6 +263,35 @@ def _update_agents_state(
         if m:
             agents.pop(m.group("sid"), None)
             return
+    if kind == "checklist":
+        # Always lands on root: the checklist is a per-session
+        # construct, not per-agent. (Subagents don't get their own
+        # list — see pyagent/checklist.py.) Compute the footer
+        # summary here so _render_status doesn't have to re-walk
+        # the task list on every redraw.
+        tasks = event.get("tasks") or []
+        slot = agents.setdefault("root", {"status": "thinking"})
+        if not tasks:
+            slot.pop("checklist", None)
+            slot["checklist_tasks"] = []
+            return
+        total = sum(1 for t in tasks if t.get("status") != "cancelled")
+        completed = sum(1 for t in tasks if t.get("status") == "completed")
+        current = next(
+            (t for t in tasks if t.get("status") == "in_progress"), None
+        ) or next(
+            (t for t in tasks if t.get("status") == "pending"), None
+        )
+        slot["checklist"] = {
+            "completed": completed,
+            "total": total,
+            "current_title": current.get("title", "") if current else "",
+        }
+        # Stash the full list so /tasks can render it without an IPC
+        # round-trip. Cheap (≤ ~20 entries) and avoids an additional
+        # request/response event type.
+        slot["checklist_tasks"] = tasks
+        return
     if kind == "usage":
         slot = agents.setdefault(key, {"status": "idle"})
         # Use .get(k, 0) + … so old two-key dicts in long-running state
@@ -310,6 +370,32 @@ def _prompt_permission(
         sys.stderr.write(
             f"  unrecognized: {answer!r} — please answer y, n, or a\n"
         )
+
+
+_TASK_STATUS_GLYPH = {
+    "pending": "○",
+    "in_progress": "▶",
+    "completed": "✓",
+    "cancelled": "✗",
+}
+
+
+def _print_tasks(agents: dict) -> None:
+    """Print the full checklist inline. Bound to the `/tasks` slash
+    command. Reads the latest snapshot stashed by the `checklist`
+    event; no IPC round-trip needed."""
+    tasks = agents.get("root", {}).get("checklist_tasks") or []
+    if not tasks:
+        console.print("[dim]no tasks[/dim]")
+        return
+    for t in tasks:
+        glyph = _TASK_STATUS_GLYPH.get(t.get("status", ""), "·")
+        title = t.get("title", "")
+        note = t.get("note", "")
+        line = f"[dim]  {glyph} {title}[/dim]"
+        if note:
+            line += f"  [dim grey42]— {note}[/dim grey42]"
+        console.print(line)
 
 
 def _handle_model_command(
@@ -424,6 +510,12 @@ def _drive_turn(
             # Token-counter event. State already updated by
             # _update_agents_state and reflected in the footer; no
             # additional rendering needed here.
+            pass
+        elif kind == "checklist":
+            # State already updated by _update_agents_state; the footer
+            # picked up the new summary via status.update above. No
+            # inline render — checklist activity is intentionally
+            # quiet, surfaced only via the footer and `/tasks`.
             pass
         elif kind == "ready":
             # Sub-agent became ready — purely informational here, the
@@ -750,6 +842,9 @@ def main(
                 continue
             if stripped.startswith("/model"):
                 model = _handle_model_command(parent_conn, stripped, model)
+                continue
+            if stripped == "/tasks":
+                _print_tasks(agents_state)
                 continue
             try:
                 protocol.send(parent_conn, "user_prompt", prompt=prompt)

--- a/pyagent/defaults/TOOLS.md
+++ b/pyagent/defaults/TOOLS.md
@@ -88,6 +88,32 @@ thing started.
   default `True` is right for news / blogs / articles where chrome
   dwarfs the body.
 
+## Tracking multi-step work
+
+For genuine multi-step jobs — three or more distinct subtasks, or
+work that spans several tool batches — maintain a checklist with
+`add_task` / `update_task` / `list_tasks`. The user sees current
+progress in the status footer (`3/7 · "writing migration"`), so the
+list is also a status indicator, not just an internal note.
+
+- **Skip the checklist for one-shot work.** Single edit, single
+  question, quick lookup → no list. Indiscriminate use is worse
+  than none — it adds noise without any of the focus benefit.
+- **Plan up front when the shape is clear.** `add_task` for each
+  step before starting, then drive each one to `in_progress` →
+  `completed` as you go.
+- **Exactly one task `in_progress` at a time.** Move the previous
+  one to `completed` (or `cancelled`) before starting the next.
+  Two "in_progress" at once means you aren't tracking either.
+- **Mark `completed` immediately when done — don't batch.** The
+  user's footer lags otherwise, and you lose the self-monitoring
+  benefit on the next turn.
+- **`cancelled` (with a `note`) when you abandon a step.** Don't
+  silently leave it `pending`; the user reading the list later
+  should be able to tell what happened.
+- **Titles are short imperative phrases.** "write migration",
+  "run tests", "update README" — they appear in a one-line footer.
+
 ## Errors
 
 Predictable failures come back as data, not exceptions: a marker

--- a/pyagent/protocol.py
+++ b/pyagent/protocol.py
@@ -62,6 +62,12 @@ agent → CLI
         accumulates these per-agent in its `agents_state` dict and
         renders the running total (and a USD cost estimate when
         the model is in the pricing table) in the status footer.
+  - checklist {tasks: list[dict]}
+        Snapshot of the agent's current task list. Emitted after
+        every add_task / update_task call. `tasks` is a list of
+        `{id, title, status, note}` dicts in insertion order. The
+        CLI uses it to render a progress segment in the status footer
+        and to print full state on `/tasks`.
   - turn_complete {final_text: str}
         The child finished a `user_prompt` (no errors). `final_text`
         is the aggregated assistant text returned by `agent.run` and

--- a/tests/smoke_checklist.py
+++ b/tests/smoke_checklist.py
@@ -1,0 +1,281 @@
+"""Smoke for the agent-managed checklist (issue #38).
+
+Locks the contract for `pyagent.checklist.Checklist`, the three
+tool factories that bind to it, the `checklist` event flowing into
+`_update_agents_state`, and the footer rendering produced by
+`_render_status` when a checklist is live.
+
+Run with:
+
+    .venv/bin/python -m tests.smoke_checklist
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+from pathlib import Path
+
+from rich.console import Console
+
+from pyagent.checklist import (
+    Checklist,
+    make_add_task,
+    make_list_tasks,
+    make_update_task,
+)
+from pyagent.cli import (
+    _CHECKLIST_TITLE_MAX,
+    _checklist_segment,
+    _print_tasks,
+    _render_status,
+    _update_agents_state,
+)
+
+
+def render_plain(markup: str) -> str:
+    buf = io.StringIO()
+    Console(file=buf, force_terminal=False, color_system=None).print(markup)
+    return buf.getvalue().rstrip()
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "checklist.json"
+
+        # 1. Empty checklist persists nothing yet, summary is None.
+        emitted: list[list[dict]] = []
+        cl = Checklist(path, on_change=lambda tasks: emitted.append(tasks))
+        assert cl.list() == []
+        assert cl.summary() is None
+        assert not path.exists()
+        print("✓ empty checklist: no file, no summary")
+
+        # 2. add → file exists, summary reports 0/N with current title,
+        #    on_change fired with the snapshot.
+        a = cl.add("write migration")
+        b = cl.add("run tests")
+        c = cl.add("update README")
+        assert a["id"] == "t-1" and a["status"] == "pending"
+        assert path.exists()
+        assert len(emitted) == 3, f"on_change fired {len(emitted)}x"
+        s = cl.summary()
+        assert s == {
+            "completed": 0,
+            "total": 3,
+            "current_title": "write migration",
+        }, s
+        print(f"✓ add: {s}")
+
+        # 3. update to in_progress shifts the current title to the
+        #    newly active task.
+        cl.update("t-1", "in_progress")
+        s = cl.summary()
+        assert s["current_title"] == "write migration", s
+        # Move t-1 to completed; current should fall through to t-2 (pending).
+        cl.update("t-1", "completed")
+        s = cl.summary()
+        assert s == {
+            "completed": 1,
+            "total": 3,
+            "current_title": "run tests",
+        }, s
+        print(f"✓ update progresses current: {s}")
+
+        # 4. Cancelled task drops out of total and current.
+        cl.update("t-2", "cancelled", note="superseded by manual fix")
+        s = cl.summary()
+        assert s == {
+            "completed": 1,
+            "total": 2,
+            "current_title": "update README",
+        }, s
+        print(f"✓ cancelled excluded from total: {s}")
+
+        # 5. All-complete summary returns None (footer drops segment).
+        cl.update("t-3", "completed")
+        assert cl.summary() is None, cl.summary()
+        print("✓ all complete → summary None")
+
+        # 6. Resume: a new Checklist on the same path picks up state
+        #    AND continues the id sequence past the existing max.
+        cl2 = Checklist(path)
+        assert [t["id"] for t in cl2.list()] == ["t-1", "t-2", "t-3"]
+        d = cl2.add("post-merge cleanup")
+        assert d["id"] == "t-4", d
+        print(f"✓ resume: ids continue → {d['id']}")
+
+        # 7. Bad inputs raise — caller (the agent) sees the error.
+        try:
+            cl2.update("t-1", "bogus_status")
+        except ValueError as e:
+            assert "status must be one of" in str(e)
+            print(f"✓ bad status raises: {e}")
+        else:
+            raise AssertionError("expected ValueError on bad status")
+        try:
+            cl2.update("t-999", "completed")
+        except KeyError as e:
+            assert "t-999" in str(e)
+            print(f"✓ unknown id raises: {e}")
+        else:
+            raise AssertionError("expected KeyError on unknown id")
+        try:
+            cl2.add("   ")
+        except ValueError as e:
+            assert "title is required" in str(e)
+            print(f"✓ empty title raises: {e}")
+        else:
+            raise AssertionError("expected ValueError on empty title")
+
+        # 8. JSON on disk round-trips cleanly (next_id preserved).
+        data = json.loads(path.read_text())
+        assert data["next_id"] == 5, data
+        assert len(data["tasks"]) == 4, data
+        print(f"✓ disk format: next_id={data['next_id']}")
+
+    # 9. Tool factories: add_task / update_task / list_tasks behave
+    #    as the model would experience them.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cl = Checklist(Path(tmpdir) / "checklist.json")
+        add = make_add_task(cl)
+        upd = make_update_task(cl)
+        lst = make_list_tasks(cl)
+        t = add("design schema")
+        assert t["id"] == "t-1" and t["title"] == "design schema"
+        upd(t["id"], "in_progress")
+        upd(t["id"], "completed", note="reviewed in PR")
+        rows = lst()
+        assert rows[0]["status"] == "completed"
+        assert rows[0]["note"] == "reviewed in PR"
+        print("✓ tool factories: add/update/list end-to-end")
+
+    # 10. CLI footer integration: checklist event populates root,
+    #     _render_status shows the segment, all-complete drops it.
+    agents: dict = {"root": {"status": "thinking"}}
+    _update_agents_state(
+        agents,
+        {
+            "type": "checklist",
+            "tasks": [
+                {"id": "t-1", "title": "write migration",
+                 "status": "in_progress", "note": ""},
+                {"id": "t-2", "title": "run tests",
+                 "status": "pending", "note": ""},
+                {"id": "t-3", "title": "update README",
+                 "status": "pending", "note": ""},
+            ],
+        },
+    )
+    out = render_plain(_render_status(agents))
+    assert "0/3" in out and "write migration" in out, out
+    assert out.startswith("thinking…"), out
+    print(f"✓ footer (in_progress): {out!r}")
+
+    # Move first to completed → counts and current update.
+    _update_agents_state(
+        agents,
+        {
+            "type": "checklist",
+            "tasks": [
+                {"id": "t-1", "title": "write migration",
+                 "status": "completed", "note": ""},
+                {"id": "t-2", "title": "run tests",
+                 "status": "in_progress", "note": ""},
+                {"id": "t-3", "title": "update README",
+                 "status": "pending", "note": ""},
+            ],
+        },
+    )
+    out = render_plain(_render_status(agents))
+    assert "1/3" in out and "run tests" in out, out
+    print(f"✓ footer (advance): {out!r}")
+
+    # All-complete → segment vanishes.
+    _update_agents_state(
+        agents,
+        {
+            "type": "checklist",
+            "tasks": [
+                {"id": "t-1", "title": "x",
+                 "status": "completed", "note": ""},
+                {"id": "t-2", "title": "y",
+                 "status": "completed", "note": ""},
+            ],
+        },
+    )
+    seg = _checklist_segment(agents)
+    assert seg == "", repr(seg)
+    out = render_plain(_render_status(agents))
+    assert out == "thinking…", out
+    print("✓ footer drops segment when all complete")
+
+    # 11. Long titles get truncated in the footer (not in /tasks).
+    long_title = "x" * (_CHECKLIST_TITLE_MAX + 20)
+    _update_agents_state(
+        agents,
+        {
+            "type": "checklist",
+            "tasks": [
+                {"id": "t-1", "title": long_title,
+                 "status": "in_progress", "note": ""},
+                {"id": "t-2", "title": "next",
+                 "status": "pending", "note": ""},
+            ],
+        },
+    )
+    seg = _checklist_segment(agents)
+    assert "…" in seg, seg
+    assert len(seg) < len(long_title) + 20, seg
+    print(f"✓ long title truncated in footer: ...{seg[-30:]!r}")
+
+    # 12. /tasks renders full list including notes (no truncation).
+    _update_agents_state(
+        agents,
+        {
+            "type": "checklist",
+            "tasks": [
+                {"id": "t-1", "title": "design schema",
+                 "status": "completed", "note": "reviewed in PR"},
+                {"id": "t-2", "title": "write migration",
+                 "status": "in_progress", "note": ""},
+                {"id": "t-3", "title": "abandoned approach",
+                 "status": "cancelled", "note": "supplanted by t-2"},
+            ],
+        },
+    )
+    buf = io.StringIO()
+    captured = Console(file=buf, force_terminal=False, color_system=None)
+    # Patch the module's `console` so _print_tasks renders into our buf.
+    import pyagent.cli as cli_mod
+    real_console = cli_mod.console
+    cli_mod.console = captured
+    try:
+        _print_tasks(agents)
+    finally:
+        cli_mod.console = real_console
+    out = buf.getvalue()
+    assert "design schema" in out and "write migration" in out, out
+    assert "abandoned approach" in out, out
+    assert "reviewed in PR" in out, out
+    assert "✓" in out and "▶" in out and "✗" in out, out
+    print("✓ /tasks renders full list with status glyphs and notes")
+
+    # 13. /tasks on empty list prints "no tasks".
+    agents_empty: dict = {"root": {"status": "thinking"}}
+    buf = io.StringIO()
+    captured = Console(file=buf, force_terminal=False, color_system=None)
+    cli_mod.console = captured
+    try:
+        _print_tasks(agents_empty)
+    finally:
+        cli_mod.console = real_console
+    assert "no tasks" in buf.getvalue(), buf.getvalue()
+    print("✓ /tasks on empty: 'no tasks'")
+
+    print("\nALL CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #38.

## Summary

- New `pyagent/checklist.py`: `Checklist` class with atomic JSON persistence at `<session.dir>/checklist.json`, plus `add_task` / `update_task` / `list_tasks` tool factories. Tool docstrings carry the Claude-Code-style discipline (one `in_progress` at a time, mark completed immediately, ≥3 subtasks before reaching for it).
- Root agent only (per-session construct, not per-agent). Subagents don't get the tools — they'd compete for the user's one footer slot.
- New `checklist` protocol event fired via an `on_change` callback after every add/update; the CLI consumes it into `agents_state["root"]` and renders `· N/M · "current title"` between the thinking status and the token meter. Drops out cleanly when the list is empty or all-complete.
- `/tasks` slash command prints the full list inline with status glyphs (○ ▶ ✓ ✗) and notes — no IPC round-trip, reads the cached snapshot.
- TOOLS.md gains a "Tracking multi-step work" section codifying the discipline.

## Test plan

- [x] `tests/smoke_checklist.py` — 13 checks covering add/update/list semantics, JSONL persistence and resume, status transitions, cancelled-task accounting, footer truncation, `/tasks` rendering with and without tasks.
- [x] All 31 existing smokes still pass (verified locally).
- [ ] Manual: run `pyagent`, ask for a multi-step task, watch the footer tick through tasks; `/tasks` shows the full list; `--resume` brings the checklist back.