### PR TITLE
cli: swap readline-backed input() for prompt_toolkit PromptSession

### DIFF
--- a/pyagent/cli.py
+++ b/pyagent/cli.py
@@ -1,7 +1,6 @@
 import logging
 import multiprocessing
 import re
-import readline  # imported for side effect: enables line editing and history in input()
 import shutil
 import sys
 from multiprocessing.connection import Connection
@@ -9,6 +8,8 @@ from pathlib import Path
 from typing import Any
 
 import click
+from prompt_toolkit import PromptSession
+from prompt_toolkit.history import InMemoryHistory
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.traceback import install as install_traceback
@@ -306,19 +307,30 @@ def _update_agents_state(
         return
 
 
-def _seed_input_history(conversation: list[Any]) -> None:
-    """Populate readline's in-memory history from prior user prompts so
-    up/down arrow at the input cycles through what was typed before.
+def _build_input_history(conversation: list[Any]) -> InMemoryHistory:
+    """Seed an `InMemoryHistory` from prior user prompts so up/down at
+    the prompt cycles through what was typed before — same per-
+    process semantics readline gave us. A persistent on-disk history
+    would be a behavior change (cross-session bleed-through);
+    intentionally avoided here.
+
+    History is built eagerly; the actual `PromptSession` is
+    constructed lazily inside the REPL loop to avoid prompt_toolkit's
+    "Input is not a terminal" warning firing in non-tty contexts
+    (tests, pipes) that import this module without ever prompting.
+
     Filters to user messages with string content; tool-result turns
     are skipped because they don't have a `content` string.
     """
+    history = InMemoryHistory()
     for entry in conversation:
         if not isinstance(entry, dict) or entry.get("role") != "user":
             continue
         content = entry.get("content")
         if not isinstance(content, str):
             continue
-        readline.add_history(content)
+        history.append_string(content)
+    return history
 
 
 def _resume_callback(
@@ -742,10 +754,11 @@ def main(
     primer = paths.resolve("PRIMER.md", override=primer, seed="PRIMER.md")
     permissions.pre_approve(paths.config_dir())
 
-    # CLI keeps a read-only view of history for readline seeding and
-    # the "resumed N entries" line; the child owns writes during the run.
+    # CLI keeps a read-only view of history to seed prompt_toolkit's
+    # in-memory up-arrow history and to render the "resumed N entries"
+    # line; the child owns writes during the run.
     prior = session.load_history()
-    _seed_input_history(prior)
+    input_history = _build_input_history(prior)
 
     agent_config = {
         "cwd": str(Path.cwd().resolve()),
@@ -831,9 +844,18 @@ def main(
         # _update_agents_state.
         agents_state["root"] = {"status": "thinking"}
 
+        # PromptSession lazily — by the time we get here, stdin is the
+        # tty the user is typing into, so prompt_toolkit's no-tty
+        # warning doesn't fire.
+        input_session = PromptSession(history=input_history)
+
         while True:
             try:
-                prompt = input("> ")
+                # prompt_toolkit returns terminal modes to their pre-call
+                # state on every prompt() return — by the time the
+                # CancelWatcher (cbreak) and rich status spinner start
+                # below, prompt_toolkit has fully released the tty.
+                prompt = input_session.prompt("> ")
             except (EOFError, KeyboardInterrupt):
                 console.print()
                 break

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,10 @@ dependencies = [
     "openai>=1.50",
     "petname>=2.6",
     "platformdirs>=4",
+    # CLI input layer — replaces the stdlib readline-backed `input()`
+    # so we can keep the prompt alive while the agent is busy (typed
+    # input queue, footer redraws, etc.). pure-python, ~250KB.
+    "prompt_toolkit>=3.0",
     "requests>=2.31",
     "rich>=13",
     "tree-sitter>=0.25",

--- a/tests/smoke_prompt_toolkit.py
+++ b/tests/smoke_prompt_toolkit.py
@@ -1,0 +1,141 @@
+"""Smoke for the prompt_toolkit-backed REPL input.
+
+Runs pyagent under a real PTY so prompt_toolkit's interactive path
+is exercised (the PIPE-based smoke_ctrlc falls back to a non-tty
+input mode and wouldn't catch a regression here). Asserts:
+
+  1. The CLI starts cleanly, the agent reaches `ready`, and the `> `
+     prompt is rendered.
+  2. EOF (Ctrl-D) at the prompt cleanly exits the CLI — same
+     behavior as the readline-backed `input()` we replaced.
+  3. No Python traceback in the captured output.
+
+Uses the `pyagent/echo` stub so no network is required.
+
+Run with:
+
+    .venv/bin/python -m tests.smoke_prompt_toolkit
+"""
+
+from __future__ import annotations
+
+import os
+import pty
+import select
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+
+def _read_until(fd: int, needle: bytes, timeout_s: float) -> bytes:
+    """Read from `fd` until `needle` appears or timeout. Returns the
+    accumulated bytes regardless of whether the needle was found —
+    caller asserts."""
+    deadline = time.monotonic() + timeout_s
+    buf = bytearray()
+    while time.monotonic() < deadline:
+        remaining = deadline - time.monotonic()
+        r, _, _ = select.select([fd], [], [], min(remaining, 0.2))
+        if fd in r:
+            try:
+                chunk = os.read(fd, 4096)
+            except OSError:
+                break
+            if not chunk:
+                break
+            buf.extend(chunk)
+            if needle in buf:
+                return bytes(buf)
+    return bytes(buf)
+
+
+def main() -> None:
+    repo_root = Path(__file__).parent.parent
+    pyagent_bin = repo_root / ".venv" / "bin" / "pyagent"
+    if not pyagent_bin.exists():
+        print(f"skip: {pyagent_bin} not present")
+        return
+
+    work = Path(tempfile.mkdtemp(prefix="pyagent-pty-"))
+
+    pid, fd = pty.fork()
+    if pid == 0:
+        # Child — exec pyagent in the temp work dir.
+        os.chdir(str(work))
+        os.execv(
+            str(pyagent_bin),
+            [str(pyagent_bin), "--model", "pyagent/echo"],
+        )
+        # unreachable
+        os._exit(127)
+
+    try:
+        # Wait for the `>` prompt char to render. prompt_toolkit
+        # positions the cursor with escape sequences after the
+        # prompt, so we don't see a literal "> " — just the `>`
+        # bracketed by ANSI cursor moves. Presence of the `>` plus
+        # the session header is enough to know the REPL is live.
+        out = _read_until(fd, b">", timeout_s=10.0)
+        assert b"session:" in out, f"no session header:\n{out!r}"
+        assert b">" in out, f"no prompt rendered:\n{out!r}"
+        print("✓ ready, prompt rendered under PTY")
+
+        # Send EOF (Ctrl-D, byte 0x04) — prompt_toolkit should turn
+        # this into EOFError, which the main loop catches and exits.
+        os.write(fd, b"\x04")
+
+        # Drain any remaining output (the resume hint, etc.).
+        deadline = time.monotonic() + 10.0
+        tail = bytearray()
+        while time.monotonic() < deadline:
+            r, _, _ = select.select([fd], [], [], 0.2)
+            if fd in r:
+                try:
+                    chunk = os.read(fd, 4096)
+                except OSError:
+                    break
+                if not chunk:
+                    break
+                tail.extend(chunk)
+            else:
+                # Quiescent — check if child has exited.
+                wpid, status = os.waitpid(pid, os.WNOHANG)
+                if wpid == pid:
+                    break
+        else:
+            os.kill(pid, 9)
+            raise AssertionError("CLI did not exit within 10s of EOF")
+
+        # Reap if not already reaped.
+        try:
+            wpid, status = os.waitpid(pid, os.WNOHANG)
+        except ChildProcessError:
+            wpid, status = pid, 0
+
+        combined = bytes(out + bytes(tail))
+        assert b"Traceback" not in combined, (
+            f"traceback in PTY output:\n{combined!r}"
+        )
+        print("✓ EOF cleanly exited the CLI; no traceback")
+
+        # Exit status: 0 is the only acceptable result for a clean EOF.
+        if os.WIFEXITED(status):
+            rc = os.WEXITSTATUS(status)
+            assert rc == 0, f"unexpected exit code {rc}"
+            print(f"✓ exit code: {rc}")
+        elif os.WIFSIGNALED(status):
+            raise AssertionError(
+                f"CLI was killed by signal {os.WTERMSIG(status)}"
+            )
+
+        print("\nALL CHECKS PASSED")
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Prerequisite for #42.

## Summary

- Adds `prompt_toolkit>=3.0` as a runtime dependency (BSD, pure-python, ~250KB; pulls `wcwidth`).
- Replaces the readline-backed `input("> ")` in `cli.py`'s REPL loop with `PromptSession.prompt("> ")`. Same modal behavior — still blocks during a turn, no UX change yet.
- `_seed_input_history` becomes `_build_input_history`, returning an `InMemoryHistory` seeded from prior user prompts so up/down at the prompt cycles through what was typed before. **No** persistent on-disk history — that'd be a behavior change (cross-session bleed-through).
- The `PromptSession` itself is constructed lazily inside the REPL loop so prompt_toolkit's "Input is not a terminal" warning doesn't fire in non-tty contexts (tests, piped invocations).

## Why a separate PR

The dependency addition is the riskiest piece (tty handling, terminal mode interactions with the existing `CancelWatcher` cbreak mode and rich status spinner). Isolating it here makes a regression easy to bisect and lets #42 focus purely on queue + persistent-input logic.

## Test plan

- [x] All 31 existing smokes pass (`smoke_ctrlc` covers the SIGINT path; `smoke_subprocess` covers the agent IPC).
- [x] New `tests/smoke_prompt_toolkit.py` runs `pyagent` under a real PTY and exercises the EOF-at-prompt exit path — caught a regression that pipe-based tests would miss (prompt_toolkit positions the cursor with escape sequences after the `>` rather than printing a literal `"> "`).
- [x] `_build_input_history` unit-style verification (filters tool-result turns, preserves order, pure data structure — no tty side effects).
- [ ] Manual smoke: launch `pyagent`, send a turn, verify prompt re-renders cleanly after the agent finishes; up-arrow recalls the previous input.

## What's NOT in this PR

- Persistent input field / typed-input queue (#42).
- Any change to the cancel mechanism, status footer, or rich rendering.