### PR TITLE
cli: stop showing "thinking…" while the agent is idle

### DIFF
--- a/pyagent/cli.py
+++ b/pyagent/cli.py
@@ -219,7 +219,12 @@ def _render_status(agents: dict, model: str = "") -> str:
     checklist = _checklist_segment(agents)
     if len(agents) <= 1:
         status = agents.get("root", {}).get("status", "thinking")
-        return f"[dim]{status}…{checklist}{suffix}[/dim]"
+        # `…` indicates active work — drop it for terminal states
+        # (`ready`, `error`) so the always-on bottom_toolbar doesn't
+        # lie about what the agent is doing while it sits idle
+        # waiting for the next user input.
+        trailing = "" if status in ("ready", "error") else "…"
+        return f"[dim]{status}{trailing}{checklist}{suffix}[/dim]"
     parts = []
     for key, info in agents.items():
         label = "root" if key == "root" else key
@@ -647,6 +652,14 @@ async def _repl_async(
             elif kind == "turn_complete" and agent_id is None:
                 state["turn_busy"] = False
                 drain_queue_one()
+                # If we didn't drain into a new turn, the agent is
+                # idle. Reset root status so the always-on footer
+                # stops claiming "thinking…" while we wait for the
+                # next user input.
+                if not state["turn_busy"]:
+                    agents_state.setdefault(
+                        "root", {"status": "ready"}
+                    )["status"] = "ready"
             elif kind == "agent_error":
                 _print_event(event)
                 if agent_id is None:

--- a/tests/smoke_status_footer.py
+++ b/tests/smoke_status_footer.py
@@ -128,6 +128,26 @@ def main() -> None:
     )
     print("✓ unknown event ignored")
 
+    # Idle root: terminal `ready` and `error` statuses drop the `…`
+    # so the always-on bottom_toolbar doesn't say "thinking…" while
+    # the agent is just waiting for input.
+    idle = {"root": {"status": "ready"}}
+    out = render_plain(_render_status(idle))
+    assert out == "ready", repr(out)
+    print(f"✓ idle (ready): {out!r}")
+
+    err = {"root": {"status": "error"}}
+    out = render_plain(_render_status(err))
+    assert out == "error", repr(out)
+    print(f"✓ idle (error): {out!r}")
+
+    # Active states still show the `…`.
+    busy = {"root": {"status": "thinking"}}
+    assert render_plain(_render_status(busy)) == "thinking…"
+    busy = {"root": {"status": "· execute"}}
+    assert render_plain(_render_status(busy)) == "· execute…"
+    print("✓ active states keep '…'")
+
     print("\nALL CHECKS PASSED")
 
 


### PR DESCRIPTION
Fixes the misleading footer state introduced by #50.

## Problem

The new `bottom_toolbar` (#50) renders unconditionally. The old `rich.Console.status` was stopped explicitly at end of turn, but nothing in the new flow resets the root status from `"thinking"` to a terminal state when `turn_complete` arrives. Result: the footer keeps saying `thinking…` while the agent sits idle waiting for the next prompt.

## Fix

- `_repl_async.on_pipe`: when `turn_complete` (root) lands and the queue is empty (no immediate drain into a new turn), set root status to `"ready"`.
- `_render_status`: drop the trailing `"…"` for terminal statuses (`"ready"`, `"error"`). The dots are meant to signal in-progress work; appending them to a terminal state lied about activity.

Active states (`"thinking"`, tool-call markers like `"· execute"`) keep the `"…"` — they're the ones doing actual work.

## Test plan

- [x] `smoke_status_footer` extended with assertions for the idle and error cases (`"ready"` and `"error"` render without dots; active states keep them).
- [x] All 33 existing smokes still pass.
- [ ] Manual: run `pyagent`, send a prompt, observe the footer transition `thinking…` → `ready` after the agent finishes.