### PR TITLE
cli: animated Braille spinner in bottom_toolbar while busy

### DIFF
--- a/pyagent/cli.py
+++ b/pyagent/cli.py
@@ -5,6 +5,7 @@ import logging
 import multiprocessing
 import re
 import shutil
+import time
 from multiprocessing.connection import Connection
 from pathlib import Path
 from typing import Any
@@ -466,6 +467,29 @@ def _queue_segment(queue: "collections.deque[str]") -> str:
     return f' · queued: {n} (next: "{head}")'
 
 
+# Braille spinner — 10 frames, indistinguishable in 0-width-glyph
+# fonts but reads as a smooth rotating dot in any modern terminal.
+_SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+_SPINNER_FPS = 10  # ticks per second; chosen to feel "alive" without
+                   # being distracting. The bottom_toolbar's
+                   # refresh_interval needs to be ≤ 1/_SPINNER_FPS to
+                   # actually render every frame.
+
+
+def _spinner_segment(busy: bool) -> str:
+    """ANSI-encoded spinner prefix when `busy`, empty string otherwise.
+
+    Animation is driven by `time.monotonic()` rather than a frame
+    counter so the spinner stays smooth across redraws even if
+    prompt_toolkit's refresh interval drifts. Hidden when idle so
+    the footer doesn't pretend the agent is doing work.
+    """
+    if not busy:
+        return ""
+    idx = int(time.monotonic() * _SPINNER_FPS) % len(_SPINNER_FRAMES)
+    return f"\x1b[2m{_SPINNER_FRAMES[idx]}\x1b[0m "
+
+
 def _render_status_ansi(
     agents: dict,
     model: str,
@@ -702,8 +726,11 @@ async def _repl_async(
             pt_session.app.invalidate()
 
     def bottom_toolbar() -> ANSI:
+        # Spinner gates on `turn_busy` — visible only while the
+        # agent is actively working; stays out of the way at idle.
+        spinner = _spinner_segment(state["turn_busy"])
         return ANSI(
-            _render_status_ansi(
+            spinner + _render_status_ansi(
                 agents_state,
                 state["model"],
                 queue,
@@ -740,7 +767,10 @@ async def _repl_async(
     pt_session: PromptSession = PromptSession(
         history=input_history,
         bottom_toolbar=bottom_toolbar,
-        refresh_interval=0.5,
+        # 0.1s tick so the spinner runs at its full 10 fps; lower
+        # would burn CPU on idle redraws, higher would make the
+        # spinner look choppy.
+        refresh_interval=0.1,
         key_bindings=bindings,
         style=pt_style,
     )

--- a/tests/smoke_input_queue.py
+++ b/tests/smoke_input_queue.py
@@ -24,9 +24,11 @@ from rich.console import Console
 
 import pyagent.cli as cli_mod
 from pyagent.cli import (
+    _SPINNER_FRAMES,
     _handle_queue_command,
     _queue_segment,
     _render_status_ansi,
+    _spinner_segment,
 )
 
 
@@ -133,6 +135,20 @@ def main() -> None:
     out = _strip_ansi(_render_status_ansi(agents, "", q, "/etc/passwd"))
     assert "awaiting permission" in out and "/etc/passwd" in out, out
     print(f"✓ ansi with permission pending: {out!r}")
+
+    # 8. Spinner: empty when idle, contains a Braille frame when busy.
+    assert _spinner_segment(False) == "", repr(_spinner_segment(False))
+    print("✓ spinner hidden at idle")
+
+    busy_seg = _spinner_segment(True)
+    assert busy_seg, "spinner segment should be non-empty when busy"
+    # Strip ANSI then check the visible char is one of the Braille frames.
+    visible = _strip_ansi(busy_seg).strip()
+    assert visible in _SPINNER_FRAMES, (
+        f"unexpected spinner glyph {visible!r}; "
+        f"expected one of {_SPINNER_FRAMES!r}"
+    )
+    print(f"✓ spinner busy frame: {visible!r}")
 
     print("\nALL CHECKS PASSED")
 


### PR DESCRIPTION
The asyncio rewrite (#50) replaced `rich.Console.status` with a static `bottom_toolbar`, losing the animated spinner. The static `thinking…` text reads as inert — no visual cue that the agent is actively working. Bringing the spinner back, in the toolbar this time.

## Changes

- `_spinner_segment(busy)` returns a leading Braille frame (`⠋ ⠙ ⠹ …`) when busy, empty string when idle. Animation driven by `time.monotonic()` so frames stay smooth across redraws.
- `bottom_toolbar` callback prepends the spinner segment before `_render_status_ansi(...)`. Gates on `state["turn_busy"]` — visible only during a turn, gone when waiting for input.
- `refresh_interval` drops from 0.5s → 0.1s so the spinner ticks at its full 10 fps without looking choppy. Idle-time CPU is bounded by prompt_toolkit's existing scheduling.

## Test plan

- [x] `smoke_input_queue` extended: `_spinner_segment(False)` returns `""`, `_spinner_segment(True)` returns one of the Braille frames.
- [x] All 33 smokes pass.
- [ ] Manual: launch `pyagent`, send a slow prompt, watch the spinner rotate in the bottom toolbar; confirm it disappears when the agent finishes.