### PR TITLE
auto-venv: workspace .venv shared via pip_install + ask_parent (#46)

### DIFF
--- a/pyagent/agent_proc.py
+++ b/pyagent/agent_proc.py
@@ -533,6 +533,23 @@ def _register_tools(
             subagent_mod.make_ask_parent(state, agent),
             auto_offload=False,
         )
+    # pip_install (issue #46): registered ONLY on the root agent.
+    # The root owns the workspace's `.venv/` and serializes installs
+    # via its single-threaded turn loop. Subagents don't get this
+    # tool — they `ask_parent("install <spec>")` and the root's LLM
+    # decides whether to act. That's the parent-as-broker pattern
+    # that #47 unlocked, replacing the flock approach the issue
+    # originally proposed.
+    if state is not None and state.self_agent_id is None:
+        # `base_config["cwd"]` is the workspace path; `_bootstrap`
+        # always sets it. Tools registered without `base_config` are
+        # the test-only path — skip pip_install there.
+        if base_config is not None:
+            _add(
+                "pip_install",
+                agent_tools.make_pip_install(Path(base_config["cwd"])),
+                auto_offload=False,
+            )
     if allow_meta:
         assert state is not None and parent_session is not None and base_config is not None
         _add(

--- a/pyagent/defaults/PRIMER.md
+++ b/pyagent/defaults/PRIMER.md
@@ -23,12 +23,24 @@ rest is on you.
 
 ## Python environments
 
-- **`pip install` belongs in a project-local venv** — not the system
-  interpreter, pyenv interpreters, or `--user`. `--break-system-packages`
-  is not an answer.
-- Use `$VIRTUAL_ENV` if set, else `.venv/` or `venv/` in the workspace;
-  create `.venv/` if needed.
-- One-shot CLI tools (formatters, linters): `pipx` or `uv tool run`.
+- **Use `pip_install` for any pip install.** It routes the install
+  through the workspace's `.venv/`, auto-creating it on first call.
+  Don't reach for raw `pip` via `execute` — the shell guard refuses
+  most pollution patterns anyway, and `pip_install` is the
+  positive answer (the env footer's `venv:` line shows where it
+  lands).
+- **Subagents don't have `pip_install`.** Ask the parent:
+  `ask_parent("install requests==2.31.0")`. The parent runs the
+  install in the shared workspace venv and replies; your blocked
+  call returns when it's done. This avoids concurrent installs
+  racing on the same venv — every install funnels through the
+  root agent's single-threaded turn loop.
+- The footer's `venv:` line tells you which venv is active. After
+  any `pip_install`, you can `execute` `<venv>/bin/python -m ...`
+  or `<venv>/bin/<tool>` to run installed code.
+- **One-shot CLI tools** (formatters, linters): `pipx` or `uv tool
+  run` are still fine for things you don't want bundled into the
+  workspace venv.
 
 ## Don't invent
 

--- a/pyagent/defaults/PRIMER.md
+++ b/pyagent/defaults/PRIMER.md
@@ -38,6 +38,12 @@ rest is on you.
 - The footer's `venv:` line tells you which venv is active. After
   any `pip_install`, you can `execute` `<venv>/bin/python -m ...`
   or `<venv>/bin/<tool>` to run installed code.
+- **Want a sidecar venv?** `pip_install(spec, venv=".venv-test")`
+  installs into a separate venv (auto-created on first call)
+  without touching the main one. Useful for test deps, tool
+  installs, or trying a package without committing it to the
+  primary runtime env. Relative paths resolve against the
+  workspace; absolute paths are honored as-is.
 - **One-shot CLI tools** (formatters, linters): `pipx` or `uv tool
   run` are still fine for things you don't want bundled into the
   workspace venv.

--- a/pyagent/prompts.py
+++ b/pyagent/prompts.py
@@ -160,6 +160,11 @@ class SystemPromptBuilder:
         shell_path = os.environ.get("SHELL") or os.environ.get("COMSPEC") or ""
         shell = Path(shell_path).name if shell_path else "unknown"
         os_label = f"{platform.system()} {platform.release()}".strip() or "unknown"
+        # Re-discovered each turn so a venv created mid-session shows up
+        # without restart. Lazy import dodges the prompts → venv → ...
+        # cycle and keeps the import surface narrow.
+        from pyagent import venv as venv_mod
+        venv_line = venv_mod.describe(Path(os.getcwd()))
         return (
             "## Environment\n"
             f"- cwd: {os.getcwd()}\n"
@@ -167,6 +172,7 @@ class SystemPromptBuilder:
             f"- os: {os_label}\n"
             f"- shell: {shell}\n"
             f"- python: {platform.python_version()}\n"
+            f"- venv: {venv_line}\n"
             "\n"
             "## Where your persona lives\n"
             "Your SOUL, TOOLS, and PRIMER are loaded from the paths "

--- a/pyagent/tools.py
+++ b/pyagent/tools.py
@@ -1339,21 +1339,28 @@ def make_pip_install(workspace: Path):
     """
     from pyagent import venv as venv_mod
 
-    def pip_install(spec: str) -> str:
-        """Install a pip package into the workspace's `.venv/`.
+    def pip_install(spec: str, venv: str = "") -> str:
+        """Install a pip package into the workspace venv.
 
-        On first call, auto-creates `<workspace>/.venv/` using the
-        same Python interpreter the agent is running under. The same
-        venv is shared across this agent and any subagents that
-        spawn — they all install into and execute against the
-        workspace venv (or, more precisely: subagents `ask_parent`
-        and the root does the install on their behalf).
+        On first call against a venv path, auto-creates that venv
+        using the same Python interpreter the agent is running
+        under. The default workspace `.venv/` is shared across
+        this agent and any subagents (subagents `ask_parent` and
+        the root does the install on their behalf, so concurrent
+        installs serialize naturally).
 
         Args:
             spec: A pip-style package spec — `requests`,
                 `requests==2.31.0`, `git+https://...`, or even a
                 requirements file path. Whatever you'd pass to
                 `pip install`.
+            venv: Optional override for the target venv. Empty
+                (the default) installs into the workspace's
+                auto-discovered or auto-created `.venv/`. A
+                relative path is resolved against the workspace
+                (e.g. `".venv-test"` to keep test deps separate
+                from the main runtime venv); an absolute path is
+                used as-is. The venv is auto-created if missing.
 
         Returns:
             On success: a short summary including which venv was
@@ -1364,8 +1371,15 @@ def make_pip_install(workspace: Path):
         if not spec:
             return "<refused: empty package spec>"
 
+        venv_arg = (venv or "").strip()
         try:
-            venv_path, created = venv_mod.ensure(workspace)
+            if venv_arg:
+                target = Path(venv_arg)
+                if not target.is_absolute():
+                    target = workspace / target
+                venv_path, created = venv_mod.ensure_at(target)
+            else:
+                venv_path, created = venv_mod.ensure(workspace)
         except RuntimeError as e:
             return f"<venv setup failed: {e}>"
 

--- a/pyagent/tools.py
+++ b/pyagent/tools.py
@@ -1312,3 +1312,113 @@ def fetch_url(
     )
     preview = "\n".join(header_lines) + "\n\n" + md_inline
     return Attachment(content=body, preview=preview, suffix=suffix)
+
+
+# Workspace pip install -------------------------------------------
+#
+# Routes installs through the workspace's `.venv/`, auto-creating it
+# on first call. Registered ONLY on the root agent — subagents that
+# want to install ask their parent via `ask_parent("install ...")`,
+# which the root's LLM then translates into a `pip_install` call.
+# This is the "parent-as-broker" pattern that #46 enables on top of
+# #47, replacing the flock-serialization approach the issue
+# originally proposed.
+
+# Hard timeout for a single pip install. Long enough for fastembed-
+# class downloads on a slow connection; short enough that a hung
+# install can't wedge the agent forever.
+_PIP_INSTALL_TIMEOUT_S = 600
+
+
+def make_pip_install(workspace: Path):
+    """Build the `pip_install` tool, closing over the workspace path.
+
+    The factory is the seam that lets `_register_tools` decide
+    whether to expose this on the root agent vs. wire it through
+    `ask_parent` for subagents — see `agent_proc._register_tools`.
+    """
+    from pyagent import venv as venv_mod
+
+    def pip_install(spec: str) -> str:
+        """Install a pip package into the workspace's `.venv/`.
+
+        On first call, auto-creates `<workspace>/.venv/` using the
+        same Python interpreter the agent is running under. The same
+        venv is shared across this agent and any subagents that
+        spawn — they all install into and execute against the
+        workspace venv (or, more precisely: subagents `ask_parent`
+        and the root does the install on their behalf).
+
+        Args:
+            spec: A pip-style package spec — `requests`,
+                `requests==2.31.0`, `git+https://...`, or even a
+                requirements file path. Whatever you'd pass to
+                `pip install`.
+
+        Returns:
+            On success: a short summary including which venv was
+            used and what pip reported. On failure: a `<...>`
+            error marker with pip's stderr trimmed.
+        """
+        spec = (spec or "").strip()
+        if not spec:
+            return "<refused: empty package spec>"
+
+        try:
+            venv_path, created = venv_mod.ensure(workspace)
+        except RuntimeError as e:
+            return f"<venv setup failed: {e}>"
+
+        notice = ""
+        if created:
+            notice = f"created venv at {venv_path}\n"
+
+        pip_bin = venv_mod.pip_path(venv_path)
+        if not pip_bin.exists():
+            return (
+                f"<venv at {venv_path} has no pip executable at "
+                f"{pip_bin}; venv may be corrupt — delete and retry>"
+            )
+
+        # `--quiet` keeps the success path's output bounded; on
+        # failure pip still emits the error. `--disable-pip-version-check`
+        # silences a chatty notice that wastes context.
+        cmd = [
+            str(pip_bin),
+            "install",
+            "--quiet",
+            "--disable-pip-version-check",
+            spec,
+        ]
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=_PIP_INSTALL_TIMEOUT_S,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return (
+                f"<pip install {spec!r} timed out after "
+                f"{_PIP_INSTALL_TIMEOUT_S}s>"
+            )
+        except FileNotFoundError as e:
+            return f"<pip install failed: {e}>"
+
+        if proc.returncode == 0:
+            return (
+                f"{notice}installed {spec} into {venv_path}"
+                + (f"\n{proc.stdout.strip()}" if proc.stdout.strip() else "")
+            )
+        # Failure — surface stderr, capped so a verbose pip error
+        # doesn't blow the conversation.
+        err = (proc.stderr or proc.stdout or "").strip()
+        if len(err) > 2000:
+            err = err[:2000] + "\n…[truncated]"
+        return (
+            f"<pip install {spec!r} failed (rc={proc.returncode}):\n"
+            f"{err}>"
+        )
+
+    return pip_install

--- a/pyagent/venv.py
+++ b/pyagent/venv.py
@@ -1,0 +1,163 @@
+"""Workspace-local virtualenv discovery and management.
+
+The agent reaches for `pip install` periodically. Without a workspace
+venv, those installs would land in whatever interpreter the CLI was
+launched against — which PR #45 already guards at the shell level
+(refusing system pip / pyenv pollution / sudo). This module is the
+positive answer: discover the workspace's `.venv/` (or create one
+on first install) and route every install through it.
+
+Discovery order:
+  1. `$VIRTUAL_ENV` — if set, the user already activated something;
+     respect it.
+  2. `<workspace>/.venv` — the conventional name; what most projects
+     and editors expect.
+  3. `<workspace>/venv` — the older convention; supported for
+     compatibility with existing workspaces.
+  4. None — defer creation until something actually needs to
+     install. A workspace that never installs anything stays
+     venv-free.
+
+Auto-creation uses the running CLI's interpreter (`sys.executable`),
+so the agent's Python matches the user's. Installation routes via
+`<venv>/bin/pip`.
+
+Issue #46.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _bin_dir(venv: Path) -> Path:
+    """Cross-platform bin/Scripts dir inside a venv. Linux/macOS use
+    `bin`, Windows uses `Scripts`."""
+    return venv / ("Scripts" if os.name == "nt" else "bin")
+
+
+def pip_path(venv: Path) -> Path:
+    """Path to the venv's `pip` executable."""
+    name = "pip.exe" if os.name == "nt" else "pip"
+    return _bin_dir(venv) / name
+
+
+def python_path(venv: Path) -> Path:
+    """Path to the venv's `python` executable."""
+    name = "python.exe" if os.name == "nt" else "python"
+    return _bin_dir(venv) / name
+
+
+def is_venv(path: Path) -> bool:
+    """True iff `path` looks like a venv (has bin/python or Scripts/python.exe)."""
+    return path.is_dir() and python_path(path).exists()
+
+
+def discover(workspace: Path) -> Path | None:
+    """Return the venv this agent should use, or None if there isn't one yet.
+
+    Priority:
+      1. `$VIRTUAL_ENV` (when it points at a real venv)
+      2. `<workspace>/.venv`
+      3. `<workspace>/venv`
+
+    Symlinks are resolved so two CLI processes pointing at the same
+    workspace from different paths agree on which venv to share.
+    """
+    env_venv = os.environ.get("VIRTUAL_ENV", "").strip()
+    if env_venv:
+        p = Path(env_venv)
+        if is_venv(p):
+            return p.resolve()
+        # Stale env var (venv was deleted) — fall through to workspace
+        # discovery rather than refusing.
+        logger.warning(
+            "VIRTUAL_ENV=%s is set but does not look like a real venv; "
+            "ignoring and falling back to workspace discovery",
+            env_venv,
+        )
+
+    for name in (".venv", "venv"):
+        candidate = workspace / name
+        if is_venv(candidate):
+            return candidate.resolve()
+    return None
+
+
+def ensure(workspace: Path) -> tuple[Path, bool]:
+    """Discover an existing venv or create `<workspace>/.venv`.
+
+    Returns `(venv_path, created)` where `created` is True iff a new
+    venv was just created (so the caller can surface a one-line
+    notice). The new venv uses `sys.executable`, matching the
+    interpreter the CLI is running under.
+
+    Raises `RuntimeError` if creation fails — caller decides how to
+    surface (likely as a tool-result error marker).
+    """
+    existing = discover(workspace)
+    if existing is not None:
+        return existing, False
+
+    target = workspace / ".venv"
+    logger.info(
+        "creating workspace venv at %s using %s", target, sys.executable
+    )
+    try:
+        # `--without-pip` would be faster but then we have to
+        # bootstrap pip ourselves; default behavior installs pip.
+        subprocess.run(
+            [sys.executable, "-m", "venv", str(target)],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(
+            f"venv creation failed (rc={e.returncode}): "
+            f"{(e.stderr or e.stdout or '').strip()[:500]}"
+        ) from e
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(
+            f"venv creation timed out after 120s at {target}"
+        ) from e
+
+    if not is_venv(target):
+        raise RuntimeError(
+            f"venv creation reported success but {target} doesn't "
+            f"look like a venv afterward"
+        )
+    return target.resolve(), True
+
+
+def describe(workspace: Path) -> str:
+    """One-line description for the environment footer.
+
+    Returns one of:
+      - `<workspace>/.venv  (active)`           — VIRTUAL_ENV matches
+      - `<workspace>/.venv  (workspace)`        — found but not activated
+      - `none — created on first install`       — nothing yet
+    Path is shown relative to workspace when possible (less noise in
+    the prompt).
+    """
+    found = discover(workspace)
+    if found is None:
+        return "none — created on first pip_install"
+    try:
+        rel = found.relative_to(workspace.resolve())
+        display = str(rel) if str(rel) != "." else str(found)
+    except ValueError:
+        display = str(found)
+    env_venv = os.environ.get("VIRTUAL_ENV", "").strip()
+    if env_venv and Path(env_venv).resolve() == found:
+        suffix = "(active)"
+    else:
+        suffix = "(workspace)"
+    return f"{display}  {suffix}"

--- a/pyagent/venv.py
+++ b/pyagent/venv.py
@@ -90,24 +90,15 @@ def discover(workspace: Path) -> Path | None:
     return None
 
 
-def ensure(workspace: Path) -> tuple[Path, bool]:
-    """Discover an existing venv or create `<workspace>/.venv`.
+def _create(target: Path) -> Path:
+    """Create a venv at exactly `target` using `sys.executable`.
 
-    Returns `(venv_path, created)` where `created` is True iff a new
-    venv was just created (so the caller can surface a one-line
-    notice). The new venv uses `sys.executable`, matching the
-    interpreter the CLI is running under.
-
-    Raises `RuntimeError` if creation fails — caller decides how to
-    surface (likely as a tool-result error marker).
+    Internal helper. Raises `RuntimeError` on failure; the caller
+    decides how to surface that (likely as a tool-result marker).
+    Returns the resolved path on success.
     """
-    existing = discover(workspace)
-    if existing is not None:
-        return existing, False
-
-    target = workspace / ".venv"
     logger.info(
-        "creating workspace venv at %s using %s", target, sys.executable
+        "creating venv at %s using %s", target, sys.executable
     )
     try:
         # `--without-pip` would be faster but then we have to
@@ -134,7 +125,46 @@ def ensure(workspace: Path) -> tuple[Path, bool]:
             f"venv creation reported success but {target} doesn't "
             f"look like a venv afterward"
         )
-    return target.resolve(), True
+    return target.resolve()
+
+
+def ensure(workspace: Path) -> tuple[Path, bool]:
+    """Discover an existing venv or create `<workspace>/.venv`.
+
+    Returns `(venv_path, created)` where `created` is True iff a new
+    venv was just created (so the caller can surface a one-line
+    notice). The new venv uses `sys.executable`, matching the
+    interpreter the CLI is running under.
+
+    Raises `RuntimeError` if creation fails — caller decides how to
+    surface (likely as a tool-result error marker).
+    """
+    existing = discover(workspace)
+    if existing is not None:
+        return existing, False
+    return _create(workspace / ".venv"), True
+
+
+def ensure_at(target: Path) -> tuple[Path, bool]:
+    """Return an existing venv at `target`, or create one there.
+
+    Used when the caller wants to address a specific venv (not the
+    default workspace `.venv/`) — e.g. an explicit `pip_install`
+    invocation that names a separate `.venv-test/` to keep test
+    deps out of the main runtime env. Mirrors `ensure` but skips
+    the workspace-wide discovery — the caller has named the venv.
+
+    Returns `(venv_path, created)`. Raises `RuntimeError` on
+    creation failure.
+    """
+    if is_venv(target):
+        return target.resolve(), False
+    if target.exists() and not target.is_dir():
+        raise RuntimeError(
+            f"{target} exists and is not a directory; refuse to "
+            f"create a venv on top of it"
+        )
+    return _create(target), True
 
 
 def describe(workspace: Path) -> str:

--- a/tests/smoke_auto_venv.py
+++ b/tests/smoke_auto_venv.py
@@ -1,0 +1,196 @@
+"""Smoke for auto-venv discovery + auto-creation + pip_install (#46).
+
+Locks:
+  1. `discover` finds nothing in an empty workspace.
+  2. `discover` honors `$VIRTUAL_ENV` when it points at a real venv.
+  3. `discover` falls back to `<workspace>/.venv/` and then
+     `<workspace>/venv/`.
+  4. `discover` ignores a stale `$VIRTUAL_ENV` (variable set, no venv
+     on disk) and falls back to workspace discovery.
+  5. `ensure` creates `<workspace>/.venv/` when none exists, returns
+     `created=True`, and a second call returns `created=False`.
+  6. `pip_install` end-to-end against the real auto-created venv:
+     installs a tiny pure-python package and verifies it lands in
+     the venv's site-packages, NOT the host interpreter.
+  7. `pip_install` returns a `<...>` marker on failure (bad spec)
+     and on empty input.
+  8. `describe` produces a footer-friendly one-liner for each state.
+
+The pip install case talks to PyPI — skip if `--offline` is in
+sys.argv or the network is unreachable.
+
+Run with:
+
+    .venv/bin/python -m tests.smoke_auto_venv
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from pyagent import tools as agent_tools
+from pyagent import venv as venv_mod
+
+
+def _network_ok(host: str = "pypi.org", port: int = 443, timeout: float = 3.0) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except (OSError, socket.gaierror):
+        return False
+
+
+def _make_fake_venv(target: Path) -> None:
+    """Create a real venv quickly via the same mechanism `ensure`
+    uses — used to seed pre-existing-venv test cases. Caller owns
+    cleanup."""
+    subprocess.run(
+        [sys.executable, "-m", "venv", str(target)],
+        check=True,
+        capture_output=True,
+        timeout=120,
+    )
+
+
+def main() -> None:
+    saved_virtual_env = os.environ.pop("VIRTUAL_ENV", None)
+    try:
+        # 1. empty workspace → discover returns None
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = Path(tmp)
+            assert venv_mod.discover(ws) is None
+            assert "none" in venv_mod.describe(ws), venv_mod.describe(ws)
+            print("✓ empty workspace: discover() = None")
+
+        # 2. `$VIRTUAL_ENV` points at a real venv → wins
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = Path(tmp)
+            outside = ws / "elsewhere"
+            _make_fake_venv(outside)
+            os.environ["VIRTUAL_ENV"] = str(outside)
+            try:
+                found = venv_mod.discover(ws)
+                assert found == outside.resolve(), (found, outside.resolve())
+                desc = venv_mod.describe(ws)
+                assert "(active)" in desc, desc
+                print(f"✓ VIRTUAL_ENV honored: {desc}")
+            finally:
+                os.environ.pop("VIRTUAL_ENV", None)
+
+        # 3. workspace .venv/ — preferred over venv/ when both exist
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = Path(tmp)
+            _make_fake_venv(ws / ".venv")
+            _make_fake_venv(ws / "venv")
+            found = venv_mod.discover(ws)
+            assert found == (ws / ".venv").resolve(), found
+            assert "(workspace)" in venv_mod.describe(ws)
+            print(f"✓ .venv/ preferred over venv/: {found.name}")
+
+        # 3b. venv/ used when only it exists
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = Path(tmp)
+            _make_fake_venv(ws / "venv")
+            found = venv_mod.discover(ws)
+            assert found == (ws / "venv").resolve(), found
+            print(f"✓ venv/ fallback: {found.name}")
+
+        # 4. stale `$VIRTUAL_ENV` ignored, workspace fallback used
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = Path(tmp)
+            _make_fake_venv(ws / ".venv")
+            os.environ["VIRTUAL_ENV"] = str(ws / "deleted-elsewhere")
+            try:
+                found = venv_mod.discover(ws)
+                assert found == (ws / ".venv").resolve(), found
+                print(f"✓ stale VIRTUAL_ENV ignored, fell back to workspace .venv/")
+            finally:
+                os.environ.pop("VIRTUAL_ENV", None)
+
+        # 5. ensure creates on first call, idempotent on second
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = Path(tmp)
+            venv_path, created = venv_mod.ensure(ws)
+            assert created is True, created
+            assert venv_path == (ws / ".venv").resolve(), venv_path
+            assert venv_mod.is_venv(venv_path), venv_path
+            assert venv_mod.pip_path(venv_path).exists()
+
+            # Second call: discover returns the same path, created=False
+            venv_path2, created2 = venv_mod.ensure(ws)
+            assert venv_path2 == venv_path, (venv_path2, venv_path)
+            assert created2 is False, created2
+            print(f"✓ ensure(): created={True}, then idempotent")
+
+        # 6. pip_install end-to-end (skip if offline)
+        if "--offline" in sys.argv or not _network_ok():
+            print("⊘ pip_install live test skipped (offline / --offline)")
+        else:
+            with tempfile.TemporaryDirectory() as tmp:
+                ws = Path(tmp)
+                # `six` is tiny, pure-python, no compiled deps —
+                # ideal for a smoke that needs to land on PyPI.
+                tool = agent_tools.make_pip_install(ws)
+                result = tool("six")
+                assert "installed" in result.lower(), result
+                assert ".venv" in result, result
+                print(f"✓ pip_install ran: {result.splitlines()[0]!r}")
+
+                # Verify the package landed in the venv, not anywhere else.
+                py = venv_mod.python_path(ws / ".venv")
+                proc = subprocess.run(
+                    [str(py), "-c", "import six; print(six.__file__)"],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+                assert proc.returncode == 0, proc.stderr
+                assert ".venv" in proc.stdout, proc.stdout
+                print(f"✓ six landed inside the venv: {proc.stdout.strip()}")
+
+        # 7a. empty spec rejected
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = Path(tmp)
+            tool = agent_tools.make_pip_install(ws)
+            assert tool("   ") == "<refused: empty package spec>"
+            assert tool("") == "<refused: empty package spec>"
+            print("✓ empty spec rejected without touching the venv")
+            assert not (ws / ".venv").exists(), "venv created on empty input"
+            print("✓ empty spec did not auto-create venv")
+
+        # 7b. failing install returns marker (use a clearly-bogus spec)
+        if "--offline" in sys.argv or not _network_ok():
+            print("⊘ failing-install marker test skipped (offline)")
+        else:
+            with tempfile.TemporaryDirectory() as tmp:
+                ws = Path(tmp)
+                tool = agent_tools.make_pip_install(ws)
+                # A name that's syntactically valid but doesn't exist
+                # on PyPI, so we don't accidentally match a real package.
+                bogus = "pyagent-smoke-package-that-definitely-does-not-exist-xyzzy"
+                result = tool(bogus)
+                assert result.startswith("<pip install"), result
+                assert "failed" in result, result
+                print(f"✓ bad spec yields marker: {result.splitlines()[0]!r}")
+
+        # 8. describe variants — already covered above; just one more
+        # confirming the `none` form when nothing exists.
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = Path(tmp)
+            assert "none" in venv_mod.describe(ws)
+            print("✓ describe(empty) → 'none'")
+    finally:
+        # Restore VIRTUAL_ENV exactly as it was (or stay unset if it wasn't).
+        if saved_virtual_env is not None:
+            os.environ["VIRTUAL_ENV"] = saved_virtual_env
+
+    print("\nALL CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/smoke_auto_venv.py
+++ b/tests/smoke_auto_venv.py
@@ -153,6 +153,36 @@ def main() -> None:
                 assert ".venv" in proc.stdout, proc.stdout
                 print(f"✓ six landed inside the venv: {proc.stdout.strip()}")
 
+        # 6b. pip_install honors the optional `venv` argument:
+        # relative path resolved against workspace, absolute path
+        # used as-is, both auto-created when missing.
+        if "--offline" in sys.argv or not _network_ok():
+            print("⊘ pip_install custom-venv test skipped (offline)")
+        else:
+            with tempfile.TemporaryDirectory() as tmp:
+                ws = Path(tmp)
+                tool = agent_tools.make_pip_install(ws)
+
+                # Relative path: lands inside workspace
+                result = tool("six", venv=".venv-test")
+                assert "installed" in result.lower(), result
+                rel_target = (ws / ".venv-test").resolve()
+                assert str(rel_target) in result, result
+                assert venv_mod.is_venv(rel_target), rel_target
+                assert not (ws / ".venv").exists(), (
+                    "default .venv should NOT have been created when "
+                    "an explicit venv arg was given"
+                )
+                print(f"✓ pip_install(venv='.venv-test') → {rel_target.name}/")
+
+                # Absolute path: explicit, outside the workspace
+                with tempfile.TemporaryDirectory() as tmp2:
+                    abs_target = Path(tmp2) / "tools-venv"
+                    result = tool("six", venv=str(abs_target))
+                    assert "installed" in result.lower(), result
+                    assert venv_mod.is_venv(abs_target), abs_target
+                    print(f"✓ pip_install(venv=<abs>) → {abs_target}")
+
         # 7a. empty spec rejected
         with tempfile.TemporaryDirectory() as tmp:
             ws = Path(tmp)

--- a/tests/smoke_prompt_environment.py
+++ b/tests/smoke_prompt_environment.py
@@ -37,6 +37,7 @@ def main() -> None:
     assert "- os:" in stable, stable
     assert "- shell:" in stable, stable
     assert "- python:" in stable, stable
+    assert "- venv:" in stable, stable
 
     assert platform.system() in stable, stable
     assert platform.python_version() in stable, stable


### PR DESCRIPTION
Closes #46.

Builds on #47 (`ask_parent`) — replaces the issue's original flock proposal with the parent-as-broker pattern that #47 unlocked.

## Summary

- **`pyagent/venv.py`** (new): `discover` (`\$VIRTUAL_ENV` → `<workspace>/.venv` → `<workspace>/venv`), `ensure(workspace)` (discover or create `.venv` with `sys.executable`), `ensure_at(target)` (named-target variant), plus `pip_path` / `python_path` / `is_venv` / `describe`.
- **`pip_install(spec, venv="")`** — new tool. Auto-creates the venv on first call. Empty `venv` defaults to the workspace `.venv/`; a relative or absolute path targets a sidecar venv (e.g. `.venv-test/`). Surfaces a one-line summary on success or a `<...>` marker on failure / timeout / empty input.
- **Registered ONLY on the root agent** (gated on `state.self_agent_id is None` in `_register_tools`). Subagents don't get the tool — they `ask_parent("install <spec>")` and the root's LLM decides whether to install. Every install funnels through the root's single-threaded turn loop, so concurrent installs from sibling subagents serialize naturally without an OS-level lock.
- **Environment footer gains a `venv:` line** (`prompts.py`). Re-discovered each turn so a venv created mid-session shows up without restart.
- **PRIMER.md** tightens the "Python environments" section to point at `pip_install` (root) / `ask_parent` (subagents), plus the `venv=` sidecar pattern.

## Why no flock?

The issue's original design used `flock` on `<venv>/.install-lock` to serialize concurrent installs. With #47 in place, every install routes through the root's single-threaded turn loop, so there's nothing to serialize at the OS level. If a future depth-3 subagent tree creates real concurrency, we can add flock back as belt-and-suspenders without changing the user-facing API.

## Test plan

- [x] `tests/smoke_auto_venv.py` — 14 checks: discovery in all four states (none, `\$VIRTUAL_ENV`, `.venv`, `venv`), stale `\$VIRTUAL_ENV` ignored, `ensure` idempotent, real PyPI round-trip (`pip install six`), six lands inside the venv (not the host), sidecar venv via relative + absolute path arg, default `.venv` not created when sidecar is named, empty / bad spec markers. Skips network-dependent cases on `--offline` or unreachable PyPI.
- [x] `tests/smoke_prompt_environment.py` extended for the `- venv:` footer line.
- [x] All 35 pre-existing smokes still pass.
- [ ] Manual: launch `pyagent`, ask it to install something; observe footer flips from `none — created on first pip_install` to `.venv  (workspace)`; spawn a subagent and ask it to install; observe `[subagent X asks parent (req=...)]: install …` in the transcript and the root's `pip_install` tool call.

## Followups

- Consider extracting `pip_install` + the venv footer line into a bundled `auto-venv` plugin if a user wants a clean way to disable it. Currently a built-in for cohesion with the env footer.
- `uv` integration as the install backend — much faster, smaller venvs. Probably worth a follow-up after this lands.
- Auto-detection of `pyproject.toml` / `requirements.txt` for upfront installs at session start.