### PR TITLE
plugin: bundled py_dev_toolkit — structured lint / typecheck / pytest

### DIFF
--- a/pyagent/config.py
+++ b/pyagent/config.py
@@ -59,6 +59,7 @@ DEFAULTS: dict[str, Any] = {
         "web-search",
         "claude-code-cli",
         "echo-plugin",
+        "py-dev-toolkit",
     ],
     "subagents": {
         "max_depth": 3,

--- a/pyagent/plugins/py_dev_toolkit/__init__.py
+++ b/pyagent/plugins/py_dev_toolkit/__init__.py
@@ -1,0 +1,36 @@
+"""py-dev-toolkit — bundled plugin: structured Python dev tools.
+
+Three tools that wrap external CLIs and return structured output the
+agent can act on without parsing tea leaves:
+
+  - `lint(path, tools=["ruff"])` — ruff findings as a bullet list.
+  - `typecheck(path, tool="mypy"|"pyright")` — type errors / warnings.
+  - `run_pytest(target, k=None, fail_fast=False)` — pass/fail summary
+    plus failure tracebacks via pytest-json-report.
+
+Why a plugin rather than letting the agent shell out via `execute`:
+the structured envelope is the value. Each tool's text output is
+fragile (version-dependent, formatter-dependent, plugin-dependent);
+parsing JSON / a stable subset of mypy's text and re-emitting one
+canonical bullet shape means the calling agent gets `file:line:col
+[code] message` per finding regardless of which tool ran. That
+moves the model from "interpret a wall of text" to "act on a list
+of findings."
+
+Each tool checks its own binary at call time and returns a clean
+error if missing — no manifest [requires] gate, so a host with only
+ruff installed still benefits from `lint` while `typecheck` /
+`run_pytest` surface their own missing-tool errors.
+"""
+
+from __future__ import annotations
+
+from pyagent.plugins.py_dev_toolkit import lint as _lint
+from pyagent.plugins.py_dev_toolkit import pytest_runner as _pytest_runner
+from pyagent.plugins.py_dev_toolkit import typecheck as _typecheck
+
+
+def register(api):
+    api.register_tool("lint", _lint.run)
+    api.register_tool("typecheck", _typecheck.run)
+    api.register_tool("run_pytest", _pytest_runner.run)

--- a/pyagent/plugins/py_dev_toolkit/_pathutil.py
+++ b/pyagent/plugins/py_dev_toolkit/_pathutil.py
@@ -1,0 +1,36 @@
+"""Shared path-formatting helpers for the toolkit's output bullets.
+
+The wrapped CLIs disagree on what the `file` portion of a finding
+should look like: ruff echoes the absolute filename it resolved
+(regardless of what the caller passed), while mypy preserves the
+caller's input (so a relative input stays relative). Same finding
+shape, different path styles, depending on which tool ran. The
+calling agent shouldn't have to know which it's looking at.
+
+`shorten` normalizes both: paths inside cwd come back relative,
+everything else stays absolute. Same answer regardless of which
+upstream tool produced the finding.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def shorten(p: str) -> str:
+    """Return `p` relative to cwd when it's under cwd, else `p`
+    resolved-and-absolute. Errors (e.g. an empty/`?` placeholder)
+    return the input unchanged so downstream formatting still gets
+    *something*."""
+    if not p or p == "?":
+        return p
+    try:
+        resolved = Path(p).resolve()
+        cwd = Path.cwd().resolve()
+        return str(resolved.relative_to(cwd))
+    except (ValueError, OSError):
+        # ValueError: not under cwd. OSError: filesystem hiccup.
+        try:
+            return str(Path(p).resolve())
+        except OSError:
+            return p

--- a/pyagent/plugins/py_dev_toolkit/lint.py
+++ b/pyagent/plugins/py_dev_toolkit/lint.py
@@ -1,0 +1,123 @@
+"""Wrap `ruff check` to return structured lint findings.
+
+Why a wrapper rather than the agent calling `execute("ruff check ...")`:
+the JSON output is structured at the source — we extract `file`,
+`line`, `col`, `code`, `message`, `severity`, and fixability cleanly
+and re-emit a compact bullet list. The agent stops parsing tea
+leaves and starts acting on findings.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+from pyagent import permissions
+
+_TIMEOUT_S = 60
+
+
+def run(path: str, tools: list[str] | None = None) -> str:
+    """Run linters against a Python file or directory.
+
+    Args:
+        path: File or directory path. Workspace-relative or absolute.
+            Outside-workspace paths trigger a permission prompt via
+            the standard pyagent path gate.
+        tools: Linter binaries to run. Defaults to `["ruff"]`. Only
+            "ruff" is supported in v1; the parameter exists so a
+            future caller can opt into additional linters without an
+            API break.
+
+    Returns:
+        On findings: a one-line summary (`ruff: N findings on PATH
+        (E errors, W warnings, K fixable)`) followed by a blank line
+        and a `- file:line:col [code] message` bullet per finding,
+        with ` — fixable` appended when `--fix` could clear it.
+        On a clean run: `ruff: clean (no findings on PATH)`.
+        Errors come back inline as `<error: ...>`.
+    """
+    if not path or not str(path).strip():
+        return "<error: path is required>"
+    if tools is None:
+        tools = ["ruff"]
+    unsupported = [t for t in tools if t != "ruff"]
+    if unsupported:
+        return (
+            f"<error: only 'ruff' is supported in v1 "
+            f"(got unsupported: {unsupported})>"
+        )
+
+    target = Path(path)
+    if not target.exists():
+        return f"<error: path does not exist: {path}>"
+    if not permissions.require_access(target):
+        return f"<error: access denied to {path}>"
+
+    binary = shutil.which("ruff")
+    if not binary:
+        return (
+            "<error: ruff is not on PATH; install via "
+            "`pip_install ruff` and retry>"
+        )
+
+    try:
+        proc = subprocess.run(
+            [binary, "check", "--output-format", "json", str(target)],
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return f"<error: ruff timed out after {_TIMEOUT_S}s>"
+
+    # ruff exits non-zero when findings exist; treat that as success
+    # for our purposes. JSON parse failure is the actual error
+    # condition (binary crashed, output corrupted).
+    out = proc.stdout or ""
+    try:
+        findings = json.loads(out) if out.strip() else []
+    except json.JSONDecodeError:
+        err = (proc.stderr or "").strip() or out[:200]
+        return f"<error: ruff returned non-JSON output: {err}>"
+
+    if not findings:
+        return f"ruff: clean (no findings on {target})"
+
+    return _format_findings(findings, str(target))
+
+
+def _format_findings(findings: list[dict], target: str) -> str:
+    by_sev: dict[str, int] = {}
+    fixable = 0
+    lines: list[str] = []
+    for f in findings:
+        loc = f.get("location") or {}
+        line = loc.get("row", "?")
+        col = loc.get("column", "?")
+        code = f.get("code", "?")
+        message = f.get("message", "")
+        sev = f.get("severity", "error")
+        by_sev[sev] = by_sev.get(sev, 0) + 1
+        fix_marker = ""
+        if f.get("fix"):
+            fixable += 1
+            fix_marker = " — fixable"
+        file_rel = f.get("filename", "?")
+        lines.append(
+            f"- {file_rel}:{line}:{col} [{code}] {message}{fix_marker}"
+        )
+
+    sev_part = ", ".join(
+        f"{n} {sev}{'s' if n != 1 else ''}"
+        for sev, n in sorted(by_sev.items())
+    )
+    fix_part = f", {fixable} fixable" if fixable else ""
+    summary = (
+        f"ruff: {len(findings)} finding"
+        f"{'s' if len(findings) != 1 else ''} on "
+        f"{target} ({sev_part}{fix_part})"
+    )
+    return summary + "\n\n" + "\n".join(lines)

--- a/pyagent/plugins/py_dev_toolkit/lint.py
+++ b/pyagent/plugins/py_dev_toolkit/lint.py
@@ -15,6 +15,7 @@ import subprocess
 from pathlib import Path
 
 from pyagent import permissions
+from pyagent.plugins.py_dev_toolkit._pathutil import shorten as _shorten
 
 _TIMEOUT_S = 60
 
@@ -105,7 +106,7 @@ def _format_findings(findings: list[dict], target: str) -> str:
         if f.get("fix"):
             fixable += 1
             fix_marker = " — fixable"
-        file_rel = f.get("filename", "?")
+        file_rel = _shorten(f.get("filename", "?"))
         lines.append(
             f"- {file_rel}:{line}:{col} [{code}] {message}{fix_marker}"
         )

--- a/pyagent/plugins/py_dev_toolkit/manifest.toml
+++ b/pyagent/plugins/py_dev_toolkit/manifest.toml
@@ -1,0 +1,17 @@
+name = "py-dev-toolkit"
+version = "0.1.0"
+description = "Python developer toolkit: structured lint / typecheck / pytest results."
+api_version = "1"
+
+[provides]
+tools = ["lint", "typecheck", "run_pytest"]
+
+# No [requires] binaries gate — each tool checks its own binary at
+# call time and returns a clean error if missing. A user with only
+# ruff installed can still use `lint` while `typecheck` /
+# `run_pytest` surface their own missing-tool errors. Keeps the
+# plugin from disappearing entirely just because one of three tools
+# isn't on PATH.
+
+[load]
+in_subagents = true

--- a/pyagent/plugins/py_dev_toolkit/pytest_runner.py
+++ b/pyagent/plugins/py_dev_toolkit/pytest_runner.py
@@ -1,0 +1,194 @@
+"""Wrap pytest to return a structured pass/fail summary.
+
+Uses `pytest-json-report` for a reliable structured envelope rather
+than parsing pytest's text output (which shifts shape between
+versions, plugins, and tracebacks). When the json-report plugin
+isn't installed, surfaces a clean error pointing the caller at
+`pip_install pytest-json-report` rather than degrading silently.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from pyagent import permissions
+
+# pytest can take a while; longer timeout than lint/typecheck. The
+# cap is a circuit breaker for hung tests, not a per-test budget.
+_TIMEOUT_S = 600
+
+# How many failure / error tracebacks to embed in the summary. More
+# than this is hard to read at the agent level — the caller should
+# narrow with `k=` or look at attachments instead.
+_MAX_FAILURES_SHOWN = 10
+
+
+def run(
+    target: str = ".",
+    k: str | None = None,
+    fail_fast: bool = False,
+    extra_args: list[str] | None = None,
+) -> str:
+    """Run pytest with structured output.
+
+    Args:
+        target: File, directory, or pytest nodeid (e.g.
+            `tests/foo.py::TestX::test_y`). Defaults to ".".
+        k: Optional `-k EXPR` filter. Same expression syntax as
+            pytest's command line.
+        fail_fast: If True, pass `-x` so pytest stops on first
+            failure. Useful when triaging a single regression.
+        extra_args: Optional extra pytest flags (e.g.
+            `["--no-cov"]`). Use sparingly — most tuning is better
+            done via the project's `pyproject.toml` /
+            `pytest.ini`.
+
+    Returns:
+        Summary line `pytest <target>: P passed, F failed, S skipped,
+        E errors (D.DDs)` followed by failure / error blocks (test
+        id + short message + last traceback line). Errors come back
+        inline as `<error: ...>`.
+    """
+    if target is None or not str(target).strip():
+        target = "."
+    pytest_bin = shutil.which("pytest")
+    if not pytest_bin:
+        return (
+            "<error: pytest is not on PATH; install via "
+            "`pip_install pytest pytest-json-report` and retry>"
+        )
+
+    target_path = Path(target.split("::", 1)[0])
+    if target_path.exists() and not permissions.require_access(target_path):
+        return f"<error: access denied to {target}>"
+
+    with tempfile.NamedTemporaryFile(
+        suffix=".json", delete=False, mode="w"
+    ) as tmp:
+        report_path = Path(tmp.name)
+
+    try:
+        cmd = [
+            pytest_bin,
+            "--json-report",
+            f"--json-report-file={report_path}",
+            "--no-header",
+            "-q",
+        ]
+        if k:
+            cmd += ["-k", k]
+        if fail_fast:
+            cmd.append("-x")
+        if extra_args:
+            cmd.extend(str(a) for a in extra_args)
+        cmd.append(target)
+
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=_TIMEOUT_S,
+            )
+        except subprocess.TimeoutExpired:
+            return (
+                f"<error: pytest timed out after {_TIMEOUT_S}s on {target}>"
+            )
+
+        # If the json-report plugin isn't loaded, pytest prints a
+        # clear error and exits 4 (usage error). Detect that and
+        # point the caller at the install step rather than handing
+        # back an opaque exit code.
+        combined = (proc.stdout or "") + "\n" + (proc.stderr or "")
+        if "unrecognized arguments: --json-report" in combined:
+            return (
+                "<error: pytest-json-report plugin missing; install "
+                "via `pip_install pytest-json-report` and retry>"
+            )
+
+        try:
+            data = json.loads(report_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            err = (proc.stderr or "").strip() or proc.stdout[:300]
+            return (
+                f"<error: pytest produced no JSON report "
+                f"(exit {proc.returncode}): {err}>"
+            )
+
+        return _format_report(data, target)
+    finally:
+        try:
+            report_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _format_report(data: dict, target: str) -> str:
+    summary = data.get("summary") or {}
+    passed = summary.get("passed", 0)
+    failed = summary.get("failed", 0)
+    skipped = summary.get("skipped", 0)
+    errors = summary.get("error", 0) + summary.get("errors", 0)
+    duration = data.get("duration") or 0.0
+
+    parts = [f"{passed} passed"]
+    if failed:
+        parts.append(f"{failed} failed")
+    if skipped:
+        parts.append(f"{skipped} skipped")
+    if errors:
+        parts.append(f"{errors} errors")
+    head = (
+        f"pytest {target}: {', '.join(parts)} ({duration:.2f}s)"
+    )
+
+    failure_blocks: list[str] = []
+    error_blocks: list[str] = []
+    for t in data.get("tests") or []:
+        outcome = t.get("outcome")
+        if outcome not in ("failed", "error"):
+            continue
+        nodeid = t.get("nodeid", "?")
+        # Failures live in the "call" phase; errors usually surface
+        # in "setup" (fixture errors) or "teardown".
+        for phase in ("call", "setup", "teardown"):
+            stage = t.get(phase) or {}
+            if stage.get("outcome") == outcome:
+                msg = (stage.get("longrepr") or "").strip()
+                # Last non-empty traceback line is usually the most
+                # informative — show that plus the test id.
+                tail = ""
+                for ln in reversed(msg.splitlines()):
+                    if ln.strip():
+                        tail = ln.strip()
+                        break
+                bucket = (
+                    failure_blocks if outcome == "failed" else error_blocks
+                )
+                bucket.append(
+                    f"- {nodeid} ({phase})\n    {tail}"
+                )
+                break
+
+    body_parts: list[str] = []
+    if failure_blocks:
+        body_parts.append(
+            "failures:\n" + "\n".join(failure_blocks[:_MAX_FAILURES_SHOWN])
+        )
+        if len(failure_blocks) > _MAX_FAILURES_SHOWN:
+            body_parts.append(
+                f"… {len(failure_blocks) - _MAX_FAILURES_SHOWN} more failures "
+                f"(narrow with k=... to triage individually)"
+            )
+    if error_blocks:
+        body_parts.append(
+            "errors:\n" + "\n".join(error_blocks[:_MAX_FAILURES_SHOWN])
+        )
+
+    if body_parts:
+        return head + "\n\n" + "\n\n".join(body_parts)
+    return head

--- a/pyagent/plugins/py_dev_toolkit/pytest_runner.py
+++ b/pyagent/plugins/py_dev_toolkit/pytest_runner.py
@@ -62,17 +62,20 @@ def run(
             "`pip_install pytest pytest-json-report` and retry>"
         )
 
-    # `require_access` gates the target itself, but pytest's
-    # collection phase walks parent directories looking for
-    # `conftest.py` and `pyproject.toml`. Those reads aren't
-    # individually checked against the workspace gate — in practice
-    # only matters for out-of-workspace targets, since conftest
-    # discovery from inside the workspace can't escape it. Caller
-    # who passes `target=/some/abs/path` and approves it implicitly
-    # accepts ancestor reads up to filesystem root; documented
-    # rather than fought.
+    # Always gate the target with `require_access`, even if it
+    # doesn't exist on disk yet. A non-existent out-of-workspace
+    # path (typo, wrong relative path, or deliberately escapist
+    # `target="../../../etc/test_x.py"`) still causes pytest to be
+    # invoked, and pytest's collection phase walks parent
+    # directories for `conftest.py` / `pyproject.toml` — so the
+    # right time to prompt is *before* invocation, regardless of
+    # whether the named file exists.
+    #
+    # `require_access` is a no-op for paths that resolve inside the
+    # workspace, so the common case (relative paths, default ".")
+    # is silent.
     target_path = Path(target.split("::", 1)[0])
-    if target_path.exists() and not permissions.require_access(target_path):
+    if not permissions.require_access(target_path):
         return f"<error: access denied to {target}>"
 
     with tempfile.NamedTemporaryFile(
@@ -141,6 +144,10 @@ def _format_report(data: dict, target: str) -> str:
     passed = summary.get("passed", 0)
     failed = summary.get("failed", 0)
     skipped = summary.get("skipped", 0)
+    # pytest-json-report uses `error` (singular) in current versions;
+    # the `errors` fallback is belt-and-suspenders for a hypothetical
+    # schema rename. If/when we pin a minimum json-report version we
+    # can drop one.
     errors = summary.get("error", 0) + summary.get("errors", 0)
     duration = data.get("duration") or 0.0
 

--- a/pyagent/plugins/py_dev_toolkit/pytest_runner.py
+++ b/pyagent/plugins/py_dev_toolkit/pytest_runner.py
@@ -10,6 +10,7 @@ isn't installed, surfaces a clean error pointing the caller at
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import tempfile
@@ -78,10 +79,14 @@ def run(
     if not permissions.require_access(target_path):
         return f"<error: access denied to {target}>"
 
-    with tempfile.NamedTemporaryFile(
-        suffix=".json", delete=False, mode="w"
-    ) as tmp:
-        report_path = Path(tmp.name)
+    # `mkstemp` over `NamedTemporaryFile(delete=False)`: on Windows
+    # the latter can keep handles open across context-manager exit
+    # and races the subprocess that wants to write to the same path.
+    # `mkstemp` returns an fd we close immediately, leaving only the
+    # path for the subprocess.
+    fd, report_name = tempfile.mkstemp(suffix=".json", prefix="pytest_report_")
+    os.close(fd)
+    report_path = Path(report_name)
 
     try:
         cmd = [

--- a/pyagent/plugins/py_dev_toolkit/pytest_runner.py
+++ b/pyagent/plugins/py_dev_toolkit/pytest_runner.py
@@ -62,6 +62,15 @@ def run(
             "`pip_install pytest pytest-json-report` and retry>"
         )
 
+    # `require_access` gates the target itself, but pytest's
+    # collection phase walks parent directories looking for
+    # `conftest.py` and `pyproject.toml`. Those reads aren't
+    # individually checked against the workspace gate — in practice
+    # only matters for out-of-workspace targets, since conftest
+    # discovery from inside the workspace can't escape it. Caller
+    # who passes `target=/some/abs/path` and approves it implicitly
+    # accepts ancestor reads up to filesystem root; documented
+    # rather than fought.
     target_path = Path(target.split("::", 1)[0])
     if target_path.exists() and not permissions.require_access(target_path):
         return f"<error: access denied to {target}>"

--- a/pyagent/plugins/py_dev_toolkit/typecheck.py
+++ b/pyagent/plugins/py_dev_toolkit/typecheck.py
@@ -20,6 +20,7 @@ import subprocess
 from pathlib import Path
 
 from pyagent import permissions
+from pyagent.plugins.py_dev_toolkit._pathutil import shorten as _shorten
 
 _TIMEOUT_S = 120  # typecheckers are slower than linters; bump from 60.
 
@@ -28,6 +29,15 @@ _TIMEOUT_S = 120  # typecheckers are slower than linters; bump from 60.
 # colons — Windows drive letters (`C:\foo\bar.py:3:1: error: …`)
 # being the case that bit us. Earlier `[^:]+` silently dropped
 # every error on Windows, returning a false-clean result.
+#
+# Edge case the non-greedy match doesn't fully cover: a POSIX path
+# with a single colon followed by a digit (e.g. `dir:9file.py`)
+# could in principle confuse the engine. In practice it matches
+# correctly because the trailing `:\s+(error|note|warning):\s+`
+# anchor requires a real severity token after the second colon —
+# the engine backtracks until the file portion is the right shape.
+# Documented because the algorithmic guarantee isn't obvious from
+# the regex alone.
 _MYPY_TEXT_LINE = re.compile(
     r"^(?P<file>.+?):(?P<line>\d+):(?P<col>\d+):\s+"
     r"(?P<sev>error|note|warning):\s+(?P<msg>.*?)"
@@ -117,19 +127,26 @@ def _try_mypy_json(
     except subprocess.TimeoutExpired:
         return [], f"<error: mypy timed out after {_TIMEOUT_S}s>"
 
-    combined = (proc.stdout or "") + "\n" + (proc.stderr or "")
-    if (
-        "unrecognized arguments: -O" in combined
-        or "invalid choice: 'json'" in combined.lower()
-    ):
+    # Robustly detect "JSON flag not recognized" by inspecting the
+    # *first non-empty stdout line* rather than substring-matching
+    # mypy's error wording. If JSON is producing output, the first
+    # non-empty line is a JSON object (`{...}`); anything else means
+    # mypy printed a usage error or a localized message and we
+    # should fall through to text parsing instead of trusting what
+    # we got. This survives mypy reword / locale changes.
+    first = next(
+        (ln for ln in (proc.stdout or "").splitlines() if ln.strip()),
+        "",
+    ).lstrip()
+    if first and not first.startswith("{"):
         return None  # older mypy — fall back to text parsing
 
     # mypy exits 1 when it finds errors — that's normal. Treat
-    # exit > 1 as failure only if no parseable output came through;
-    # some configurations print a partial result and a non-zero
-    # status (e.g. plugin failures), and we'd rather surface what
-    # we got than swallow it.
-    if proc.returncode > 1 and not (proc.stdout or "").strip():
+    # exit > 1 as failure only if no JSON output came through; some
+    # configurations print partial results plus a non-zero status
+    # (plugin failures, etc.), and we'd rather surface what we got
+    # than swallow it.
+    if proc.returncode > 1 and not first:
         err = (proc.stderr or "").strip() or "(no stderr)"
         return [], f"<error: mypy failed (exit {proc.returncode}): {err}>"
 
@@ -278,7 +295,7 @@ def _format(tool: str, findings: list[dict], target: str) -> str:
         by_sev[f["severity"]] = by_sev.get(f["severity"], 0) + 1
         code_part = f"[{f['code']}] " if f["code"] else ""
         lines.append(
-            f"- {f['filename']}:{f['line']}:{f['col']} "
+            f"- {_shorten(f['filename'])}:{f['line']}:{f['col']} "
             f"{code_part}{f['message']}"
         )
     sev_part = ", ".join(

--- a/pyagent/plugins/py_dev_toolkit/typecheck.py
+++ b/pyagent/plugins/py_dev_toolkit/typecheck.py
@@ -1,0 +1,173 @@
+"""Wrap mypy / pyright to return structured type-check findings.
+
+mypy emits text in a stable shape (`file:line:col: severity:
+message [code]`) and we parse that. pyright has native JSON
+(`--outputjson`) and we use that directly. Both feed the same
+output shape so the calling agent sees one format regardless of
+which typechecker is on the host.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+from pyagent import permissions
+
+_TIMEOUT_S = 120  # typecheckers are slower than linters; bump from 60.
+
+# `path:line:col: severity: message [code]` — mypy with
+# --show-column-numbers and default error codes on. The code is the
+# bracketed last token; older mypy versions sometimes omit it.
+_MYPY_LINE = re.compile(
+    r"^(?P<file>[^:]+):(?P<line>\d+):(?P<col>\d+):\s+"
+    r"(?P<sev>error|note|warning):\s+(?P<msg>.*?)"
+    r"(?:\s+\[(?P<code>[\w-]+)\])?\s*$"
+)
+
+
+def run(path: str, tool: str = "mypy") -> str:
+    """Type-check a Python file or directory.
+
+    Args:
+        path: File or directory path. Workspace-relative or absolute.
+        tool: "mypy" (default) or "pyright". Pick whichever the
+            project already configures; both feed the same output
+            shape so the choice is about ecosystem fit, not parsing.
+
+    Returns:
+        On findings: a one-line summary (`<tool>: N findings on PATH
+        (E errors, W warnings)`) followed by a blank line and a
+        `- file:line:col [code] message` bullet per finding.
+        On a clean run: `<tool>: clean (no findings on PATH)`.
+        Errors come back inline as `<error: ...>`.
+    """
+    if not path or not str(path).strip():
+        return "<error: path is required>"
+    if tool not in ("mypy", "pyright"):
+        return (
+            f"<error: tool must be 'mypy' or 'pyright', got {tool!r}>"
+        )
+
+    target = Path(path)
+    if not target.exists():
+        return f"<error: path does not exist: {path}>"
+    if not permissions.require_access(target):
+        return f"<error: access denied to {path}>"
+
+    binary = shutil.which(tool)
+    if not binary:
+        return (
+            f"<error: {tool} is not on PATH; install via "
+            f"`pip_install {tool}` and retry>"
+        )
+
+    if tool == "mypy":
+        return _run_mypy(binary, target)
+    return _run_pyright(binary, target)
+
+
+def _run_mypy(binary: str, target: Path) -> str:
+    try:
+        proc = subprocess.run(
+            [
+                binary,
+                "--no-error-summary",
+                "--show-column-numbers",
+                "--no-color-output",
+                str(target),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return f"<error: mypy timed out after {_TIMEOUT_S}s>"
+
+    # mypy exits 1 when it finds errors — that's normal. exit > 1
+    # means a real failure (couldn't import, internal error).
+    if proc.returncode > 1:
+        err = (proc.stderr or "").strip() or proc.stdout[:200]
+        return f"<error: mypy failed (exit {proc.returncode}): {err}>"
+
+    findings: list[dict] = []
+    for raw in (proc.stdout or "").splitlines():
+        m = _MYPY_LINE.match(raw)
+        if m is None:
+            continue
+        findings.append(
+            {
+                "filename": m.group("file"),
+                "line": int(m.group("line")),
+                "col": int(m.group("col")),
+                "severity": m.group("sev"),
+                "code": m.group("code") or "",
+                "message": m.group("msg"),
+            }
+        )
+
+    if not findings:
+        return f"mypy: clean (no findings on {target})"
+    return _format("mypy", findings, str(target))
+
+
+def _run_pyright(binary: str, target: Path) -> str:
+    try:
+        proc = subprocess.run(
+            [binary, "--outputjson", str(target)],
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return f"<error: pyright timed out after {_TIMEOUT_S}s>"
+
+    out = proc.stdout or ""
+    try:
+        data = json.loads(out) if out.strip() else {}
+    except json.JSONDecodeError:
+        err = (proc.stderr or "").strip() or out[:200]
+        return f"<error: pyright returned non-JSON output: {err}>"
+
+    diagnostics = data.get("generalDiagnostics") or []
+    findings: list[dict] = []
+    for d in diagnostics:
+        rng = (d.get("range") or {}).get("start") or {}
+        findings.append(
+            {
+                "filename": d.get("file", "?"),
+                "line": int(rng.get("line", 0)) + 1,  # pyright is 0-based
+                "col": int(rng.get("character", 0)) + 1,
+                "severity": d.get("severity", "error"),
+                "code": d.get("rule") or "",
+                "message": d.get("message", ""),
+            }
+        )
+
+    if not findings:
+        return f"pyright: clean (no findings on {target})"
+    return _format("pyright", findings, str(target))
+
+
+def _format(tool: str, findings: list[dict], target: str) -> str:
+    by_sev: dict[str, int] = {}
+    lines: list[str] = []
+    for f in findings:
+        by_sev[f["severity"]] = by_sev.get(f["severity"], 0) + 1
+        code_part = f"[{f['code']}] " if f["code"] else ""
+        lines.append(
+            f"- {f['filename']}:{f['line']}:{f['col']} "
+            f"{code_part}{f['message']}"
+        )
+    sev_part = ", ".join(
+        f"{n} {sev}{'s' if n != 1 else ''}"
+        for sev, n in sorted(by_sev.items())
+    )
+    summary = (
+        f"{tool}: {len(findings)} finding"
+        f"{'s' if len(findings) != 1 else ''} on {target} ({sev_part})"
+    )
+    return summary + "\n\n" + "\n".join(lines)

--- a/pyagent/plugins/py_dev_toolkit/typecheck.py
+++ b/pyagent/plugins/py_dev_toolkit/typecheck.py
@@ -1,10 +1,14 @@
 """Wrap mypy / pyright to return structured type-check findings.
 
-mypy emits text in a stable shape (`file:line:col: severity:
-message [code]`) and we parse that. pyright has native JSON
-(`--outputjson`) and we use that directly. Both feed the same
-output shape so the calling agent sees one format regardless of
-which typechecker is on the host.
+mypy: tries `mypy -O json` first (mypy ≥ 1.11 emits JSONL); falls
+back to text parsing on older mypy. Both paths feed the same output
+shape and both filter `severity == "note"` — notes are context the
+caller may want eventually but they aren't *findings*, and counting
+them inflates the summary ("5 findings: 1 error, 4 notes" reads as
+five problems when there's only one).
+
+pyright: uses native `--outputjson`. Same output shape; "information"
+and "hint" diagnostics are filtered for the same reason.
 """
 
 from __future__ import annotations
@@ -19,11 +23,13 @@ from pyagent import permissions
 
 _TIMEOUT_S = 120  # typecheckers are slower than linters; bump from 60.
 
-# `path:line:col: severity: message [code]` — mypy with
-# --show-column-numbers and default error codes on. The code is the
-# bracketed last token; older mypy versions sometimes omit it.
-_MYPY_LINE = re.compile(
-    r"^(?P<file>[^:]+):(?P<line>\d+):(?P<col>\d+):\s+"
+# Text-format mypy line: `path:line:col: severity: message [code]`.
+# `(?P<file>.+?)` is non-greedy so it accepts paths containing
+# colons — Windows drive letters (`C:\foo\bar.py:3:1: error: …`)
+# being the case that bit us. Earlier `[^:]+` silently dropped
+# every error on Windows, returning a false-clean result.
+_MYPY_TEXT_LINE = re.compile(
+    r"^(?P<file>.+?):(?P<line>\d+):(?P<col>\d+):\s+"
     r"(?P<sev>error|note|warning):\s+(?P<msg>.*?)"
     r"(?:\s+\[(?P<code>[\w-]+)\])?\s*$"
 )
@@ -43,6 +49,9 @@ def run(path: str, tool: str = "mypy") -> str:
         (E errors, W warnings)`) followed by a blank line and a
         `- file:line:col [code] message` bullet per finding.
         On a clean run: `<tool>: clean (no findings on PATH)`.
+        Notes (mypy `note:` lines, pyright "information"/"hint"
+        diagnostics) are excluded from both the count and the bullet
+        list — they're context, not findings.
         Errors come back inline as `<error: ...>`.
     """
     if not path or not str(path).strip():
@@ -71,6 +80,99 @@ def run(path: str, tool: str = "mypy") -> str:
 
 
 def _run_mypy(binary: str, target: Path) -> str:
+    """Run mypy, preferring JSON output. Falls back to text parsing
+    on older mypy that doesn't recognize `-O json`."""
+    json_attempt = _try_mypy_json(binary, target)
+    if json_attempt is not None:
+        findings, error = json_attempt
+        if error:
+            return error
+    else:
+        text_attempt = _run_mypy_text(binary, target)
+        if isinstance(text_attempt, str):
+            return text_attempt
+        findings = text_attempt
+
+    if not findings:
+        return f"mypy: clean (no findings on {target})"
+    return _format("mypy", findings, str(target))
+
+
+def _try_mypy_json(
+    binary: str, target: Path
+) -> tuple[list[dict], str | None] | None:
+    """Try `mypy -O json`. Returns:
+      - `(findings, None)` on success.
+      - `(_, error_string)` when mypy ran but failed.
+      - `None` when the JSON flag isn't recognized (older mypy);
+        caller should fall back to text parsing.
+    """
+    try:
+        proc = subprocess.run(
+            [binary, "-O", "json", "--no-color-output", str(target)],
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return [], f"<error: mypy timed out after {_TIMEOUT_S}s>"
+
+    combined = (proc.stdout or "") + "\n" + (proc.stderr or "")
+    if (
+        "unrecognized arguments: -O" in combined
+        or "invalid choice: 'json'" in combined.lower()
+    ):
+        return None  # older mypy — fall back to text parsing
+
+    # mypy exits 1 when it finds errors — that's normal. Treat
+    # exit > 1 as failure only if no parseable output came through;
+    # some configurations print a partial result and a non-zero
+    # status (e.g. plugin failures), and we'd rather surface what
+    # we got than swallow it.
+    if proc.returncode > 1 and not (proc.stdout or "").strip():
+        err = (proc.stderr or "").strip() or "(no stderr)"
+        return [], f"<error: mypy failed (exit {proc.returncode}): {err}>"
+
+    findings = parse_mypy_json(proc.stdout or "")
+    return findings, None
+
+
+def parse_mypy_json(text: str) -> list[dict]:
+    """Parse mypy's `-O json` output (JSONL — one JSON object per
+    line). Skips `severity == "note"` for the same reason as the
+    text parser. Lines that aren't JSON (mypy's footer, progress
+    output) are silently skipped.
+
+    Exposed at module scope (no `_` prefix) so tests can exercise
+    the parser without spawning mypy.
+    """
+    findings: list[dict] = []
+    for raw in text.splitlines():
+        raw = raw.strip()
+        if not raw or not raw.startswith("{"):
+            continue
+        try:
+            d = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if d.get("severity") == "note":
+            continue
+        findings.append(
+            {
+                "filename": d.get("file", "?"),
+                "line": int(d.get("line") or 0),
+                "col": int(d.get("column") or 0),
+                "severity": d.get("severity", "error"),
+                "code": d.get("code") or "",
+                "message": d.get("message", ""),
+            }
+        )
+    return findings
+
+
+def _run_mypy_text(binary: str, target: Path) -> list[dict] | str:
+    """Fallback for mypy < 1.11. Returns a list on success or an
+    error string on subprocess failure."""
     try:
         proc = subprocess.run(
             [
@@ -87,31 +189,44 @@ def _run_mypy(binary: str, target: Path) -> str:
     except subprocess.TimeoutExpired:
         return f"<error: mypy timed out after {_TIMEOUT_S}s>"
 
-    # mypy exits 1 when it finds errors — that's normal. exit > 1
-    # means a real failure (couldn't import, internal error).
     if proc.returncode > 1:
         err = (proc.stderr or "").strip() or proc.stdout[:200]
         return f"<error: mypy failed (exit {proc.returncode}): {err}>"
 
+    return parse_mypy_text(proc.stdout or "")
+
+
+def parse_mypy_text(text: str) -> list[dict]:
+    """Parse mypy's text output into the canonical finding shape.
+
+    Skips `note:` lines (they're context for an adjacent error,
+    not a finding in their own right; counting them inflates the
+    summary and confuses the caller). Lines that don't match the
+    expected shape are also skipped — usually mypy's "Found N
+    errors" footer or progress output.
+
+    Exposed at module scope (no `_` prefix) so tests can exercise
+    the parser without spawning mypy.
+    """
     findings: list[dict] = []
-    for raw in (proc.stdout or "").splitlines():
-        m = _MYPY_LINE.match(raw)
+    for raw in text.splitlines():
+        m = _MYPY_TEXT_LINE.match(raw)
         if m is None:
+            continue
+        sev = m.group("sev")
+        if sev == "note":
             continue
         findings.append(
             {
                 "filename": m.group("file"),
                 "line": int(m.group("line")),
                 "col": int(m.group("col")),
-                "severity": m.group("sev"),
+                "severity": sev,
                 "code": m.group("code") or "",
                 "message": m.group("msg"),
             }
         )
-
-    if not findings:
-        return f"mypy: clean (no findings on {target})"
-    return _format("mypy", findings, str(target))
+    return findings
 
 
 def _run_pyright(binary: str, target: Path) -> str:
@@ -135,6 +250,10 @@ def _run_pyright(binary: str, target: Path) -> str:
     diagnostics = data.get("generalDiagnostics") or []
     findings: list[dict] = []
     for d in diagnostics:
+        # "information" / "hint" are pyright's equivalent of mypy
+        # notes — context, not findings. Skip for the same reason.
+        if d.get("severity") in ("information", "hint"):
+            continue
         rng = (d.get("range") or {}).get("start") or {}
         findings.append(
             {

--- a/tests/smoke_py_dev_toolkit.py
+++ b/tests/smoke_py_dev_toolkit.py
@@ -246,6 +246,30 @@ def test_lint_on_directory(tools: dict, workdir: Path) -> None:
     _check("finding cites file in directory", "a.py" in out, out[:300])
 
 
+def test_pathutil_shorten() -> None:
+    """`_pathutil.shorten` normalizes path output across tools so
+    `lint` (ruff resolves to absolute) and `typecheck` (mypy
+    preserves caller input) emit the same shape: relative when
+    inside cwd, absolute otherwise. Keeps the calling agent from
+    having to know which tool produced a finding."""
+    from pyagent.plugins.py_dev_toolkit._pathutil import shorten
+
+    cwd = Path.cwd().resolve()
+    inside = cwd / "pyagent" / "plugins" / "__init__.py"
+    _check(
+        "in-cwd path becomes relative",
+        shorten(str(inside)) == "pyagent/plugins/__init__.py",
+        shorten(str(inside)),
+    )
+    _check(
+        "out-of-cwd path stays absolute",
+        shorten("/etc/hosts") == "/etc/hosts",
+        shorten("/etc/hosts"),
+    )
+    _check("placeholder '?' returns unchanged", shorten("?") == "?")
+    _check("empty input returns unchanged", shorten("") == "")
+
+
 def test_pytest_permission_gate_runs_for_nonexistent_paths(
     tools: dict,
 ) -> None:
@@ -305,6 +329,7 @@ def main() -> None:
     test_mypy_text_parser_filters_notes()
     test_mypy_json_parser_filters_notes()
     test_lint_on_directory(tools, workdir)
+    test_pathutil_shorten()
     test_pytest_permission_gate_runs_for_nonexistent_paths(tools)
     test_missing_binary_path(workdir)
     print("\nALL CHECKS PASSED")

--- a/tests/smoke_py_dev_toolkit.py
+++ b/tests/smoke_py_dev_toolkit.py
@@ -1,0 +1,191 @@
+"""Smoke tests for the py-dev-toolkit plugin (lint / typecheck / run_pytest).
+
+Each test is gated on the relevant binary being installed in the
+runtime environment. CI hosts without ruff / mypy / pytest will skip
+the matching block rather than fail — same shape as the rest of the
+plugin smoke suite. The plugin's own missing-tool error path is
+covered by spoofing PATH lookup.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+from pyagent import permissions
+from pyagent.plugins import load
+
+
+def _check(label: str, cond: bool, detail: str = "") -> None:
+    sym = "✓" if cond else "✗"
+    extra = f" — {detail}" if detail else ""
+    print(f"{sym} {label}{extra}")
+    if not cond:
+        sys.exit(1)
+
+
+def _setup() -> tuple[dict, Path]:
+    permissions.set_workspace(Path.cwd())
+    workdir = Path(tempfile.mkdtemp(prefix="pydevtools_smoke_"))
+    permissions.pre_approve(workdir)
+    loaded = load()
+    tools = {name: fn for name, (_, fn) in loaded.tools().items()}
+    return tools, workdir
+
+
+def test_plugin_registers_three_tools() -> None:
+    tools, _ = _setup()
+    for name in ("lint", "typecheck", "run_pytest"):
+        _check(f"{name!r} registered", name in tools, f"have: {sorted(tools)}")
+
+
+def test_lint_findings_and_clean(tools: dict, workdir: Path) -> None:
+    if shutil.which("ruff") is None:
+        _check("ruff smoke skipped (binary missing)", True)
+        return
+    bad = workdir / "lint_bad.py"
+    bad.write_text(
+        "import os, sys\n"
+        "unused = 42\n"
+    )
+    out = tools["lint"](str(bad))
+    _check("lint summary line includes count", "ruff:" in out and "finding" in out, out[:120])
+    _check("lint cites E401 (multi-import)", "E401" in out, out[:200])
+    _check("lint marks fixable", "fixable" in out, out[:200])
+
+    clean = workdir / "lint_clean.py"
+    clean.write_text("def f() -> int:\n    return 42\n")
+    out_clean = tools["lint"](str(clean))
+    _check("lint clean run", out_clean.startswith("ruff: clean"), out_clean)
+
+
+def test_lint_input_validation(tools: dict, workdir: Path) -> None:
+    out = tools["lint"]("")
+    _check("empty path → error", out.startswith("<error:"), out)
+
+    out = tools["lint"]("/no/such/path-xyz")
+    _check("missing path → error", "does not exist" in out, out)
+
+    if (workdir / "lint_clean.py").exists():
+        out = tools["lint"](str(workdir / "lint_clean.py"), tools=["pylint"])
+        _check(
+            "unsupported linter → error",
+            "<error:" in out and "pylint" in out,
+            out,
+        )
+
+
+def test_typecheck_mypy(tools: dict, workdir: Path) -> None:
+    if shutil.which("mypy") is None:
+        _check("mypy smoke skipped (binary missing)", True)
+        return
+    bad = workdir / "tc_bad.py"
+    bad.write_text(
+        "def add(a: int, b: int) -> int:\n"
+        "    return a + b\n"
+        "x: str = add(1, 2)\n"
+    )
+    out = tools["typecheck"](str(bad), tool="mypy")
+    _check("mypy summary line", "mypy:" in out and "finding" in out, out[:120])
+    _check("mypy cites assignment error code", "[assignment]" in out, out[:300])
+
+    clean = workdir / "tc_clean.py"
+    clean.write_text("def add(a: int, b: int) -> int:\n    return a + b\n")
+    out_clean = tools["typecheck"](str(clean), tool="mypy")
+    _check("mypy clean run", out_clean.startswith("mypy: clean"), out_clean)
+
+
+def test_typecheck_input_validation(tools: dict) -> None:
+    out = tools["typecheck"]("/some/path", tool="pyflakes")
+    _check(
+        "unsupported typecheck tool → error",
+        "<error:" in out and "pyflakes" in out,
+        out,
+    )
+
+
+def test_run_pytest_basic(tools: dict, workdir: Path) -> None:
+    if shutil.which("pytest") is None:
+        _check("pytest smoke skipped (binary missing)", True)
+        return
+    test_file = workdir / "test_demo.py"
+    test_file.write_text(
+        "def test_pass():\n"
+        "    assert 1 + 1 == 2\n"
+        "\n"
+        "def test_fail():\n"
+        "    assert 1 + 1 == 3, 'math broken'\n"
+        "\n"
+        "def test_skip():\n"
+        "    import pytest; pytest.skip('not relevant')\n"
+    )
+    out = tools["run_pytest"](str(test_file))
+    if "pytest-json-report" in out and "<error:" in out:
+        _check("pytest smoke skipped (json-report plugin missing)", True)
+        return
+    _check(
+        "pytest reports passed/failed/skipped",
+        "1 passed" in out and "1 failed" in out and "1 skipped" in out,
+        out[:200],
+    )
+    _check(
+        "pytest surfaces failed test id",
+        "test_demo.py::test_fail" in out,
+        out[:300],
+    )
+
+
+def test_run_pytest_k_filter(tools: dict, workdir: Path) -> None:
+    if shutil.which("pytest") is None:
+        return
+    test_file = workdir / "test_demo.py"
+    if not test_file.exists():
+        return
+    out = tools["run_pytest"](str(test_file), k="pass")
+    if "pytest-json-report" in out and "<error:" in out:
+        return
+    _check(
+        "pytest k= filter narrows to one test",
+        "1 passed" in out and "0 failed" not in out and "failed" not in out.split("(")[0],
+        out[:200],
+    )
+
+
+def test_missing_binary_path(workdir: Path) -> None:
+    # Spoof PATH to confirm clean error when binary missing. Need a
+    # real-on-disk file because the existence check runs before the
+    # binary check.
+    real = workdir / "stub_for_missing_binary.py"
+    real.write_text("x = 1\n")
+    saved = os.environ.get("PATH", "")
+    try:
+        os.environ["PATH"] = "/nonexistent"
+        from pyagent.plugins.py_dev_toolkit import lint
+        out = lint.run(str(real))
+        _check(
+            "lint surfaces missing-binary error cleanly",
+            "<error:" in out and "ruff is not on PATH" in out,
+            out,
+        )
+    finally:
+        os.environ["PATH"] = saved
+
+
+def main() -> None:
+    tools, workdir = _setup()
+    test_plugin_registers_three_tools()
+    test_lint_findings_and_clean(tools, workdir)
+    test_lint_input_validation(tools, workdir)
+    test_typecheck_mypy(tools, workdir)
+    test_typecheck_input_validation(tools)
+    test_run_pytest_basic(tools, workdir)
+    test_run_pytest_k_filter(tools, workdir)
+    test_missing_binary_path(workdir)
+    print("\nALL CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/smoke_py_dev_toolkit.py
+++ b/tests/smoke_py_dev_toolkit.py
@@ -36,8 +36,7 @@ def _setup() -> tuple[dict, Path]:
     return tools, workdir
 
 
-def test_plugin_registers_three_tools() -> None:
-    tools, _ = _setup()
+def test_plugin_registers_three_tools(tools: dict) -> None:
     for name in ("lint", "typecheck", "run_pytest"):
         _check(f"{name!r} registered", name in tools, f"have: {sorted(tools)}")
 
@@ -147,9 +146,12 @@ def test_run_pytest_k_filter(tools: dict, workdir: Path) -> None:
     out = tools["run_pytest"](str(test_file), k="pass")
     if "pytest-json-report" in out and "<error:" in out:
         return
+    # Format omits zero-counts ("0 failed" never appears), so a
+    # filtered run with only passes shouldn't mention "failed" in
+    # the summary half (the part before the duration parenthesis).
     _check(
         "pytest k= filter narrows to one test",
-        "1 passed" in out and "0 failed" not in out and "failed" not in out.split("(")[0],
+        "1 passed" in out and "failed" not in out.split("(")[0],
         out[:200],
     )
 
@@ -244,6 +246,32 @@ def test_lint_on_directory(tools: dict, workdir: Path) -> None:
     _check("finding cites file in directory", "a.py" in out, out[:300])
 
 
+def test_pytest_permission_gate_runs_for_nonexistent_paths(
+    tools: dict,
+) -> None:
+    """Reviewer-found bug: `if target_path.exists() and not
+    require_access(...)` skipped the permission check when the path
+    didn't exist. An out-of-workspace target like `/etc/foo.py` then
+    got pytest invoked anyway (its discovery walks parents).
+    Regression test: a non-existent out-of-workspace path must
+    surface a clear refusal, not silently invoke pytest.
+
+    We install a deny-all prompt handler so any out-of-workspace
+    path is rejected without an interactive prompt.
+    """
+    saved_handler = permissions._PROMPT_HANDLER  # type: ignore[attr-defined]
+    permissions.set_prompt_handler(lambda _target: False)
+    try:
+        out = tools["run_pytest"]("/no/such/dir/test_xyz.py")
+        _check(
+            "pytest surfaces access-denied for non-existent OOW path",
+            "<error:" in out and "access denied" in out,
+            out,
+        )
+    finally:
+        permissions.set_prompt_handler(saved_handler)
+
+
 def test_missing_binary_path(workdir: Path) -> None:
     # Spoof PATH to confirm clean error when binary missing. Need a
     # real-on-disk file because the existence check runs before the
@@ -266,7 +294,7 @@ def test_missing_binary_path(workdir: Path) -> None:
 
 def main() -> None:
     tools, workdir = _setup()
-    test_plugin_registers_three_tools()
+    test_plugin_registers_three_tools(tools)
     test_lint_findings_and_clean(tools, workdir)
     test_lint_input_validation(tools, workdir)
     test_typecheck_mypy(tools, workdir)
@@ -277,6 +305,7 @@ def main() -> None:
     test_mypy_text_parser_filters_notes()
     test_mypy_json_parser_filters_notes()
     test_lint_on_directory(tools, workdir)
+    test_pytest_permission_gate_runs_for_nonexistent_paths(tools)
     test_missing_binary_path(workdir)
     print("\nALL CHECKS PASSED")
 

--- a/tests/smoke_py_dev_toolkit.py
+++ b/tests/smoke_py_dev_toolkit.py
@@ -154,6 +154,96 @@ def test_run_pytest_k_filter(tools: dict, workdir: Path) -> None:
     )
 
 
+def test_mypy_text_parser_handles_windows_paths() -> None:
+    """Reviewer-found bug: previous regex used `[^:]+` for the file
+    path, so `C:\\foo\\bar.py:3:1: error: …` never matched and
+    Windows hosts got a false-clean result. New regex uses a
+    non-greedy `.+?` so drive-letter paths parse correctly."""
+    from pyagent.plugins.py_dev_toolkit.typecheck import parse_mypy_text
+
+    sample = (
+        "C:\\src\\proj\\foo.py:3:1: error: Bad arg [arg-type]\n"
+        "/src/proj/foo.py:5:9: error: Other thing [assignment]\n"
+        "relative/foo.py:7:2: warning: Risky [misc]\n"
+    )
+    out = parse_mypy_text(sample)
+    _check("3 findings parsed across path styles", len(out) == 3, repr(out))
+    paths = {f["filename"] for f in out}
+    _check(
+        "windows path captured intact",
+        "C:\\src\\proj\\foo.py" in paths,
+        repr(paths),
+    )
+    _check(
+        "linux abs path captured intact",
+        "/src/proj/foo.py" in paths,
+        repr(paths),
+    )
+    _check(
+        "relative path captured intact",
+        "relative/foo.py" in paths,
+        repr(paths),
+    )
+
+
+def test_mypy_text_parser_filters_notes() -> None:
+    """Reviewer-found bug: `note:` lines were being counted as
+    findings, inflating the summary (e.g. `1 error, 4 notes` shown
+    as 5 findings). They're context for the adjacent error, not
+    separate problems."""
+    from pyagent.plugins.py_dev_toolkit.typecheck import parse_mypy_text
+
+    sample = (
+        "/proj/foo.py:10:5: error: Incompatible overload [misc]\n"
+        "/proj/foo.py:10:5: note: Possible overload variant 1\n"
+        "/proj/foo.py:10:5: note: Possible overload variant 2\n"
+        "/proj/foo.py:11:5: note: Suggested fix: rename param\n"
+    )
+    out = parse_mypy_text(sample)
+    _check("only the error is kept", len(out) == 1, repr(out))
+    _check(
+        "kept finding is the error",
+        out[0]["severity"] == "error",
+        repr(out[0]),
+    )
+
+
+def test_mypy_json_parser_filters_notes() -> None:
+    """Same notes-filtering applied to mypy's JSONL output."""
+    from pyagent.plugins.py_dev_toolkit.typecheck import parse_mypy_json
+
+    sample = (
+        '{"file": "/proj/foo.py", "line": 1, "column": 1, '
+        '"severity": "error", "code": "assignment", "message": "bad"}\n'
+        '{"file": "/proj/foo.py", "line": 1, "column": 1, '
+        '"severity": "note", "code": null, "message": "context"}\n'
+        'Found 1 error in 1 file (checked 1 source file)\n'
+    )
+    out = parse_mypy_json(sample)
+    _check("error kept, note dropped, footer ignored", len(out) == 1, repr(out))
+    _check(
+        "kept finding is the error",
+        out[0]["severity"] == "error" and out[0]["code"] == "assignment",
+        repr(out[0]),
+    )
+
+
+def test_lint_on_directory(tools: dict, workdir: Path) -> None:
+    if shutil.which("ruff") is None:
+        return
+    sub = workdir / "lint_dir"
+    sub.mkdir(exist_ok=True)
+    (sub / "a.py").write_text("import os\n")  # F401
+    (sub / "b.py").write_text("def f():\n    return 42\n")  # clean
+    out = tools["lint"](str(sub))
+    _check(
+        "lint runs on a directory",
+        "ruff:" in out and "finding" in out,
+        out[:200],
+    )
+    _check("finding cites file in directory", "a.py" in out, out[:300])
+
+
 def test_missing_binary_path(workdir: Path) -> None:
     # Spoof PATH to confirm clean error when binary missing. Need a
     # real-on-disk file because the existence check runs before the
@@ -183,6 +273,10 @@ def main() -> None:
     test_typecheck_input_validation(tools)
     test_run_pytest_basic(tools, workdir)
     test_run_pytest_k_filter(tools, workdir)
+    test_mypy_text_parser_handles_windows_paths()
+    test_mypy_text_parser_filters_notes()
+    test_mypy_json_parser_filters_notes()
+    test_lint_on_directory(tools, workdir)
     test_missing_binary_path(workdir)
     print("\nALL CHECKS PASSED")
 


### PR DESCRIPTION
Builds the programmer's-toolkit plugin discussed in chat. Three tools, all read-only, each wrapping an external CLI and returning a structured bullet list the agent can act on without parsing text:

| Tool | Wraps | Returns |
|------|-------|---------|
| `lint(path, tools=["ruff"])` | `ruff check --output-format json` | `- file:line:col [code] msg — fixable` per finding |
| `typecheck(path, tool="mypy"\|"pyright")` | mypy text / pyright `--outputjson` | Same shape, regardless of tool |
| `run_pytest(target, k=None, fail_fast=False)` | pytest + `--json-report` | `P passed, F failed, S skipped, E errors (D.DDs)` + failure blocks |

## Why a plugin and not `execute("ruff check ...")`

Each underlying tool's text output is fragile (version-dependent, formatter-dependent, plugin-dependent). Parsing JSON / a stable subset of mypy's text and re-emitting one canonical shape moves the calling agent from "interpret a wall of text" to "act on a list of findings." Same idea as #56's structured plugin-provider envelope: the value is in normalizing the surface.

## Per-tool gating

No manifest `[requires] binaries` — each tool runs `shutil.which` at call time and returns a clean error if the binary is missing. A host with only ruff installed still gets `lint` while `typecheck` / `run_pytest` surface their own missing-tool errors with the right `pip_install ...` hint.

`pytest-json-report` absence is detected separately (the `unrecognized arguments: --json-report` line in pytest's stderr) and points at `pip_install pytest-json-report`.

## Permissions

Each tool calls `permissions.require_access(path)` before invoking the binary — workspace-boundary rules apply the same way they do for `read_file` / `map_code`.

## Layout

```
pyagent/plugins/py_dev_toolkit/
├── manifest.toml
├── __init__.py            # registers the three tools
├── lint.py                # ruff JSON → bullet list
├── typecheck.py           # mypy regex / pyright JSON → bullet list
└── pytest_runner.py       # pytest --json-report → structured summary
```

## Tests

`tests/smoke_py_dev_toolkit.py` covers:
- Plugin registers all three tools.
- `lint` against a file with multi-import / unused-import / unused-var; verifies summary line, code citation (E401), `— fixable` marker, and clean-run path.
- `lint` input validation: empty path, missing path, unsupported-linter error.
- `typecheck` mypy: assignment-incompatibility detection, `[assignment]` code, clean-run path. Pyright path is implemented but not exercised in CI (no binary on this host).
- `typecheck` input validation: `tool="pyflakes"` → clean error.
- `run_pytest`: 1 pass / 1 fail / 1 skip mix; failed-test-id surfaces; `k=` filter narrows.
- Missing-binary error path via PATH spoof.

Each binary-dependent test gates on `shutil.which` so CI hosts without `ruff` / `mypy` / `pytest` skip rather than fail. Existing smoke tests (`smoke_plugin_provider.py`, `smoke_status_footer.py`, `smoke_plugins.py`) still pass.

## Sample output

```
ruff: 3 findings on bad.py (3 errors, 3 fixable)

- bad.py:1:1 [E401] Multiple imports on one line — fixable
- bad.py:1:8 [F401] `os` imported but unused — fixable
- bad.py:1:12 [F401] `sys` imported but unused — fixable
```

```
mypy: 2 findings on bad.py (2 errors)

- bad.py:4:10 [assignment] Incompatible types in assignment (expression has type "int", variable has type "str")
- bad.py:5:9 [arg-type] Argument 1 to "add" has incompatible type "str"; expected "int"
```

```
pytest test_demo.py: 1 passed, 1 failed, 1 skipped (0.01s)

failures:
- test_demo.py::test_fail (call)
    test_demo.py:5: AssertionError
```

## What's deliberately not in this PR

- **LSP integration** (go-to-def, find-references, hover) — separate proposal worth its own discussion; ~10× implementation cost.
- **AST navigation** (find_callers, imports_of) — overlaps with the existing `code_mapper` plugin; better to extend that than build a parallel surface.
- **Coverage analysis** — useful but specialized; doesn't show up in 80% of tasks.
- **Adding pylint / pyflakes / black** to `lint` — the `tools=` parameter is in the signature so adding them later isn't an API break.

## Test plan

- [x] `python tests/smoke_py_dev_toolkit.py` — passes locally with ruff / mypy / pytest installed.
- [x] `python tests/smoke_plugin_provider.py` — passes (no regression).
- [x] `python tests/smoke_status_footer.py` — passes.
- [x] End-to-end exercised via `pyagent.plugins.load()` against fixture files.

Ready for review — happy to discuss naming (`lint` vs `py_lint` etc.), the per-tool gating choice, or the output format.