### PR TITLE
Notification protocol foundation: subagent_note + parent_note + notify_parent

### DIFF
--- a/pyagent/agent.py
+++ b/pyagent/agent.py
@@ -1,6 +1,8 @@
+import collections
 import logging
 import queue
 import threading
+import time
 from typing import Any, Callable
 
 from pyagent.llms import LLMClient
@@ -91,6 +93,25 @@ class Agent:
         # the IO thread is what produces, the main thread (where
         # run() executes) is what consumes.
         self.pending_async_replies: queue.Queue = queue.Queue()
+        # Per-sid notification ring (issue #64). The IO thread
+        # appends a `(seq, ts, severity, text)` tuple per inbound
+        # `subagent_note`. `deque(maxlen=N)` drops the oldest on
+        # overflow; the dropped count is tracked separately on
+        # `_subagent_note_drops` so peek (issue #65) can surface a
+        # synthetic `... (N notes dropped) ...` line covering the
+        # gap between cursor and the smallest seq still in the
+        # ring. Inbox delivery does NOT consume — peek reads
+        # history from this ring, while the inbox surfaces notes
+        # at turn boundaries via `pending_async_replies`.
+        self._subagent_notes: dict[str, "collections.deque"] = {}
+        self._subagent_note_seq: dict[str, int] = {}
+        self._subagent_note_drops: dict[str, int] = {}
+        self._notes_lock = threading.Lock()
+        # Wallclock anchor per subagent so peek output can render
+        # `t+12s` relative to spawn rather than an absolute time.
+        # The IO thread sets this on first note; cleared when the
+        # subagent terminates (issue #65).
+        self._subagent_note_t0: dict[str, float] = {}
 
     def add_tool(
         self,
@@ -376,6 +397,56 @@ class Agent:
                 r["content"] = stub
                 stubbed += 1
         return stubbed
+
+    _NOTES_RING_MAXLEN = 64
+
+    def _append_subagent_note(
+        self, sid: str, severity: str, text: str
+    ) -> tuple[int, float]:
+        """Append a note to a subagent's per-sid ring (issue #64).
+
+        Allocates the ring on first use. Increments the per-sid
+        seq counter — monotonic, never reused even when overflow
+        evicts the entry the seq was paired with. On overflow the
+        deque drops the leftmost entry and `_subagent_note_drops`
+        increments; #65's peek surfaces the gap as a synthetic
+        `... (N notes dropped) ...` line at read time, which keeps
+        the cursor honest without trying to maintain a marker
+        entry inside a self-evicting ring.
+
+        Returns the (seq, ts) of the appended note. ts is
+        monotonic seconds since the first note for this sid so
+        peek output can render `t+Ns` relative to that anchor.
+        """
+        with self._notes_lock:
+            ring = self._subagent_notes.get(sid)
+            if ring is None:
+                ring = collections.deque(maxlen=self._NOTES_RING_MAXLEN)
+                self._subagent_notes[sid] = ring
+                self._subagent_note_seq[sid] = 0
+                self._subagent_note_drops[sid] = 0
+                self._subagent_note_t0[sid] = time.monotonic()
+            seq = self._subagent_note_seq[sid]
+            self._subagent_note_seq[sid] = seq + 1
+            ts = time.monotonic() - self._subagent_note_t0[sid]
+            if len(ring) == ring.maxlen:
+                self._subagent_note_drops[sid] += 1
+            ring.append((seq, ts, severity, text))
+            return seq, ts
+
+    def _clear_subagent_notes(self, sid: str) -> None:
+        """Drop a subagent's ring (issue #65 — terminate / pipe close).
+
+        Called when a subagent is terminated or its pipe closes
+        unexpectedly. Late peeks of the dead sid return the
+        unknown-subagent marker; keeping a ghost ring would risk
+        confusing peek with stale history.
+        """
+        with self._notes_lock:
+            self._subagent_notes.pop(sid, None)
+            self._subagent_note_seq.pop(sid, None)
+            self._subagent_note_drops.pop(sid, None)
+            self._subagent_note_t0.pop(sid, None)
 
     def _drain_pending_async(self) -> int:
         """Append every queued async-subagent reply as a user message.

--- a/pyagent/agent_proc.py
+++ b/pyagent/agent_proc.py
@@ -284,6 +284,17 @@ class _ChildState:
                     "parent_answer for unknown request_id %r; dropping",
                     req_id,
                 )
+        elif kind == "parent_note":
+            # Non-blocking note from this agent's parent. Queue as a
+            # formatted user-role message onto our own
+            # pending_async_replies so the next LLM call sees it.
+            # Issue #64. No producer ships in this PR; #65 adds
+            # `tell_subagent` which fires this event downward.
+            text = event.get("text", "") or ""
+            if self.agent is not None:
+                self.agent.pending_async_replies.put(
+                    f"[parent says]: {text}"
+                )
         elif kind == "set_model":
             self._handle_set_model(event.get("model", ""))
         elif kind == "shutdown":
@@ -431,6 +442,38 @@ class _ChildState:
             # `agent_id=sid` so the CLI knows which subagent originated.
             self._forward_upstream(event, sid)
             return
+        if kind == "subagent_note":
+            # A direct child dropped a non-blocking note. Append to
+            # the per-sid ring on the parent agent and queue a
+            # formatted user-role message onto pending_async_replies
+            # so the parent's next LLM call sees it. Issue #64.
+            #
+            # Notes always target the IMMEDIATE parent — a bubbled
+            # variant from a grandchild is dropped with a warning,
+            # mirroring the subagent_ask rule above.
+            if inner_id is not None:
+                logger.warning(
+                    "subagent_note bubbled past its direct parent "
+                    "(inner_id=%r via sid=%r); dropping",
+                    inner_id, sid,
+                )
+                self._forward_upstream(event, sid)
+                return
+            severity = event.get("severity", "info") or "info"
+            text = event.get("text", "") or ""
+            if self.agent is not None:
+                self.agent._append_subagent_note(sid, severity, text)
+                entry = self.agent._subagents.get(sid)
+                name = entry.name if entry else sid
+                formatted = (
+                    f"[subagent {name} ({sid}) notes ({severity})]: "
+                    f"{text}"
+                )
+                self.agent.pending_async_replies.put(formatted)
+            # Surface upstream so the CLI can render the note in
+            # the transcript like any other cross-agent event.
+            self._forward_upstream(event, sid)
+            return
         # Everything else (assistant_text, tool_*, info, permission_request).
         # Learn the route if this event came from a deeper descendant,
         # then forward upstream so the CLI can render it.
@@ -531,6 +574,14 @@ def _register_tools(
         _add(
             "ask_parent",
             subagent_mod.make_ask_parent(state, agent),
+            auto_offload=False,
+        )
+        # notify_parent (issue #64): non-blocking, fire-and-forget.
+        # Counterpart to ask_parent for cases where the subagent
+        # has information for the parent but doesn't need a reply.
+        _add(
+            "notify_parent",
+            subagent_mod.make_notify_parent(state, agent),
             auto_offload=False,
         )
     # pip_install (issue #46): registered ONLY on the root agent.

--- a/pyagent/defaults/PRIMER.md
+++ b/pyagent/defaults/PRIMER.md
@@ -92,6 +92,19 @@ rest is on you.
 - Read your inbox first. When a turn opens with one of those
   `[subagent … reports]` messages, the subagent is talking to you
   — process it before doing anything else.
+- **Subagent → parent notes** (`notify_parent`, fire-and-forget):
+  use sparingly to surface a framing concern, a heads-up that
+  supersedes earlier work, or a milestone the parent is waiting
+  on. Don't narrate progress. One note should change behaviour
+  or understanding — if it wouldn't, don't send it.
+- **Parent receiving notes** (`[subagent … notes (severity)]`
+  appearing mid-turn): treat them like late-arriving facts about
+  the work. Finish any load-bearing tool sequence safely (don't
+  abandon a half-applied edit or a tool batch with unpaired
+  results), then act on the note. When the note clearly
+  redirects, *do* pivot — terminate subagents, drop the current
+  plan, start fresh. Treating notes as advisory-only would
+  defeat the channel.
 - Terminate when done. Lingering subagents waste their share of
   the fanout cap and any work they're still doing.
 - Caps refuse with `<refused: …>`. If you hit one, you're either

--- a/pyagent/subagent.py
+++ b/pyagent/subagent.py
@@ -514,6 +514,71 @@ def make_ask_parent(
     return ask_parent
 
 
+_NOTIFY_VALID_SEVERITIES = ("info", "warn", "alert")
+
+
+def make_notify_parent(
+    state: "_ChildState",
+    agent: "Agent",
+) -> Callable[..., str]:
+    """Build the `notify_parent` tool — only registered on subagents.
+
+    Sends a non-blocking note up to the immediate parent agent and
+    returns immediately. The parent's IO thread appends the note to
+    a per-sid ring and queues a formatted user-role message onto the
+    parent's `pending_async_replies`, surfacing at the parent's next
+    LLM-call boundary. Issue #64.
+    """
+
+    def notify_parent(text: str, severity: str = "info") -> str:
+        """Drop a non-blocking note to your immediate parent agent.
+
+        Use this when you've learned something the parent should
+        know but you don't need an answer to keep going. The parent
+        will see your note as a user-role message at its next
+        LLM-call boundary; it can act, defer, or ignore.
+
+        Don't spam. One note should change the parent's behavior or
+        understanding — if it wouldn't, don't send it. Good fits:
+        a framing concern ("the test runner here is broken; switch
+        approach"), a heads-up that supersedes earlier work, a
+        completed milestone the parent is waiting on. Bad fits:
+        progress chatter ("starting now", "still working"),
+        restating the obvious, anything that reads like narration.
+
+        Unlike `ask_parent`, this is fire-and-forget: there's no
+        request_id and the parent never replies. Use `ask_parent`
+        when you actually need a decision.
+
+        Args:
+            text: The note text. Plain prose, self-contained — the
+                parent has its context but doesn't have yours.
+            severity: One of "info", "warn", "alert". "alert"
+                signals the parent should consider pivoting; "warn"
+                flags a concern; "info" is everything else. Default
+                "info".
+
+        Returns:
+            A short status string. Errors come back as `<...>`
+            markers (empty text, unknown severity, send failure).
+        """
+        text = (text or "").strip()
+        if not text:
+            return "<refused: empty text>"
+        if severity not in _NOTIFY_VALID_SEVERITIES:
+            valid = ", ".join(repr(s) for s in _NOTIFY_VALID_SEVERITIES)
+            return f"<refused: severity {severity!r} not in {{{valid}}}>"
+        try:
+            state.send(
+                "subagent_note", severity=severity, text=text
+            )
+        except Exception as e:
+            return f"<send failed: {type(e).__name__}: {e}>"
+        return f"note sent ({severity})"
+
+    return notify_parent
+
+
 def make_reply_to_subagent(
     state: "_ChildState",
     agent: "Agent",

--- a/tests/smoke_notify.py
+++ b/tests/smoke_notify.py
@@ -1,0 +1,337 @@
+"""Smoke for the subagent ↔ parent notification protocol (issue #64).
+
+Drives both directions of the new `subagent_note` / `parent_note`
+pipe events against real `_ChildState` IO threads without spawning
+subagent subprocesses — Pipe pairs simulate the cross-process
+channel so we can both inject events at the "subagent" and observe
+what the parent does with them.
+
+Locks:
+  1. Subagent side: `notify_parent("text")` emits a `subagent_note`
+     event upstream and returns immediately (non-blocking).
+  2. Subagent side: empty / whitespace text and unknown severity
+     return `<refused: ...>` markers without emitting upstream.
+  3. Parent side: an inbound `subagent_note` from a (fake) direct
+     child appends to the per-sid ring with a monotonic seq, sets
+     the t0 anchor, and queues a formatted user-role message onto
+     `pending_async_replies`.
+  4. Parent side: a `subagent_note` arriving with `agent_id` set
+     (bubbled from a grandchild) is dropped — no inbox injection,
+     no ring append.
+  5. Parent side: ring overflow drops the oldest entry and
+     increments the per-sid drop counter; the seq counter never
+     reuses values.
+  6. Subagent side: an inbound `parent_note` queues a `[parent
+     says]: ...` formatted message onto its own
+     `pending_async_replies`.
+
+In-process — no real LLM, no subprocesses. Run with:
+
+    .venv/bin/python -m tests.smoke_notify
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import queue as _queue
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+from pyagent import agent_proc
+from pyagent import subagent as subagent_mod
+from pyagent.agent import Agent
+from pyagent.llms.pyagent import EchoClient
+from pyagent.session import Session
+from pyagent.subagent import SubagentEntry
+
+
+class _FakeProcess:
+    def __init__(self, alive: bool = True) -> None:
+        self._alive = alive
+
+    def is_alive(self) -> bool:
+        return self._alive
+
+
+def _make_subagent_state(
+    tmp: Path,
+) -> tuple[
+    agent_proc._ChildState,
+    "multiprocessing.connection.Connection",
+    threading.Thread,
+]:
+    ctx = multiprocessing.get_context("spawn")
+    upstream_test_end, upstream_state_end = ctx.Pipe(duplex=True)
+    state = agent_proc._ChildState(conn=upstream_state_end)
+    state.self_agent_id = "fake-sub"
+    state.agent = Agent(client=EchoClient())
+    io = threading.Thread(target=state.io_loop, daemon=True)
+    io.start()
+    return state, upstream_test_end, io
+
+
+def _drain_pipe(conn) -> list[dict]:
+    out: list[dict] = []
+    while conn.poll(0.05):
+        try:
+            out.append(conn.recv())
+        except (EOFError, OSError):
+            break
+    return out
+
+
+def main() -> None:
+    tmp = Path(tempfile.mkdtemp(prefix="pyagent-notify-smoke-"))
+    os.chdir(tmp)
+    print(f"cwd: {tmp}")
+
+    # =========================================================
+    # Subagent-side flows
+    # =========================================================
+    state, upstream, io = _make_subagent_state(tmp)
+    notify = subagent_mod.make_notify_parent(state, state.agent)
+
+    try:
+        # 1. happy path: notify emits subagent_note and returns.
+        result = notify("framing is off; switching approach", "alert")
+        assert result.startswith("note sent"), result
+        ev = None
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            if upstream.poll(0.1):
+                ev = upstream.recv()
+                break
+        assert ev is not None, "no subagent_note emitted"
+        assert ev["type"] == "subagent_note", ev
+        assert ev["severity"] == "alert", ev
+        assert "framing is off" in ev["text"], ev
+        # No request_id / agent_id on the wire — notes are not
+        # requests and target the immediate parent only.
+        assert "request_id" not in ev, ev
+        print(f"✓ notify emitted subagent_note: severity={ev['severity']!r}")
+
+        # 2. default severity is "info".
+        notify("everything fine")
+        ev = None
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            if upstream.poll(0.1):
+                ev = upstream.recv()
+                break
+        assert ev is not None and ev["severity"] == "info", ev
+        print("✓ default severity = 'info'")
+
+        # 3. empty text refused without emitting.
+        refused = notify("   ")
+        assert refused == "<refused: empty text>", refused
+        assert not upstream.poll(0.2), "refused notify still emitted"
+        print(f"✓ empty text refused: {refused!r}")
+
+        # 4. unknown severity refused without emitting.
+        refused = notify("hi", severity="blocker")
+        assert refused.startswith("<refused: severity 'blocker'"), refused
+        assert not upstream.poll(0.2), "bad-severity notify still emitted"
+        print(f"✓ unknown severity refused: {refused!r}")
+
+        # 5. parent_note arriving on subagent side queues formatted msg.
+        upstream.send({"type": "parent_note", "text": "stop and switch to pytest"})
+        deadline = time.monotonic() + 2.0
+        msg = None
+        while time.monotonic() < deadline:
+            if state.agent.pending_async_replies.qsize() >= 1:
+                msg = state.agent.pending_async_replies.get_nowait()
+                break
+            time.sleep(0.05)
+        assert msg is not None, "parent_note not queued onto inbox"
+        assert msg.startswith("[parent says]:"), msg
+        assert "stop and switch to pytest" in msg, msg
+        print(f"✓ parent_note queued on subagent inbox: {msg!r}")
+
+    finally:
+        state.shutdown_event.set()
+        io.join(timeout=2)
+
+    # =========================================================
+    # Parent-side flows
+    # =========================================================
+    parent_session = Session(root=tmp / "sessions")
+    ctx = multiprocessing.get_context("spawn")
+    upstream_test_end, upstream_state_end = ctx.Pipe(duplex=True)
+    pstate = agent_proc._ChildState(conn=upstream_state_end)
+    pagent = Agent(client=EchoClient(), session=parent_session, depth=0)
+    pstate.agent = pagent
+
+    fake_sub_end, fake_parent_end = ctx.Pipe(duplex=True)
+    fake_sid = "fake-sub-cafefade"
+    pstate._subagent_conns[fake_sid] = fake_parent_end
+    pstate._subagent_reply_queues[fake_sid] = _queue.Queue()
+    pagent._subagents[fake_sid] = SubagentEntry(
+        id=fake_sid,
+        name="fake",
+        process=_FakeProcess(alive=True),  # type: ignore[arg-type]
+        conn=fake_parent_end,
+        reply_queue=pstate._subagent_reply_queues[fake_sid],
+        depth=1,
+    )
+
+    pio = threading.Thread(target=pstate.io_loop, daemon=True)
+    pio.start()
+
+    try:
+        # 6. inbound subagent_note appends to ring and queues inbox msg.
+        fake_sub_end.send({
+            "type": "subagent_note",
+            "severity": "warn",
+            "text": "tests pass on darwin",
+        })
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            if pagent.pending_async_replies.qsize() >= 1:
+                break
+            time.sleep(0.05)
+        assert pagent.pending_async_replies.qsize() == 1, (
+            f"pending_async_replies did not pick up the note "
+            f"(qsize={pagent.pending_async_replies.qsize()})"
+        )
+        msg = pagent.pending_async_replies.get_nowait()
+        assert "fake" in msg and fake_sid in msg, msg
+        assert "(warn)" in msg, msg
+        assert "tests pass on darwin" in msg, msg
+        # Ring populated with seq=0.
+        with pagent._notes_lock:
+            ring = list(pagent._subagent_notes[fake_sid])
+            seq_next = pagent._subagent_note_seq[fake_sid]
+            drops = pagent._subagent_note_drops[fake_sid]
+        assert len(ring) == 1, ring
+        assert ring[0][0] == 0, ring  # seq
+        assert ring[0][2] == "warn", ring  # severity
+        assert ring[0][3] == "tests pass on darwin", ring
+        assert seq_next == 1, seq_next
+        assert drops == 0, drops
+        print(f"✓ parent ring populated: seq=0, drops=0; inbox: {msg!r}")
+
+        # The IO thread also forwards upstream so the CLI can render.
+        # Drain that off the upstream test end.
+        forwarded = _drain_pipe(upstream_test_end)
+        assert any(
+            e.get("type") == "subagent_note"
+            and e.get("agent_id") == fake_sid
+            for e in forwarded
+        ), forwarded
+        print(f"✓ subagent_note forwarded upstream with agent_id={fake_sid}")
+
+        # 7. Bubbled (grandchild) subagent_note is dropped: no inbox
+        #    injection, no ring append. We surface it upstream so the
+        #    human sees something went sideways.
+        fake_sub_end.send({
+            "type": "subagent_note",
+            "severity": "info",
+            "text": "from a grandchild",
+            "agent_id": "grandchild-id",  # makes inner_id non-None
+        })
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline:
+            time.sleep(0.05)
+            forwarded = _drain_pipe(upstream_test_end)
+            if forwarded:
+                break
+        # Inbox unchanged (still 0 — we drained the warn one above).
+        assert pagent.pending_async_replies.qsize() == 0, (
+            "bubbled note polluted parent inbox"
+        )
+        # Ring unchanged.
+        with pagent._notes_lock:
+            ring = list(pagent._subagent_notes[fake_sid])
+        assert len(ring) == 1, "bubbled note appended to ring"
+        # Forwarded upstream so the human sees it.
+        assert any(
+            e.get("type") == "subagent_note"
+            and e.get("text") == "from a grandchild"
+            for e in forwarded
+        ), forwarded
+        print("✓ bubbled subagent_note dropped (no inbox / ring change)")
+
+        # 8. Ring overflow: feed 64 more notes (we already have 1),
+        #    so total = 65 → 1 drop expected.
+        for i in range(64):
+            fake_sub_end.send({
+                "type": "subagent_note",
+                "severity": "info",
+                "text": f"flood-{i}",
+            })
+        # Wait until 64 more inbox messages have queued.
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if pagent.pending_async_replies.qsize() >= 64:
+                break
+            time.sleep(0.05)
+        assert pagent.pending_async_replies.qsize() == 64, (
+            f"flood not drained into inbox "
+            f"(qsize={pagent.pending_async_replies.qsize()})"
+        )
+        # Drain the inbox so it doesn't pollute later tests.
+        while pagent.pending_async_replies.qsize():
+            pagent.pending_async_replies.get_nowait()
+        with pagent._notes_lock:
+            ring = list(pagent._subagent_notes[fake_sid])
+            seq_next = pagent._subagent_note_seq[fake_sid]
+            drops = pagent._subagent_note_drops[fake_sid]
+        assert len(ring) == 64, f"ring not full: len={len(ring)}"
+        assert seq_next == 65, f"seq_next != 65: {seq_next}"
+        assert drops == 1, f"drops != 1: {drops}"
+        # The leftmost entry is now seq=1 (seq=0 was the first 'warn'
+        # note from test 6, which got evicted).
+        assert ring[0][0] == 1, f"ring[0].seq != 1: {ring[0][0]}"
+        assert ring[0][3] == "flood-0", ring[0]
+        # The rightmost entry is seq=64.
+        assert ring[-1][0] == 64, f"ring[-1].seq != 64: {ring[-1][0]}"
+        assert ring[-1][3] == "flood-63", ring[-1]
+        print(
+            f"✓ ring overflow: len={len(ring)}, seq_next={seq_next}, "
+            f"drops={drops}, leftmost seq={ring[0][0]}"
+        )
+
+        # 9. More overflow: 10 more notes → drops = 11 cumulative.
+        for i in range(10):
+            fake_sub_end.send({
+                "type": "subagent_note",
+                "severity": "info",
+                "text": f"more-{i}",
+            })
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if pagent.pending_async_replies.qsize() >= 10:
+                break
+            time.sleep(0.05)
+        # Drain inbox.
+        while pagent.pending_async_replies.qsize():
+            pagent.pending_async_replies.get_nowait()
+        with pagent._notes_lock:
+            ring = list(pagent._subagent_notes[fake_sid])
+            drops = pagent._subagent_note_drops[fake_sid]
+        assert drops == 11, f"drops should be 11: got {drops}"
+        # Leftmost seq is now 11 (seqs 0..10 dropped).
+        assert ring[0][0] == 11, ring[0]
+        print(f"✓ continued overflow: drops={drops}, leftmost seq={ring[0][0]}")
+
+        # 10. _clear_subagent_notes drops the per-sid state cleanly.
+        pagent._clear_subagent_notes(fake_sid)
+        with pagent._notes_lock:
+            assert fake_sid not in pagent._subagent_notes
+            assert fake_sid not in pagent._subagent_note_seq
+            assert fake_sid not in pagent._subagent_note_drops
+            assert fake_sid not in pagent._subagent_note_t0
+        print("✓ _clear_subagent_notes wipes per-sid state")
+
+    finally:
+        pstate.shutdown_event.set()
+        pio.join(timeout=2)
+
+    print("\nALL CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #64. First of the dynamic-feedback series tracked in #63.

## Summary

Lands the pipe-event mechanism, per-sid storage, and IO-thread routing that #65 (peek + tell_subagent) and #68 (mid-turn user_note) build on. Surface in this PR is intentionally narrow — only `notify_parent` ships, just enough to exercise the channel end-to-end.

## What's here

- **Two new pipe events** mirroring the existing `subagent_ask` / `parent_answer` split:
  - `subagent_note` (upward, with `severity` in `{info, warn, alert}`)
  - `parent_note` (downward)
- **`make_notify_parent`** in `pyagent/subagent.py` — non-blocking, fire-and-forget. Registered on subagents alongside `ask_parent`. Refuses empty text and unknown severity.
- **Per-sid ring on `Agent`** — `deque(maxlen=64)` of `(seq, ts, severity, text)` plus a separate drop counter. Drop tracking lives outside the ring (so overflow doesn't have to manipulate a self-evicting marker entry); `peek_subagent` in #65 will surface the gap as a synthetic line.
- **Parent IO-thread routing** in `_handle_subagent_event`: append to ring + queue formatted message onto `pending_async_replies` so the parent's next LLM call sees the note. Bubbled-grandchild events are dropped with a warning, mirroring the `subagent_ask` rule at `agent_proc.py:407-416`.
- **Subagent IO-thread routing** in `_handle_event`: queue `parent_note` onto own `pending_async_replies`. No producer ships here; #65 adds `tell_subagent`.
- **PRIMER guidance** — balanced two-bullet paragraph. One bullet for subagents (don't spam, one note should change behaviour), one bullet for parents receiving notes (finish load-bearing work safely, then pivot when the note clearly redirects).

## Test plan

- [x] `tests/smoke_notify.py` — covers both directions end-to-end via fake pipes:
  - `notify_parent` emits `subagent_note` upstream and returns immediately
  - empty text + unknown severity refused without emitting
  - default severity = `info`
  - parent ring populates with monotonic seq; inbox shows formatted `[subagent <name> (<sid>) notes (<severity>)]: <text>` message
  - bubbled-grandchild `subagent_note` dropped (no inbox / ring change), still surfaced upstream
  - ring overflow: 65 notes total → drop count 1, leftmost seq advances to 1
  - 75 notes total → drop count 11, leftmost seq advances to 11
  - `_clear_subagent_notes` wipes per-sid state cleanly
  - `parent_note` arriving on subagent side queues `[parent says]: <text>` onto inbox
- [x] `tests/smoke_ask_parent.py` — no regression
- [x] `tests/smoke_subagent.py`, `smoke_async_subagent.py`, `smoke_subagent_routing.py`, `smoke_recursive_subagent.py`, `smoke_subagent_caps.py`, `smoke_plugins.py` — no regression
- [ ] `pyagent_self_audit.toml` bench — not run; user-controlled (mention in review).

## Notes

The issue body specified a `(seq, ts, "DROP", n_dropped)` *ring entry* for overflow markers. That has nasty edge cases when the marker itself gets evicted on subsequent overflows in a saturated ring. Switched to a separate per-sid drop counter — same observable behaviour from peek's perspective (the synthetic gap line will appear at read time in #65), simpler invariant. Worth confirming this is acceptable before #65 lands and consumes it.

Out of scope (deferred to follow-up issues):
- `tell_subagent` and `peek_subagent` — #65
- Mid-turn user `user_note` channel — #68
- Multi-permission queue — #69
- Controlling hooks v2 — #66