### PR TITLE
plugins: v2 controlling hooks for before_tool / after_tool (#66)

### DIFF
--- a/docs/plugin-design.md
+++ b/docs/plugin-design.md
@@ -55,9 +55,11 @@ don't conflict because they target different scopes.
   things that aren't in the session: `info` events, status footer,
   tool-call previews. `api.log(...)` writes here.
 - **The human** — the actor at the keyboard.
-- **Observer hook** — a hook whose return value pyagent ignores. **All
-  v1 hooks are observers.** Controlling hooks (return value directs
-  flow) are reserved for v2.
+- **Observer hook** — a hook whose return value pyagent ignores. All
+  v1 hooks are observers. v2 promotes `before_tool_call` and
+  `after_tool_call` to **controlling hooks** whose return value can
+  block / mutate / inject mid-turn feedback (see "Controlling hooks
+  (v2)" below). Other hooks remain observers.
 
 ## The plugin contract
 
@@ -186,14 +188,16 @@ no text doesn't fire it. Plugin can extract facts, index for vector
 recall, persist a clean transcript, trigger external systems, etc.
 Observer only — return value ignored."""
 
-api.before_tool_call(fn: Callable[[str, dict], None])
-"""Fired before each tool call. Plugin can log, audit, prefetch
-context. Observer only — cannot abort or modify the call (controlling
-hooks are v2)."""
+api.before_tool_call(fn: Callable[[str, dict], ToolHookResult | None])
+"""Fired before each tool call. v1 plugins return None (observer).
+v2 plugins (manifest `api_version = "2"`) may return a
+`ToolHookResult` to block / mutate / inject feedback — see
+"Controlling hooks (v2)" below."""
 
-api.after_tool_call(fn: Callable[[str, dict, str], None])
-"""Fired after each tool call with (name, args, result). Plugin can
-extract entities, update working memory, etc. Observer only."""
+api.after_tool_call(fn: Callable[[str, dict, Any], AfterToolHookResult | None])
+"""Fired after each tool call with (name, args, result). v1 plugins
+return None (observer). v2 plugins may return an
+`AfterToolHookResult` to replace the tool result or inject feedback."""
 ```
 
 Utility (1):
@@ -256,6 +260,126 @@ register_prompt_section (volatile):  read pre-computed embeddings,
 This means recall is **always one turn stale** — the plugin retrieves
 based on what it indexed up to the previous turn. That's the only
 shape that fits Python's no-preemption reality.
+
+## Controlling hooks (v2)
+
+Plugins declaring `api_version = "2"` can promote `before_tool_call`
+and `after_tool_call` from observers to **controllers** by returning
+a result dataclass instead of `None`. The hook signatures don't
+change — the only change is the return type — so v1 plugins keep
+working without edit.
+
+### `before_tool_call` return contract
+
+```python
+from pyagent.plugins import ToolHookResult
+
+@dataclass(frozen=True)
+class ToolHookResult:
+    decision: Literal["allow", "block", "mutate"] = "allow"
+    reason: str = ""                 # required when decision="block"
+    mutated_args: dict | None = None # required when decision="mutate"
+    extra_user_message: str = ""     # injected at next turn boundary
+```
+
+- `None` (or `decision="allow"`) — no change. Pure observer.
+- `decision="block"` — tool not executed; the model sees a synthetic
+  tool result `<blocked by plugin <name>: <reason>>`. Recovery is
+  natural: pyagent already returns errors as data via the `<...>`
+  marker convention, so the LLM can read the marker and adapt on
+  the next turn.
+- `decision="mutate"` — the tool runs with `mutated_args` instead of
+  the original args. The mutated dict also persists into the
+  conversation history (so session replay sees the args the tool
+  actually ran with) and into arg-scrubbing.
+- `extra_user_message` — non-empty strings get prepended to the
+  next assistant turn as a user-role message tagged
+  `[plugin <name> notes]: <text>`. Combinable with any decision.
+  Routed through the same `pending_async_replies` channel the
+  async-subagent reply machinery uses, so the next-turn ordering
+  rule is one rule across the harness.
+
+### `after_tool_call` return contract
+
+```python
+from pyagent.plugins import AfterToolHookResult
+
+@dataclass(frozen=True)
+class AfterToolHookResult:
+    extra_user_message: str = ""
+    replace_result: Any = _SENTINEL  # if set, replaces the tool result
+```
+
+- `extra_user_message` — same shape as in `ToolHookResult`.
+- `replace_result` — overrides the tool result string the model
+  sees on this turn. Useful for secret redaction, summarising a
+  huge log, etc. The sentinel default means "no replacement";
+  `None` is a legal replacement value.
+
+### Conflict resolution across multiple plugins
+
+Hooks fire in **plugin registration order** (i.e. plugin load order;
+see "Discovery").
+
+- `before_tool_call`: `block` short-circuits — once a plugin
+  returns `decision="block"`, no further `before_tool_call` hooks
+  fire on this call. `mutate` chains: each later plugin sees the
+  args the earlier plugin returned. `extra_user_message` from
+  hooks that ran (including the one that blocked) accumulates in
+  registration order, each tagged with its plugin name.
+- `after_tool_call`: `replace_result` chains — each later plugin's
+  hook is invoked with the result the previous plugin replaced.
+  Last-wins on the final result the model sees.
+
+### v1 / v2 dispatch — explicit rule
+
+`SUPPORTED_API_VERSIONS = {"1", "2"}` (set, not a single equality
+check). Plugins declaring any other value are skipped at load time
+with a warn log.
+
+**v1 plugins' return values are ignored unconditionally**, even if
+the plugin happens to return something v2-shaped. The dispatch loop
+checks `record.api_version == "2"` before honoring controller
+semantics. Otherwise a v1 plugin that accidentally `return True`s
+could start blocking tools.
+
+### Hook order vs. permission check
+
+Plugin hooks fire **before** permission checks. The v1 call site at
+`agent.py:_route_tool` runs `call_before_tool_call` before
+`_execute_tool`, and permission checks live inside the tool bodies
+(invoked from `_execute_tool`). v2 preserves this ordering — a
+controller hook returning `block` short-circuits before any
+permission prompt reaches the human. This is the right order: a
+plugin can redact a tool call or substitute a default before the
+human sees a permission prompt they'd otherwise have to dismiss.
+`smoke_controlling_hooks.test_block_short_circuits_before_permission`
+locks this in so a future refactor doesn't accidentally flip it.
+
+### Audit hook for blocks
+
+Every block emits an INFO-level structured log line:
+
+```
+plugin=<name> tool=<name> reason=<text>
+```
+
+The `<blocked by plugin X>` marker the model sees is for the model;
+the log line is for the human running a session audit ("plugin X
+blocked tool Y N times this run") without re-reading the full
+transcript.
+
+### Worked example: `strategic-reevaluation`
+
+The bundled `strategic_reevaluation` plugin (`pyagent/plugins/
+strategic_reevaluation/`) demonstrates the controlling-hook
+pattern. It registers no tools and no prompt sections — purely a
+v2 hook plugin. It tracks consecutive `edit_file` failures **per
+path** and, after three failures on the same path, returns an
+`AfterToolHookResult` with an `extra_user_message` that nudges the
+agent to step back and re-read the file before the next attempt.
+Three failures across *different* paths do not trip the heuristic
+— that's a refactor sweep, not a stuck loop.
 
 ## Cache-breakpoint architecture
 
@@ -530,9 +654,11 @@ that no longer exists. The graceful behavior:
 
 ## Versioning
 
-`api_version` is the pyagent ↔ plugin contract. A single integer-as-
-string ("1"). Pyagent supports exactly one value; plugins declaring a
-different value are skipped.
+`api_version` is the pyagent ↔ plugin contract — an integer-as-
+string. Pyagent supports a **set** of values
+(`SUPPORTED_API_VERSIONS = {"1", "2"}` today); plugins declaring any
+other value are skipped at load time. v1 and v2 plugins coexist in
+the same agent process.
 
 A plugin's *own* on-disk data format is its concern. A plugin that
 persists state should write a `version` file in its data dir on
@@ -575,7 +701,7 @@ The four communication shapes a plugin can use to surface results:
 | **1. Side-effect + log** | plugin → terminal | sync | Plugin did a thing | shipped (`api.log`) |
 | **2. One-way notification** | plugin → terminal *or* session, async | async | "GitHub issue arrived" | v2 (`api.deliver`) |
 | **3. Interactive query** | plugin ↔ human, blocking | sync | "Prompt has a secret; proceed?" | v2 (`api.ask_user`) |
-| **4. Hook return-value control** | controlling hook → pyagent | sync | Reject/modify a turn before LLM call | v2 (controlling hooks) |
+| **4. Hook return-value control** | controlling hook → pyagent | sync | Reject/modify a turn before LLM call | shipped (v2 — `before_tool_call` / `after_tool_call`) |
 
 ### v2 API sketches
 

--- a/pyagent/agent.py
+++ b/pyagent/agent.py
@@ -279,20 +279,73 @@ class Agent:
         will dispatch from here without further surgery on `run`. Exceptions
         are caught and returned as strings so the caller never has to
         compose tool results around a half-broken batch.
+
+        Plugin v2 controlling-hook semantics live here:
+
+        - ``before_tool`` runs *before* ``_execute_tool`` (which is
+          where permission checks fire, inside the wrapped tool body),
+          so a ``decision="block"`` short-circuits before any
+          permission prompt reaches the human. Preserve this ordering
+          — ``smoke_controlling_hooks.test_block_short_circuits_before_permission``
+          locks it in.
+        - ``decision="mutate"`` swaps the args dict in place inside
+          the conversation so subsequent turns see the args the tool
+          was actually invoked with (and arg-scrubbing applies to the
+          mutated bytes, not the originals).
+        - ``after_tool`` ``replace_result`` rewrites the bytes that
+          land in the tool_result.
+        - ``extra_user_message`` from either hook is pushed onto
+          ``pending_async_replies`` so the next assistant turn sees it
+          as a user-role message tagged with the originating plugin.
         """
         name = call["name"]
         args = call["args"]
         if on_tool_call:
             on_tool_call(name, args)
         if self.plugins is not None:
-            self.plugins.call_before_tool_call(name, args)
+            before = self.plugins.call_before_tool_call(name, args)
+            for note in before.extra_user_messages:
+                self.pending_async_replies.put(note)
+            if before.mutated and before.args is not args:
+                # Persist the mutated args back into the tool_call
+                # dict in self.conversation so future turns and
+                # session replay see the args the tool actually ran
+                # with. The reference swap matters: arg-scrubbing
+                # below operates on `call["args"]`.
+                call["args"] = before.args
+                args = before.args
+            if before.blocked:
+                content = (
+                    f"<blocked by plugin {before.block_plugin}: "
+                    f"{before.block_reason}>"
+                )
+                logger.info(
+                    "plugin=%s tool=%s reason=%s",
+                    before.block_plugin,
+                    name,
+                    before.block_reason,
+                )
+                if on_tool_result:
+                    on_tool_result(name, content)
+                # No tool ran, so nothing to scrub. Skip the after_tool
+                # hooks — the contract is "after the tool runs"; no
+                # tool ran.
+                return content
         try:
             content = self._execute_tool(name, args)
         except Exception as e:
             logger.exception("tool %s raised", name)
             content = f"Error: {type(e).__name__}: {e}"
         if self.plugins is not None:
-            self.plugins.call_after_tool_call(name, args, content)
+            after = self.plugins.call_after_tool_call(name, args, content)
+            for note in after.extra_user_messages:
+                self.pending_async_replies.put(note)
+            if after.replaced:
+                content = (
+                    after.result
+                    if isinstance(after.result, str)
+                    else str(after.result)
+                )
         if on_tool_result:
             on_tool_result(name, content)
         # Scrub bulky string args from the conversation so they don't

--- a/pyagent/plugins/__init__.py
+++ b/pyagent/plugins/__init__.py
@@ -43,7 +43,7 @@ from dataclasses import dataclass, field
 from importlib import resources
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Literal, Mapping
 
 from pyagent import config, paths
 
@@ -52,8 +52,17 @@ logger = logging.getLogger(__name__)
 LOCAL_PLUGINS_DIR = Path(".pyagent") / "plugins"
 PACKAGE_PLUGINS_PKG = "pyagent.plugins"
 ENTRY_POINT_GROUP = "pyagent.plugins"
-SUPPORTED_API_VERSION = "1"
+# Set of plugin API versions this build of pyagent understands. v1
+# plugins are observers (return values ignored); v2 plugins can return
+# `ToolHookResult` / `AfterToolHookResult` from before_tool / after_tool
+# to direct flow (block, mutate args, replace results, inject
+# user-role messages).
+SUPPORTED_API_VERSIONS: set[str] = {"1", "2"}
 RECENT_MESSAGES_WINDOW = 8
+
+# Sentinel for "no replacement" on AfterToolHookResult.replace_result
+# — `None` is a legitimate result value, so we need a distinct marker.
+_REPLACE_RESULT_SENTINEL = object()
 
 
 # ---- Public types ----------------------------------------------
@@ -75,6 +84,121 @@ class Manifest:
     requires_binaries: tuple[str, ...]
     in_subagents: bool
     source: Path  # absolute path to manifest.toml
+
+
+@dataclass(frozen=True)
+class ToolHookResult:
+    """Return value from a v2 ``before_tool`` hook.
+
+    Returning ``None`` (or omitting all fields → ``decision="allow"``)
+    is a no-op observer — the call proceeds with the original args and
+    no message is injected.
+
+    Fields:
+      - ``decision``: one of ``"allow"`` / ``"block"`` / ``"mutate"``.
+        ``"block"`` short-circuits the call before it reaches
+        ``_execute_tool`` (and before any permission prompt). The model
+        sees a synthetic ``<blocked by plugin <name>: <reason>>`` tool
+        result.
+        ``"mutate"`` runs the tool with ``mutated_args`` instead of the
+        original args. Multiple mutating plugins compose in
+        registration order — each later plugin sees the args the
+        earlier one returned.
+      - ``reason``: required when ``decision="block"``. Surfaces in the
+        synthetic tool-result string and in the structured INFO log.
+      - ``mutated_args``: required when ``decision="mutate"``. Replaces
+        the args dict for downstream hooks and tool execution.
+      - ``extra_user_message``: optional. If non-empty, the harness
+        prepends a user-role message tagged
+        ``[plugin <name> notes]: <text>`` onto the next assistant turn
+        (via the same ``pending_async_replies`` queue the subagent
+        notes machinery uses). Combinable with any ``decision``.
+
+    v1 plugins' return values are ignored unconditionally — the
+    dispatch loop checks ``record.api_version == "2"`` before honoring
+    these semantics.
+    """
+
+    decision: Literal["allow", "block", "mutate"] = "allow"
+    reason: str = ""
+    mutated_args: dict | None = None
+    extra_user_message: str = ""
+
+
+@dataclass(frozen=True)
+class AfterToolHookResult:
+    """Return value from a v2 ``after_tool`` hook.
+
+    Both fields are optional. Returning ``None`` is a no-op observer.
+
+    Fields:
+      - ``replace_result``: if set, replaces the tool result that the
+        model sees. Multiple plugins chain in registration order —
+        each later plugin sees the *replaced* result. Useful for
+        secret redaction or huge-log summarisation. Sentinel default
+        means "no replacement"; ``None`` is a legal replacement value.
+      - ``extra_user_message``: same shape as in ``ToolHookResult`` —
+        prepended to the next assistant turn as a user-role message
+        tagged with the plugin name.
+    """
+
+    extra_user_message: str = ""
+    replace_result: Any = _REPLACE_RESULT_SENTINEL
+
+
+@dataclass
+class BeforeToolDispatch:
+    """Aggregated outcome of running every plugin's ``before_tool``
+    hook for one tool call. Returned to the agent's ``_route_tool``.
+
+    - ``args``: the args dict to pass to the tool. Equals the original
+      dict when no plugin mutated; otherwise the last mutator's output.
+    - ``blocked`` + ``block_plugin`` + ``block_reason``: when ``blocked``,
+      the agent must not invoke the tool. The synthetic
+      ``<blocked by plugin <name>: <reason>>`` marker becomes the tool
+      result, and an INFO log line is emitted.
+    - ``mutated``: True iff at least one plugin returned
+      ``decision="mutate"``. Informational only — callers usually only
+      need ``args``.
+    - ``extra_user_messages``: pre-formatted user-role strings to push
+      onto the agent's ``pending_async_replies`` queue so they show up
+      at the start of the next turn.
+    """
+
+    args: dict
+    blocked: bool = False
+    block_plugin: str = ""
+    block_reason: str = ""
+    mutated: bool = False
+    extra_user_messages: list[str] = field(default_factory=list)
+
+
+@dataclass
+class AfterToolDispatch:
+    """Aggregated outcome of running every plugin's ``after_tool`` hook
+    for one tool call.
+
+    - ``result``: the (possibly replaced) result the model should see.
+    - ``replaced``: True iff at least one plugin returned a
+      ``replace_result`` other than the sentinel.
+    - ``extra_user_messages``: same shape as on ``BeforeToolDispatch``.
+    """
+
+    result: Any
+    replaced: bool = False
+    extra_user_messages: list[str] = field(default_factory=list)
+
+
+def _format_plugin_note(plugin_name: str, text: str) -> str:
+    """Format a plugin-contributed extra_user_message into the
+    canonical user-role string the agent sees on the next turn.
+
+    Mirrors the ``[subagent <name> (<id>) reports]: <text>`` shape
+    used by ``pending_async_replies`` for async-subagent notes so the
+    LLM has one consistent grammar for "harness-injected note from
+    component X".
+    """
+    return f"[plugin {plugin_name} notes]: {text}"
 
 
 @dataclass(frozen=True)
@@ -338,12 +462,12 @@ def _parse_manifest(manifest_path: Path) -> Manifest | None:
         )
         return None
 
-    if str(data.get("api_version")) != SUPPORTED_API_VERSION:
+    if str(data.get("api_version")) not in SUPPORTED_API_VERSIONS:
         logger.warning(
-            "plugin %s: api_version %r unsupported (expected %r); skipping",
+            "plugin %s: api_version %r unsupported (supported: %s); skipping",
             data.get("name"),
             data.get("api_version"),
-            SUPPORTED_API_VERSION,
+            sorted(SUPPORTED_API_VERSIONS),
         )
         return None
 
@@ -845,29 +969,124 @@ class LoadedPlugins:
                         state.manifest.name,
                     )
 
-    def call_before_tool_call(self, name: str, args: dict) -> None:
+    def call_before_tool_call(
+        self, name: str, args: dict
+    ) -> "BeforeToolDispatch":
+        """Fire every plugin's before_tool hook in registration order.
+
+        Conflict resolution (matches the v2 contract documented in
+        `docs/plugin-design.md`):
+
+        - ``block`` short-circuits the dispatch loop. No further
+          plugins fire after the first block. The block reason is
+          carried back to the call site for surfacing as a synthetic
+          tool result and an INFO log line. Hooks earlier in
+          registration order than the blocker still run; their
+          ``extra_user_message`` contributions are preserved on the
+          returned dispatch.
+        - ``mutate`` chains: later plugins see the args the earlier
+          plugin returned. The returned ``args`` is the final mutated
+          dict (or the original if no plugin mutated).
+        - ``extra_user_message`` accumulates from every plugin that
+          contributed one, each tagged with the originating plugin
+          name. Returned as a list of pre-formatted strings the
+          caller queues onto ``pending_async_replies``.
+
+        v1 plugins' return values are ignored unconditionally — the
+        loop only honors decision semantics when ``api_version == "2"``.
+        Hooks that raise are caught and logged so one bad plugin
+        doesn't poison the rest of the loop.
+        """
+        dispatch = BeforeToolDispatch(args=args)
         for state in self.states:
+            is_v2 = state.manifest.api_version == "2"
+            plugin_name = state.manifest.name
             for fn in state.before_tool_hooks:
                 try:
-                    fn(name, args)
+                    rv = fn(name, dispatch.args)
                 except Exception:
                     logger.exception(
                         "plugin %s before_tool_call raised",
-                        state.manifest.name,
+                        plugin_name,
                     )
+                    continue
+                if not is_v2 or rv is None:
+                    continue
+                if not isinstance(rv, ToolHookResult):
+                    logger.warning(
+                        "plugin %s before_tool_call returned unexpected "
+                        "type %r; ignoring",
+                        plugin_name,
+                        type(rv).__name__,
+                    )
+                    continue
+                if rv.extra_user_message:
+                    dispatch.extra_user_messages.append(
+                        _format_plugin_note(
+                            plugin_name, rv.extra_user_message
+                        )
+                    )
+                if rv.decision == "block":
+                    dispatch.blocked = True
+                    dispatch.block_plugin = plugin_name
+                    dispatch.block_reason = rv.reason or ""
+                    return dispatch
+                if rv.decision == "mutate":
+                    if isinstance(rv.mutated_args, dict):
+                        dispatch.args = rv.mutated_args
+                        dispatch.mutated = True
+                    else:
+                        logger.warning(
+                            "plugin %s before_tool_call returned "
+                            "decision='mutate' without a dict "
+                            "mutated_args; ignoring",
+                            plugin_name,
+                        )
+        return dispatch
 
     def call_after_tool_call(
-        self, name: str, args: dict, result: str
-    ) -> None:
+        self, name: str, args: dict, result: Any
+    ) -> "AfterToolDispatch":
+        """Fire every plugin's after_tool hook in registration order.
+
+        ``replace_result`` chains in registration order — each later
+        plugin's hook is invoked with the result the previous plugin
+        replaced. ``extra_user_message`` accumulates the same way as
+        in ``call_before_tool_call``.
+        """
+        dispatch = AfterToolDispatch(result=result)
         for state in self.states:
+            is_v2 = state.manifest.api_version == "2"
+            plugin_name = state.manifest.name
             for fn in state.after_tool_hooks:
                 try:
-                    fn(name, args, result)
+                    rv = fn(name, args, dispatch.result)
                 except Exception:
                     logger.exception(
                         "plugin %s after_tool_call raised",
-                        state.manifest.name,
+                        plugin_name,
                     )
+                    continue
+                if not is_v2 or rv is None:
+                    continue
+                if not isinstance(rv, AfterToolHookResult):
+                    logger.warning(
+                        "plugin %s after_tool_call returned unexpected "
+                        "type %r; ignoring",
+                        plugin_name,
+                        type(rv).__name__,
+                    )
+                    continue
+                if rv.extra_user_message:
+                    dispatch.extra_user_messages.append(
+                        _format_plugin_note(
+                            plugin_name, rv.extra_user_message
+                        )
+                    )
+                if rv.replace_result is not _REPLACE_RESULT_SENTINEL:
+                    dispatch.result = rv.replace_result
+                    dispatch.replaced = True
+        return dispatch
 
 
 def load(*, is_subagent: bool = False) -> LoadedPlugins:

--- a/pyagent/plugins/strategic_reevaluation/__init__.py
+++ b/pyagent/plugins/strategic_reevaluation/__init__.py
@@ -1,0 +1,122 @@
+"""strategic-reevaluation — bundled v2 demo plugin.
+
+Watches `edit_file` tool results. When the same path fails three
+times in a row (consecutive failures, not cumulative across the
+session), the plugin injects an H4-flavored "step back and
+reconsider" note onto the next assistant turn via the v2
+``AfterToolHookResult.extra_user_message`` channel.
+
+The counter is **path-keyed**, not global — a flurry of failures
+across different files (a refactor where the same `old_string` is
+hunted across N files, two of which legitimately don't have the
+text) does not trip the heuristic. Three real-honest-to-goodness
+failures on the same file does.
+
+Counter resets on:
+  - Any successful `edit_file` call against that path.
+  - Any non-`edit_file` tool call against that path (read_file,
+    write_file, grep — any of these are evidence the agent is
+    actually inspecting the situation rather than blind-retrying).
+
+This plugin is the canonical worked example for the "controlling
+hooks" feature: ~80 lines, zero tools registered, demonstrates that
+plugin-injected mid-turn feedback is now a 30-line plugin instead of
+a paragraph baked into PRIMER.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pyagent.plugins import AfterToolHookResult
+
+CONSECUTIVE_FAILURE_THRESHOLD = 3
+
+# Per-process state. The plugin is `in_subagents = false`, so this
+# only ever lives in the root agent's process.
+_consecutive_fails: dict[str, int] = {}
+
+# A tool result counts as a failure if the tool returned an error
+# marker. pyagent's `<...>` convention covers most cases:
+# `<file not found: ...>`, `<error: old_string ... not found>`, etc.
+# We also flag `_denied(path)` results (which start with
+# `<permission denied to ...>`) as failures.
+_FAILURE_PREFIXES = ("<error", "<file not found", "<permission denied",
+                     "<is a directory", "<cannot decode", "<no match",
+                     "<old_string", "<the original", "<")
+
+
+RECONSIDER_NOTE = (
+    "You've now had several consecutive edit_file failures on the "
+    "same path. Step back. Re-read the file from scratch. The "
+    "old_string you keep trying to match probably isn't there in the "
+    "form you think it is — confirm with read_file or grep before "
+    "the next edit, and consider whether the change you're trying to "
+    "make is the right one at all."
+)
+
+
+def _is_failure(result: Any) -> bool:
+    """edit_file returns a string; failures start with `<...>` markers
+    (the codebase's `tools.py` `<...>` convention). A confirmation
+    starts with `Wrote ...` or `Replaced ...`."""
+    if not isinstance(result, str):
+        return False
+    s = result.lstrip()
+    if not s:
+        return False
+    # Cheap test: confirmations start with Wrote/Replaced/etc., not
+    # with `<`. Anything starting with `<` is a marker per the
+    # tools.py convention.
+    return s.startswith("<")
+
+
+def _path_from_args(args: dict) -> str | None:
+    if not isinstance(args, dict):
+        return None
+    p = args.get("path")
+    return p if isinstance(p, str) and p else None
+
+
+def _on_after_tool(name: str, args: dict, result: Any) -> AfterToolHookResult | None:
+    path = _path_from_args(args)
+    if path is None:
+        return None
+    if name != "edit_file":
+        # Reset the counter on any other tool against this path —
+        # evidence the agent is inspecting rather than blind-
+        # retrying.
+        _consecutive_fails.pop(path, None)
+        return None
+
+    if not _is_failure(result):
+        # Successful edit. Reset.
+        _consecutive_fails.pop(path, None)
+        return None
+
+    # Bumping the counter.
+    n = _consecutive_fails.get(path, 0) + 1
+    _consecutive_fails[path] = n
+    if n < CONSECUTIVE_FAILURE_THRESHOLD:
+        return None
+
+    # Threshold tripped. Reset so the note doesn't fire on every
+    # subsequent failure too — the agent gets one nudge, not a
+    # spammy stream.
+    _consecutive_fails.pop(path, None)
+    return AfterToolHookResult(
+        extra_user_message=(
+            f"{RECONSIDER_NOTE} (path={path}, "
+            f"{CONSECUTIVE_FAILURE_THRESHOLD} consecutive failures)"
+        )
+    )
+
+
+def register(api: Any) -> None:
+    api.after_tool_call(_on_after_tool)
+
+
+def _reset_for_tests() -> None:
+    """Clear the per-path counter. Called by smoke tests so each test
+    starts from a known state."""
+    _consecutive_fails.clear()

--- a/pyagent/plugins/strategic_reevaluation/manifest.toml
+++ b/pyagent/plugins/strategic_reevaluation/manifest.toml
@@ -1,0 +1,16 @@
+name = "strategic-reevaluation"
+version = "0.1.0"
+description = "After 3 consecutive edit_file failures on the same path, inject a 'step back and reconsider' note onto the next turn."
+api_version = "2"
+
+# Hook-only plugin: registers no tools, no prompt sections, no
+# providers. Lives entirely in `after_tool` and uses the v2
+# controlling-hook contract to inject an `extra_user_message` when its
+# heuristic trips.
+[provides]
+
+# Stateless across processes (per-process counter), but only useful
+# in the root agent — subagents have short-lived task scopes where
+# the "you've been spinning, reconsider" framing is rarely apt.
+[load]
+in_subagents = false

--- a/tests/smoke_controlling_hooks.py
+++ b/tests/smoke_controlling_hooks.py
@@ -1,0 +1,703 @@
+"""Smoke tests for v2 controlling hooks (issue #66).
+
+Covers every acceptance-criteria bullet:
+
+  - allow (no change) — v2 hook returning None or
+    `ToolHookResult(decision="allow")` is a pure observer.
+  - block — tool not executed, synthetic marker shown, INFO log
+    emitted, permission check NOT reached (short-circuit ordering).
+  - mutate — tool sees mutated args; mutation persists into
+    conversation history.
+  - extra_user_message from before_tool and after_tool — flows
+    through `pending_async_replies` and lands as a user-role turn
+    next iteration.
+  - conflict resolution: block > mutate, mutate chaining,
+    replace_result chaining (later plugin sees replaced result).
+  - v1 plugin returning a v2-shaped value → ignored, behavior
+    unchanged.
+  - strategic_reevaluation: 3 fails on path A → inject; 3 fails
+    interleaved across paths A and B → no inject (path-keyed).
+
+Run with:
+
+    .venv/bin/python -m tests.smoke_controlling_hooks
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+from pyagent import paths
+from pyagent import plugins as plugins_mod
+from pyagent.agent import Agent
+
+
+# ---- Test fixture helpers (mirrored from tests/smoke_plugins.py) ----
+
+
+def _write_plugin(
+    plugins_root: Path,
+    dirname: str,
+    *,
+    name: str,
+    api_version: str = "2",
+    provides_tools: list[str] | None = None,
+    provides_sections: list[str] | None = None,
+    in_subagents: bool = True,
+    plugin_py: str = "",
+) -> Path:
+    pdir = plugins_root / dirname
+    pdir.mkdir(parents=True, exist_ok=True)
+    tools_line = (
+        "tools = ["
+        + ", ".join(f'"{t}"' for t in (provides_tools or []))
+        + "]"
+    )
+    sections_line = (
+        "prompt_sections = ["
+        + ", ".join(f'"{s}"' for s in (provides_sections or []))
+        + "]"
+    )
+    in_sub_line = "true" if in_subagents else "false"
+    manifest = (
+        f'name = "{name}"\n'
+        f'version = "0.1.0"\n'
+        f'description = "{name} plugin (smoke test)"\n'
+        f'api_version = "{api_version}"\n\n'
+        "[provides]\n"
+        f"{tools_line}\n"
+        f"{sections_line}\n\n"
+        "[load]\n"
+        f"in_subagents = {in_sub_line}\n"
+    )
+    (pdir / "manifest.toml").write_text(manifest)
+    (pdir / "plugin.py").write_text(plugin_py)
+    return pdir
+
+
+def _isolated_config_dir():
+    tmp_cfg = Path(tempfile.mkdtemp(prefix="pyagent-v2hook-cfg-"))
+    (tmp_cfg / "config.toml").write_text(
+        "built_in_plugins_enabled = []\n"
+    )
+    original_config = paths.config_dir
+    original_data = paths.data_dir
+    paths.config_dir = lambda: tmp_cfg  # type: ignore[assignment]
+    paths.data_dir = lambda: tmp_cfg  # type: ignore[assignment]
+
+    def restore() -> None:
+        paths.config_dir = original_config  # type: ignore[assignment]
+        paths.data_dir = original_data  # type: ignore[assignment]
+        shutil.rmtree(tmp_cfg, ignore_errors=True)
+
+    return tmp_cfg, restore
+
+
+def _mk_agent(loaded: plugins_mod.LoadedPlugins) -> Agent:
+    """An Agent with a stub LLM and one in-process tool. Each test
+    drives `_route_tool` directly so we don't need to round-trip
+    through a real LLM client."""
+    stub_client = MagicMock()
+    agent = Agent(client=stub_client, plugins=loaded)
+
+    def widget(path: str, value: str = "") -> str:
+        """Test tool that echoes its args; lets us assert mutation."""
+        return f"widget(path={path!r}, value={value!r})"
+
+    agent.add_tool("widget", widget, auto_offload=False)
+    return agent
+
+
+def _drain_pending(agent: Agent) -> list[str]:
+    out: list[str] = []
+    while not agent.pending_async_replies.empty():
+        out.append(agent.pending_async_replies.get_nowait())
+    return out
+
+
+# ---- Test cases -----------------------------------------------------
+
+
+def test_allow_no_change() -> None:
+    cfg, restore = _isolated_config_dir()
+    try:
+        plugin_py = (
+            "from pyagent.plugins import ToolHookResult\n"
+            "events = []\n"
+            "def register(api):\n"
+            "    def before(name, args):\n"
+            "        events.append(('before', name, dict(args)))\n"
+            "        return ToolHookResult(decision='allow')\n"
+            "    def after(name, args, result):\n"
+            "        events.append(('after', name, result))\n"
+            "        return None\n"
+            "    api.before_tool_call(before)\n"
+            "    api.after_tool_call(after)\n"
+        )
+        _write_plugin(
+            cfg / "plugins",
+            dirname="allow",
+            name="allow",
+            plugin_py=plugin_py,
+        )
+        loaded = plugins_mod.load()
+        agent = _mk_agent(loaded)
+        result = agent._route_tool({
+            "id": "1", "name": "widget",
+            "args": {"path": "/x", "value": "v"},
+        })
+        assert result == "widget(path='/x', value='v')", result
+        assert _drain_pending(agent) == []
+        print("✓ allow: hook is observer, tool runs unchanged")
+    finally:
+        restore()
+
+
+def test_block_short_circuits_before_permission(caplog=None) -> None:
+    """A `block` decision must:
+      - prevent the tool from running entirely
+      - surface a `<blocked by plugin X: reason>` marker to the model
+      - emit an INFO log line with `plugin=`, `tool=`, `reason=`
+      - happen BEFORE permission checks (asserted by the tool body
+        never running — if it ran, our marker tool would record it)
+    """
+    cfg, restore = _isolated_config_dir()
+    try:
+        # Plugin will block; the tool body would set this if reached.
+        plugin_py = (
+            "from pyagent.plugins import ToolHookResult\n"
+            "def register(api):\n"
+            "    def before(name, args):\n"
+            "        return ToolHookResult(\n"
+            "            decision='block',\n"
+            "            reason='not allowed in tests',\n"
+            "        )\n"
+            "    api.before_tool_call(before)\n"
+        )
+        _write_plugin(
+            cfg / "plugins",
+            dirname="blocker",
+            name="blocker",
+            plugin_py=plugin_py,
+        )
+        loaded = plugins_mod.load()
+        agent = _mk_agent(loaded)
+
+        # Replace the widget tool with one that records if it ran —
+        # if the block didn't short-circuit, this list would grow.
+        ran: list[str] = []
+
+        def widget(path: str, value: str = "") -> str:
+            ran.append(path)
+            return "TOOL RAN"
+
+        agent.tools["widget"] = widget
+
+        # Capture INFO logs from the plugins logger.
+        records: list[logging.LogRecord] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        cap = _Capture(level=logging.INFO)
+        agent_logger = logging.getLogger("pyagent.agent")
+        prev_level = agent_logger.level
+        agent_logger.setLevel(logging.INFO)
+        agent_logger.addHandler(cap)
+        try:
+            result = agent._route_tool({
+                "id": "1", "name": "widget",
+                "args": {"path": "/x", "value": "v"},
+            })
+        finally:
+            agent_logger.removeHandler(cap)
+            agent_logger.setLevel(prev_level)
+
+        assert result == "<blocked by plugin blocker: not allowed in tests>", result
+        assert ran == [], (
+            "block must short-circuit BEFORE the tool body runs "
+            "(tool body is also where permission checks live)"
+        )
+        # INFO-level structured log line.
+        info_msgs = [
+            r.getMessage() for r in records if r.levelno == logging.INFO
+        ]
+        matched = [
+            m for m in info_msgs
+            if "plugin=blocker" in m
+            and "tool=widget" in m
+            and "reason=not allowed in tests" in m
+        ]
+        assert matched, (
+            f"expected INFO log with plugin=blocker tool=widget reason=...; "
+            f"got {info_msgs}"
+        )
+        print(
+            "✓ block: tool not executed, marker returned, INFO log "
+            "emitted, permission check unreached"
+        )
+    finally:
+        restore()
+
+
+def test_mutate_args() -> None:
+    cfg, restore = _isolated_config_dir()
+    try:
+        plugin_py = (
+            "from pyagent.plugins import ToolHookResult\n"
+            "def register(api):\n"
+            "    def before(name, args):\n"
+            "        new = dict(args)\n"
+            "        new['value'] = 'OVERRIDDEN'\n"
+            "        return ToolHookResult(\n"
+            "            decision='mutate', mutated_args=new,\n"
+            "        )\n"
+            "    api.before_tool_call(before)\n"
+        )
+        _write_plugin(
+            cfg / "plugins",
+            dirname="mut",
+            name="mut",
+            plugin_py=plugin_py,
+        )
+        loaded = plugins_mod.load()
+        agent = _mk_agent(loaded)
+        call = {
+            "id": "1", "name": "widget",
+            "args": {"path": "/x", "value": "original"},
+        }
+        result = agent._route_tool(call)
+        assert "OVERRIDDEN" in result, result
+        assert "original" not in result, result
+        # The mutated args should have replaced call["args"] in place
+        # so session replay sees what actually ran.
+        assert call["args"]["value"] == "OVERRIDDEN", call["args"]
+        print("✓ mutate: tool sees mutated args; conversation persists them")
+    finally:
+        restore()
+
+
+def test_extra_user_message_before_and_after() -> None:
+    cfg, restore = _isolated_config_dir()
+    try:
+        plugin_py = (
+            "from pyagent.plugins import ToolHookResult, AfterToolHookResult\n"
+            "def register(api):\n"
+            "    def before(name, args):\n"
+            "        return ToolHookResult(\n"
+            "            extra_user_message='heads up: tool incoming',\n"
+            "        )\n"
+            "    def after(name, args, result):\n"
+            "        return AfterToolHookResult(\n"
+            "            extra_user_message='heads up: tool ran',\n"
+            "        )\n"
+            "    api.before_tool_call(before)\n"
+            "    api.after_tool_call(after)\n"
+        )
+        _write_plugin(
+            cfg / "plugins",
+            dirname="notes",
+            name="notes",
+            plugin_py=plugin_py,
+        )
+        loaded = plugins_mod.load()
+        agent = _mk_agent(loaded)
+        agent._route_tool({
+            "id": "1", "name": "widget",
+            "args": {"path": "/x"},
+        })
+        notes = _drain_pending(agent)
+        assert any("[plugin notes notes]: heads up: tool incoming" == n for n in notes), notes
+        assert any("[plugin notes notes]: heads up: tool ran" == n for n in notes), notes
+        print(
+            "✓ extra_user_message from before/after lands on "
+            "pending_async_replies with [plugin <name> notes]: tag"
+        )
+    finally:
+        restore()
+
+
+def test_extra_user_message_drains_to_next_turn() -> None:
+    """Round-trip: a v2 plugin's note shows up as a user-role turn at
+    the start of the next run iteration via `_drain_pending_async`."""
+    cfg, restore = _isolated_config_dir()
+    try:
+        plugin_py = (
+            "from pyagent.plugins import AfterToolHookResult\n"
+            "def register(api):\n"
+            "    def after(name, args, result):\n"
+            "        return AfterToolHookResult(\n"
+            "            extra_user_message='reconsider',\n"
+            "        )\n"
+            "    api.after_tool_call(after)\n"
+        )
+        _write_plugin(
+            cfg / "plugins",
+            dirname="reflect",
+            name="reflect",
+            plugin_py=plugin_py,
+        )
+        loaded = plugins_mod.load()
+        agent = _mk_agent(loaded)
+        agent._route_tool({
+            "id": "1", "name": "widget",
+            "args": {"path": "/x"},
+        })
+        # Drain — same machinery `Agent.run` uses at the top of each
+        # loop iteration.
+        n = agent._drain_pending_async()
+        assert n == 1, n
+        last = agent.conversation[-1]
+        assert last["role"] == "user", last
+        assert last["content"] == "[plugin reflect notes]: reconsider", last
+        print(
+            "✓ note drains as a user-role turn at the next loop "
+            "iteration via pending_async_replies"
+        )
+    finally:
+        restore()
+
+
+def test_block_beats_mutate() -> None:
+    cfg, restore = _isolated_config_dir()
+    try:
+        # Plugin A blocks (loads first by directory prefix). Plugin B
+        # would mutate — but never runs because A short-circuited.
+        plugin_a = (
+            "from pyagent.plugins import ToolHookResult\n"
+            "def register(api):\n"
+            "    def before(name, args):\n"
+            "        return ToolHookResult(\n"
+            "            decision='block', reason='nope',\n"
+            "        )\n"
+            "    api.before_tool_call(before)\n"
+        )
+        plugin_b = (
+            "from pyagent.plugins import ToolHookResult\n"
+            "events = []\n"
+            "def register(api):\n"
+            "    def before(name, args):\n"
+            "        events.append(('B-ran', dict(args)))\n"
+            "        return ToolHookResult(\n"
+            "            decision='mutate',\n"
+            "            mutated_args={**args, 'value': 'B'},\n"
+            "        )\n"
+            "    api.before_tool_call(before)\n"
+        )
+        _write_plugin(cfg / "plugins", dirname="01-a",
+                      name="block-a", plugin_py=plugin_a)
+        _write_plugin(cfg / "plugins", dirname="02-b",
+                      name="mutate-b", plugin_py=plugin_b)
+        loaded = plugins_mod.load()
+        agent = _mk_agent(loaded)
+        result = agent._route_tool({
+            "id": "1", "name": "widget",
+            "args": {"path": "/x", "value": "orig"},
+        })
+        assert result == "<blocked by plugin block-a: nope>", result
+        # Plugin B's hook never ran.
+        b_mod = next(
+            mod for mod_name, mod in sys.modules.items()
+            if mod_name.startswith("pyagent_plugin_mutate_b")
+        )
+        assert b_mod.events == [], (
+            f"block must short-circuit; B should not have run: {b_mod.events}"
+        )
+        print("✓ block > mutate: later mutate hook does not fire")
+    finally:
+        restore()
+
+
+def test_mutate_chaining() -> None:
+    cfg, restore = _isolated_config_dir()
+    try:
+        # Plugin A mutates value to "A"; plugin B sees "A" and mutates
+        # to "A-then-B". The tool sees the final composed args.
+        plugin_a = (
+            "from pyagent.plugins import ToolHookResult\n"
+            "def register(api):\n"
+            "    def before(name, args):\n"
+            "        return ToolHookResult(\n"
+            "            decision='mutate',\n"
+            "            mutated_args={**args, 'value': 'A'},\n"
+            "        )\n"
+            "    api.before_tool_call(before)\n"
+        )
+        plugin_b = (
+            "from pyagent.plugins import ToolHookResult\n"
+            "seen = []\n"
+            "def register(api):\n"
+            "    def before(name, args):\n"
+            "        seen.append(args.get('value'))\n"
+            "        return ToolHookResult(\n"
+            "            decision='mutate',\n"
+            "            mutated_args={**args, 'value': args.get('value', '') + '-then-B'},\n"
+            "        )\n"
+            "    api.before_tool_call(before)\n"
+        )
+        _write_plugin(cfg / "plugins", dirname="01-mA",
+                      name="mut-a", plugin_py=plugin_a)
+        _write_plugin(cfg / "plugins", dirname="02-mB",
+                      name="mut-b", plugin_py=plugin_b)
+        loaded = plugins_mod.load()
+        agent = _mk_agent(loaded)
+        result = agent._route_tool({
+            "id": "1", "name": "widget",
+            "args": {"path": "/x", "value": "orig"},
+        })
+        assert "A-then-B" in result, result
+        # Plugin B saw what plugin A returned.
+        b_mod = next(
+            mod for mod_name, mod in sys.modules.items()
+            if mod_name.startswith("pyagent_plugin_mut_b")
+        )
+        assert b_mod.seen == ["A"], (
+            f"plugin B must see A's mutated value, not 'orig': {b_mod.seen}"
+        )
+        print("✓ mutate chains in registration order; later sees earlier's args")
+    finally:
+        restore()
+
+
+def test_replace_result_chaining() -> None:
+    cfg, restore = _isolated_config_dir()
+    try:
+        plugin_a = (
+            "from pyagent.plugins import AfterToolHookResult\n"
+            "def register(api):\n"
+            "    def after(name, args, result):\n"
+            "        return AfterToolHookResult(replace_result='A')\n"
+            "    api.after_tool_call(after)\n"
+        )
+        plugin_b = (
+            "from pyagent.plugins import AfterToolHookResult\n"
+            "seen = []\n"
+            "def register(api):\n"
+            "    def after(name, args, result):\n"
+            "        seen.append(result)\n"
+            "        return AfterToolHookResult(\n"
+            "            replace_result=result + '-then-B',\n"
+            "        )\n"
+            "    api.after_tool_call(after)\n"
+        )
+        _write_plugin(cfg / "plugins", dirname="01-rA",
+                      name="rep-a", plugin_py=plugin_a)
+        _write_plugin(cfg / "plugins", dirname="02-rB",
+                      name="rep-b", plugin_py=plugin_b)
+        loaded = plugins_mod.load()
+        agent = _mk_agent(loaded)
+        result = agent._route_tool({
+            "id": "1", "name": "widget",
+            "args": {"path": "/x"},
+        })
+        assert result == "A-then-B", result
+        b_mod = next(
+            mod for mod_name, mod in sys.modules.items()
+            if mod_name.startswith("pyagent_plugin_rep_b")
+        )
+        assert b_mod.seen == ["A"], (
+            f"plugin B must see A's replaced result, not the tool's "
+            f"original output: {b_mod.seen}"
+        )
+        print("✓ replace_result chains; later sees earlier's replacement")
+    finally:
+        restore()
+
+
+def test_v1_return_value_ignored() -> None:
+    """A v1 plugin (api_version='1') returning a v2-shaped value must
+    be ignored — otherwise a v1 plugin that accidentally returns
+    `True` or a stray object could start blocking tools."""
+    cfg, restore = _isolated_config_dir()
+    try:
+        plugin_py = (
+            "from pyagent.plugins import ToolHookResult\n"
+            "def register(api):\n"
+            "    def before(name, args):\n"
+            "        return ToolHookResult(\n"
+            "            decision='block', reason='v1 should be ignored',\n"
+            "        )\n"
+            "    api.before_tool_call(before)\n"
+        )
+        _write_plugin(
+            cfg / "plugins",
+            dirname="legacy",
+            name="legacy",
+            api_version="1",
+            plugin_py=plugin_py,
+        )
+        loaded = plugins_mod.load()
+        agent = _mk_agent(loaded)
+        result = agent._route_tool({
+            "id": "1", "name": "widget",
+            "args": {"path": "/x", "value": "v"},
+        })
+        # Tool ran normally — block was ignored because plugin is v1.
+        assert "widget(path='/x'" in result, result
+        assert "<blocked" not in result, result
+        print("✓ v1 plugin's v2-shaped return is ignored unconditionally")
+    finally:
+        restore()
+
+
+def test_strategic_reevaluation_path_keyed() -> None:
+    """Bundled strategic-reevaluation plugin: 3 fails on path A → note
+    fires; 3 fails interleaved across A and B → no note (per-path
+    counter)."""
+    cfg, restore = _isolated_config_dir()
+    try:
+        (cfg / "config.toml").write_text(
+            'built_in_plugins_enabled = ["strategic-reevaluation"]\n'
+        )
+        loaded = plugins_mod.load(is_subagent=False)
+        names = [s.manifest.name for s in loaded.states]
+        assert "strategic-reevaluation" in names, (
+            f"expected strategic-reevaluation to load: {names}"
+        )
+
+        # Reset the per-path counter so this run starts clean.
+        from pyagent.plugins.strategic_reevaluation import _reset_for_tests
+        _reset_for_tests()
+
+        agent = _mk_agent(loaded)
+
+        # Force every edit_file invocation to look like a failure.
+        def failing_edit(path: str, **kw: Any) -> str:
+            return "<error: old_string ... not found>"
+
+        agent.add_tool("edit_file", failing_edit, auto_offload=False)
+
+        def call_edit(path: str) -> None:
+            agent._route_tool({
+                "id": f"id-{path}",
+                "name": "edit_file",
+                "args": {"path": path, "old_string": "x", "new_string": "y"},
+            })
+
+        # Three consecutive failures on path A → note fires.
+        call_edit("/a")
+        call_edit("/a")
+        notes = _drain_pending(agent)
+        assert notes == [], (
+            f"only 2 failures yet; should not have fired: {notes}"
+        )
+        call_edit("/a")
+        notes = _drain_pending(agent)
+        assert any("strategic-reevaluation notes" in n for n in notes), notes
+        assert any("/a" in n for n in notes), notes
+        print(
+            "✓ strategic-reevaluation: 3 consecutive fails on path A "
+            "→ inject"
+        )
+
+        # Reset and try interleaved A/B/A/B/A/B failures → no inject
+        # (per-path counter; each path tops out at 1 between resets).
+        # Wait — interleaved A/B/A/B means path A sees 3 in a row from
+        # the plugin's perspective IF it only counts edit_file calls
+        # against that specific path. But "consecutive" in the plugin
+        # means consecutive failures on THAT path; another path's
+        # tool call doesn't reset path A's counter. Re-read the spec:
+        # "3 fails interleaved across paths A and B → no inject
+        # (path-keyed counter)". So with 3 A-fails interleaved with
+        # 3 B-fails (6 calls total: A,B,A,B,A,B), each path saw
+        # exactly 3 edit_file failures back-to-back from its own
+        # perspective — and SHOULD trip the threshold. The
+        # interleaving point is about NOT mixing them into a single
+        # global counter.
+        #
+        # Re-reading the issue: "3 fails interleaved across paths A
+        # and B → no inject (path-specific counter)". This means
+        # if you have 3 total failures spread across A and B (e.g.
+        # A, B, A), no path has seen 3 — so no inject. That's the
+        # path-specific bit: a global counter would inject on the
+        # third failure regardless of path. The path-keyed counter
+        # does NOT.
+        _reset_for_tests()
+        call_edit("/a")
+        call_edit("/b")
+        call_edit("/a")
+        notes = _drain_pending(agent)
+        assert notes == [], (
+            f"3 failures spread across two paths must not trip the "
+            f"per-path threshold: {notes}"
+        )
+        print(
+            "✓ strategic-reevaluation: 3 fails spread across A and B "
+            "→ no inject (per-path counter)"
+        )
+    finally:
+        restore()
+
+
+def test_strategic_reevaluation_resets_on_success() -> None:
+    """A successful edit on a path resets that path's counter."""
+    cfg, restore = _isolated_config_dir()
+    try:
+        (cfg / "config.toml").write_text(
+            'built_in_plugins_enabled = ["strategic-reevaluation"]\n'
+        )
+        loaded = plugins_mod.load(is_subagent=False)
+        from pyagent.plugins.strategic_reevaluation import _reset_for_tests
+        _reset_for_tests()
+
+        agent = _mk_agent(loaded)
+
+        flip = {"fail": True}
+
+        def edit(path: str, **kw: Any) -> str:
+            if flip["fail"]:
+                return "<error: nope>"
+            return f"Wrote 1 replacement to {path}"
+
+        agent.add_tool("edit_file", edit, auto_offload=False)
+
+        def call_edit(path: str) -> None:
+            agent._route_tool({
+                "id": f"id-{path}",
+                "name": "edit_file",
+                "args": {"path": path, "old_string": "x", "new_string": "y"},
+            })
+
+        # Two fails, one success, two more fails → counter was reset
+        # by the success, so we're at 2 again, not 4. No note.
+        call_edit("/a")
+        call_edit("/a")
+        flip["fail"] = False
+        call_edit("/a")
+        flip["fail"] = True
+        call_edit("/a")
+        call_edit("/a")
+        notes = _drain_pending(agent)
+        assert notes == [], (
+            f"success should have reset the counter; only 2 post-reset "
+            f"failures should not trip threshold: {notes}"
+        )
+        print("✓ strategic-reevaluation: successful edit resets per-path counter")
+    finally:
+        restore()
+
+
+def main() -> None:
+    test_allow_no_change()
+    test_block_short_circuits_before_permission()
+    test_mutate_args()
+    test_extra_user_message_before_and_after()
+    test_extra_user_message_drains_to_next_turn()
+    test_block_beats_mutate()
+    test_mutate_chaining()
+    test_replace_result_chaining()
+    test_v1_return_value_ignored()
+    test_strategic_reevaluation_path_keyed()
+    test_strategic_reevaluation_resets_on_success()
+    print("\nALL CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #66.

## Summary

Promotes `before_tool_call` and `after_tool_call` from observers to controllers for plugins declaring `api_version = "2"`. v1 plugins keep working unchanged. New bundled `strategic-reevaluation` demo plugin shows the controlling-hook pattern in ~80 lines.

- New return types `ToolHookResult` (allow / block / mutate, plus `extra_user_message`) and `AfterToolHookResult` (`replace_result`, `extra_user_message`).
- `SUPPORTED_API_VERSION` becomes `SUPPORTED_API_VERSIONS = {"1", "2"}` (set). v1 plugins' return values are ignored unconditionally so a stray return can't accidentally start blocking tools.
- Conflict resolution: `block` short-circuits the dispatch, `mutate` chains in registration order, `replace_result` chains too. `extra_user_message` accumulates across plugins, each tagged with the originating plugin name, and flows through the same `pending_async_replies` queue async-subagent notes use.
- Block emits an INFO log line `plugin=<name> tool=<name> reason=<text>` so a session audit can summarise blocking behavior without re-reading the transcript.
- Hook-before-permission ordering preserved at `_route_tool` — the smoke locks it in so a future refactor can't accidentally flip it.
- Bundled `strategic_reevaluation` plugin (api_version `"2"`, registers no tools) counts consecutive `edit_file` failures **per path**. Three in a row on the same path injects an `extra_user_message`. Three spread across different paths does not — that's a refactor sweep, not a stuck loop.
- `docs/plugin-design.md` gets a "Controlling hooks (v2)" section documenting the contract, conflict resolution, the v1-ignore rule, hook-before-permission ordering, and the bundled worked example.

## Test plan

- [x] `python -m tests.smoke_controlling_hooks` — 11 checks, all pass: allow, block-with-INFO-log-and-no-permission-prompt, mutate, extra_user_message from before/after, drain-into-conversation, block > mutate, mutate chaining, replace_result chaining, v1-ignored, strategic-reevaluation 3-on-A trips, 3-spread-across-A-and-B does not, success-resets-counter.
- [x] `python -m tests.smoke_plugins` — all 21 existing plugin smokes pass (v1 plugins still load and behave identically).
- [x] `python -m tests.smoke_plugin_provider` — all 9 checks pass.
- [x] Wider sweep across `smoke_arg_scrubbing`, `smoke_session_replay`, `smoke_skill_eviction`, `smoke_subagent`, `smoke_recursive_subagent`, `smoke_async_subagent`, `smoke_ask_parent`, `smoke_subagent_caps`, `smoke_subagent_routing`, `smoke_session_audit`, `smoke_permission_handler`, `smoke_token_meter`, `smoke_status_footer`, `smoke_checklist`, `smoke_edit_file`, `smoke_glob`, `smoke_read_file_ceiling`, `smoke_write_file_append`, `smoke_input_queue`, `smoke_kill_active`, `smoke_agent_label`, `smoke_pip_safety`, `smoke_subprocess`, `smoke_background_exec`, `smoke_bench_defaults`, `smoke_auto_venv`, `smoke_html_tools`, `smoke_web_search`, `smoke_code_mapper`, `smoke_roles`, `smoke_roles_md` — all pass.
- [ ] **`pyagent_self_audit.toml` bench should be run before merge** (acceptance criterion in #66; not run here per token-spending policy).

## Notes

- One pre-existing smoke (`smoke_py_dev_toolkit`) fails on main as well — unrelated to this PR (looks like a ruff version drift in the lint smoke).
- `smoke_ctrlc` and `smoke_prompt_toolkit` skip in this worktree because `.venv/bin/pyagent` isn't installed locally. Both are environmental skips, not regressions.