### PR TITLE
Notification surface: tell_subagent + peek_subagent + notes_unread + CLI render

### DIFF
--- a/pyagent/agent.py
+++ b/pyagent/agent.py
@@ -112,6 +112,18 @@ class Agent:
         # The IO thread sets this on first note; cleared when the
         # subagent terminates (issue #65).
         self._subagent_note_t0: dict[str, float] = {}
+        # Unread-notes counters surfaced to the CLI footer (issue #67
+        # depends on this). Increment on append, reset on drain;
+        # `_notes_unread_emitter` (wired by agent_proc bootstrap on
+        # the root agent only) ships the deltas as `notes_unread`
+        # events so the CLI can render `msgs:N` without polling.
+        self._unread_notes_total: int = 0
+        self._unread_notes_by_severity: dict[str, int] = {
+            "info": 0, "warn": 0, "alert": 0,
+        }
+        self._notes_unread_emitter: Callable[
+            [int, dict[str, int]], None
+        ] | None = None
 
     def add_tool(
         self,
@@ -485,7 +497,20 @@ class Agent:
             if len(ring) == ring.maxlen:
                 self._subagent_note_drops[sid] += 1
             ring.append((seq, ts, severity, text))
-            return seq, ts
+            # Unread tracking for the CLI footer (issue #67).
+            self._unread_notes_total += 1
+            self._unread_notes_by_severity[severity] = (
+                self._unread_notes_by_severity.get(severity, 0) + 1
+            )
+            unread_total = self._unread_notes_total
+            unread_by_sev = dict(self._unread_notes_by_severity)
+        emitter = self._notes_unread_emitter
+        if emitter is not None:
+            try:
+                emitter(unread_total, unread_by_sev)
+            except Exception:
+                logger.exception("notes_unread emitter raised")
+        return seq, ts
 
     def _clear_subagent_notes(self, sid: str) -> None:
         """Drop a subagent's ring (issue #65 — terminate / pipe close).
@@ -520,6 +545,23 @@ class Agent:
                 break
             self.conversation.append({"role": "user", "content": reply})
             n += 1
+        # Reset unread-notes counters; the LLM is about to see
+        # whatever was queued, including any subagent notes that
+        # arrived since the last turn. Emit the zeroed snapshot to
+        # the CLI footer (issue #67) only if there were unread
+        # notes — avoids spamming the same "0" event every turn.
+        with self._notes_lock:
+            had_unread = self._unread_notes_total > 0
+            self._unread_notes_total = 0
+            for k in self._unread_notes_by_severity:
+                self._unread_notes_by_severity[k] = 0
+        if had_unread:
+            emitter = self._notes_unread_emitter
+            if emitter is not None:
+                try:
+                    emitter(0, {"info": 0, "warn": 0, "alert": 0})
+                except Exception:
+                    logger.exception("notes_unread emitter raised")
         return n
 
     def run(

--- a/pyagent/agent_proc.py
+++ b/pyagent/agent_proc.py
@@ -342,6 +342,11 @@ class _ChildState:
             with self._subagent_lock:
                 unexpected = sid in self._subagent_conns
             self.unregister_subagent_pipe(sid)
+            # Drop the per-sid notification ring (issue #65). The
+            # sid is gone for good — peek_subagent of it should
+            # return <unknown subagent ...> on the next call.
+            if self.agent is not None:
+                self.agent._clear_subagent_notes(sid)
             if unexpected:
                 self._send_dict(
                     {
@@ -634,6 +639,20 @@ def _register_tools(
             subagent_mod.make_reply_to_subagent(state, agent),
             auto_offload=False,
         )
+        # tell_subagent / peek_subagent (issue #65): non-blocking
+        # parent → child push and parent-side read of the per-sid
+        # notification ring. Both are pure tool factories on the
+        # protocol + storage shipped in #64.
+        _add(
+            "tell_subagent",
+            subagent_mod.make_tell_subagent(state, agent),
+            auto_offload=False,
+        )
+        _add(
+            "peek_subagent",
+            subagent_mod.make_peek_subagent(state, agent),
+            auto_offload=False,
+        )
 
 
 def _bootstrap(
@@ -735,6 +754,17 @@ def _bootstrap(
     # Hand the IO thread a reference so it can look up SubagentEntry
     # status (sync vs async mode) when routing turn_complete events.
     state.agent = agent
+
+    # notes_unread event (issue #65 comment, feeds #67 footer): only
+    # fire from the root agent. Deeper notes don't bubble per the
+    # _handle_subagent_event rule, so subagent rings are local-only
+    # and don't need a counter visible to the CLI.
+    if not is_subagent:
+        def _emit_notes_unread(count: int, by_severity: dict[str, int]) -> None:
+            state.send(
+                "notes_unread", count=count, by_severity=by_severity
+            )
+        agent._notes_unread_emitter = _emit_notes_unread
 
     # Checklist tools live on the root agent only — a per-session
     # construct, not per-agent. Subagents that try to track their

--- a/pyagent/cli.py
+++ b/pyagent/cli.py
@@ -304,6 +304,15 @@ def _update_agents_state(
         # request/response event type.
         slot["checklist_tasks"] = tasks
         return
+    if kind == "notes_unread":
+        # Root-only event from agent_proc (issue #65). Stash on root
+        # so the footer (#67) can render `msgs:N` without polling.
+        slot = agents.setdefault("root", {"status": "thinking"})
+        slot["notes_unread"] = {
+            "count": int(event.get("count", 0) or 0),
+            "by_severity": dict(event.get("by_severity", {})),
+        }
+        return
     if kind == "usage":
         slot = agents.setdefault(key, {"status": "idle"})
         # Use .get(k, 0) + … so old two-key dicts in long-running state
@@ -566,6 +575,22 @@ def _print_event(event: dict) -> None:
             f"{label}[yellow]asks parent (req={req_id}):[/yellow] "
             f"[dim]{question}[/dim]"
         )
+    elif kind == "subagent_note":
+        # A subagent dropped a non-blocking note to its parent
+        # (issue #64). The parent's IO thread also queued it onto
+        # the parent's pending_async_replies; the model sees it
+        # at its next LLM call. Surface in the transcript so the
+        # human can read along.
+        label = _agent_label(agent_id)
+        severity = event.get("severity", "info") or "info"
+        text = event.get("text", "") or ""
+        # Color severity: warn / alert get yellow to draw the eye;
+        # info stays dim.
+        sev_style = "yellow" if severity in ("warn", "alert") else "cyan"
+        console.print(
+            f"{label}[{sev_style}]notes ({severity}):[/{sev_style}] "
+            f"[dim]{text}[/dim]"
+        )
     elif kind == "agent_error":
         if agent_id is not None:
             console.print(
@@ -736,7 +761,7 @@ async def _repl_async(
                     # the error, let the user decide whether to
                     # keep going).
                     state["turn_busy"] = False
-            elif kind in ("usage", "checklist"):
+            elif kind in ("usage", "checklist", "notes_unread"):
                 # State already updated; no inline render. Footer
                 # picks it up on the next bottom_toolbar refresh.
                 pass

--- a/pyagent/defaults/PRIMER.md
+++ b/pyagent/defaults/PRIMER.md
@@ -105,6 +105,16 @@ rest is on you.
   redirects, *do* pivot — terminate subagents, drop the current
   plan, start fresh. Treating notes as advisory-only would
   defeat the channel.
+- **`tell_subagent` and `peek_subagent`** are the parent-side
+  surface on the same channel. `tell_subagent(sid, text)` pushes
+  a `[parent says]: …` message to a running subagent — same
+  no-spam discipline as `notify_parent`. `peek_subagent` reads
+  the per-sid note ring without a turn boundary. Default:
+  *don't peek*. Notes surface naturally at your next LLM call;
+  peek only when *this turn's next tool call* depends on knowing
+  (e.g., you're about to run a long test a sibling may have
+  just made obsolete). Each peek is a tool round-trip; routine
+  "let me check" polling is waste.
 - Terminate when done. Lingering subagents waste their share of
   the fanout cap and any work they're still doing.
 - Caps refuse with `<refused: …>`. If you hit one, you're either

--- a/pyagent/subagent.py
+++ b/pyagent/subagent.py
@@ -24,6 +24,7 @@ registered, so a child can spawn its own children. Bounded by
 
 from __future__ import annotations
 
+import json
 import logging
 import multiprocessing
 import queue
@@ -643,6 +644,283 @@ def make_reply_to_subagent(
     return reply_to_subagent
 
 
+def make_tell_subagent(
+    state: "_ChildState",
+    agent: "Agent",
+) -> Callable[..., str]:
+    """Build the `tell_subagent` tool — registered on agents that
+    can spawn subagents (`allow_meta=True`).
+
+    Counterpart to `notify_parent` (issue #64) for the parent → child
+    direction. Emits a `parent_note` event down the named subagent's
+    pipe; the subagent's IO thread queues the formatted message onto
+    its own `pending_async_replies` so the next LLM call sees it.
+    Issue #65.
+    """
+
+    def tell_subagent(sid: str, text: str) -> str:
+        """Send a non-blocking note down to a running subagent.
+
+        Use this when you've learned something a still-running
+        subagent should know — a new constraint, an upstream
+        decision, an API that just changed. The subagent will see
+        your note as a `[parent says]: <text>` user-role message
+        at its next LLM-call boundary; it can act, defer, or
+        ignore.
+
+        Don't spam. One note should change the subagent's
+        behaviour or understanding. If you have an actual question
+        for the subagent, you don't have a tool for that — most
+        useful patterns are: terminate + respawn with the new
+        framing, or wait for the subagent to finish and brief it
+        next round.
+
+        Args:
+            sid: The subagent id returned from `spawn_subagent`.
+            text: The note text. Plain prose, self-contained.
+
+        Returns:
+            A short status string. Errors come back as `<...>`
+            markers (empty text, unknown sid, dead subagent).
+        """
+        text = (text or "").strip()
+        if not text:
+            return "<refused: empty text>"
+        sid = (sid or "").strip()
+        if not sid:
+            return "<refused: empty sid>"
+        entry: SubagentEntry | None = agent._subagents.get(sid)
+        if entry is None:
+            return f"<unknown subagent {sid!r}>"
+        if not entry.process.is_alive():
+            return f"<subagent {sid} is no longer running>"
+        try:
+            protocol.send(entry.conn, "parent_note", text=text)
+        except (BrokenPipeError, OSError) as e:
+            return f"<send failed to subagent {sid}: {e}>"
+        return f"sent to {sid}"
+
+    return tell_subagent
+
+
+def _collect_subagent_notes(
+    agent: "Agent", sid: str, cursor: int | None
+) -> dict[str, Any]:
+    """Return a structured record of one subagent's notes.
+
+    Data layer for peek_subagent — also intended to be reused by a
+    future CLI `/notes` slash command, which would consume the same
+    structured records via a query event (issue #65 comment).
+
+    `cursor=None` means "no cursor; dump current ring, no
+    missing-marker." `cursor=N` means "entries with seq > N; record
+    `missing` for entries lost to overflow before the ring's
+    earliest seq."
+
+    Returned dict shape:
+      {
+        "sid": str,
+        "name": str,
+        "cursor": int,             # echoed back; 0 if input was None
+        "next_cursor": int,        # seq to pass as `since` next time
+        "missing": int,            # count of overflowed-past-cursor
+        "entries": list[dict],     # {seq, ts, severity, text}
+      }
+    """
+    entry = agent._subagents.get(sid)
+    name = entry.name if entry is not None else sid
+    with agent._notes_lock:
+        ring = list(agent._subagent_notes.get(sid, ()))
+        seq_next = agent._subagent_note_seq.get(sid, 0)
+
+    if not ring:
+        cur_label = 0 if cursor is None else cursor
+        next_cur = max(cur_label, seq_next - 1) if seq_next > 0 else 0
+        return {
+            "sid": sid,
+            "name": name,
+            "cursor": cur_label,
+            "next_cursor": next_cur,
+            "missing": 0,
+            "entries": [],
+        }
+
+    earliest_seq = ring[0][0]
+    latest_seq = ring[-1][0]
+
+    if cursor is None:
+        cur_label = 0
+        visible = ring
+        missing = 0
+    else:
+        cur_label = cursor
+        visible = [e for e in ring if e[0] > cursor]
+        # Missing entries: seqs in (cursor, earliest_seq) were
+        # dropped from the ring before this peek caught up.
+        missing = max(0, earliest_seq - 1 - cursor)
+
+    return {
+        "sid": sid,
+        "name": name,
+        "cursor": cur_label,
+        "next_cursor": latest_seq,
+        "missing": missing,
+        "earliest_seq": earliest_seq,
+        "entries": [
+            {"seq": s, "ts": ts, "severity": sev, "text": txt}
+            for (s, ts, sev, txt) in visible
+        ],
+    }
+
+
+def _format_peek_section(record: dict[str, Any]) -> str:
+    """Render a structured note record (from `_collect_subagent_notes`)
+    as the text-block one section of `peek_subagent`'s output.
+    """
+    name = record["name"]
+    sid = record["sid"]
+    cur = record["cursor"]
+    next_cur = record["next_cursor"]
+    missing = record["missing"]
+    entries = record["entries"]
+    header = f"[subagent {name} ({sid}) notes since cursor={cur}]:"
+    lines = [header]
+    if missing > 0:
+        lines.append(
+            f"  - (... {missing} note(s) before seq="
+            f"{record.get('earliest_seq', '?')} were dropped from ring ...)"
+        )
+    if not entries:
+        if missing == 0:
+            lines.append(f"  - (no new notes; cursor={next_cur})")
+        return "\n".join(lines)
+    for e in entries:
+        ts_label = f"t+{int(e['ts'])}s"
+        lines.append(
+            f"  - ({e['severity']}, {ts_label}) {e['text']}"
+        )
+    return "\n".join(lines)
+
+
+def make_peek_subagent(
+    state: "_ChildState",
+    agent: "Agent",
+) -> Callable[..., str]:
+    """Build the `peek_subagent` tool — registered on agents that
+    can spawn subagents (`allow_meta=True`).
+
+    Reads the per-sid notification ring (issue #64) without
+    blocking. The model calls it between its own tool calls when
+    it has reason to believe a sibling has news that would
+    invalidate the next planned tool call. Issue #65.
+    """
+
+    def peek_subagent(
+        sid: str | None = None, since: str | None = None
+    ) -> str:
+        """Do not call this reflexively.
+
+        Default expectation: subagent notes surface as user-role
+        messages at your next LLM-call boundary on their own. Peek
+        is only for the case where *this turn's next tool call*
+        depends on knowing — e.g., you're about to run a long
+        test that a sibling subagent may have just made obsolete.
+        Each peek costs a tool round-trip; routine "let me check"
+        polling is waste.
+
+        Args:
+            sid: A specific subagent id, or `None` (default) to
+                survey all live subagents.
+            since: Cursor returned by a previous peek. Pass it
+                back to skip notes you've already seen. Format:
+                  - integer string (e.g. `"2"`) — only valid with
+                    `sid`; means "I've seen up through seq 2".
+                  - JSON object string (e.g. `'{"a-1234": 5}'`) —
+                    multi-sid cursor; missing keys treated as 0.
+                  - `None` — return everything currently in the
+                    ring(s).
+
+        Returns:
+            Formatted text with one section per surveyed sid,
+            optionally a `(... N notes dropped ...)` line when
+            cursor falls below the ring's earliest seq, and a
+            trailing `next_cursor: {...}` line (always JSON-shaped)
+            you can pass back as `since` next time. Errors come
+            back as `<...>` markers.
+        """
+        parsed_int: int | None = None
+        parsed_dict: dict[str, int] | None = None
+        if since is not None:
+            since_str = since.strip()
+            if since_str:
+                try:
+                    parsed_int = int(since_str)
+                except ValueError:
+                    try:
+                        obj = json.loads(since_str)
+                    except json.JSONDecodeError as e:
+                        return f"<refused: invalid since: {e}>"
+                    if not isinstance(obj, dict):
+                        return (
+                            "<refused: invalid since: must be int "
+                            f"or JSON object, got {type(obj).__name__}>"
+                        )
+                    try:
+                        parsed_dict = {
+                            str(k): int(v) for k, v in obj.items()
+                        }
+                    except (ValueError, TypeError) as e:
+                        return (
+                            f"<refused: invalid since: cursor values "
+                            f"must be ints ({e})>"
+                        )
+
+        if sid is not None:
+            sid_clean = sid.strip()
+            if not sid_clean:
+                return "<refused: empty sid>"
+            if sid_clean not in agent._subagents:
+                return f"<unknown subagent {sid_clean!r}>"
+            if parsed_int is not None:
+                cursor: int | None = parsed_int
+            elif parsed_dict is not None:
+                cursor = parsed_dict.get(sid_clean, 0)
+            else:
+                cursor = None
+            record = _collect_subagent_notes(agent, sid_clean, cursor)
+            section = _format_peek_section(record)
+            return (
+                f"{section}\n"
+                f"next_cursor: "
+                f"{json.dumps({sid_clean: record['next_cursor']})}"
+            )
+
+        if parsed_int is not None:
+            return (
+                "<refused: integer since requires sid; use a JSON "
+                "object cursor for multi-sid peek>"
+            )
+        sids = list(agent._subagents.keys())
+        if not sids:
+            return "<no live subagents>"
+        sections: list[str] = []
+        next_cursors: dict[str, int] = {}
+        for s in sids:
+            if parsed_dict is not None:
+                cur: int | None = parsed_dict.get(s, 0)
+            else:
+                cur = None
+            record = _collect_subagent_notes(agent, s, cur)
+            sections.append(_format_peek_section(record))
+            next_cursors[s] = record["next_cursor"]
+        return (
+            "\n\n".join(sections)
+            + f"\n\nnext_cursor: {json.dumps(next_cursors)}"
+        )
+
+    return peek_subagent
+
+
 def make_terminate_subagent(
     state: "_ChildState",
     agent: "Agent",
@@ -667,6 +945,10 @@ def make_terminate_subagent(
             return f"<unknown subagent id: {id!r}>"
 
         state.unregister_subagent_pipe(id)
+        # Drop the per-sid notification ring (issue #65). After
+        # terminate, the sid is no longer peekable — late peeks
+        # of dead sids should return the unknown-subagent marker.
+        agent._clear_subagent_notes(id)
 
         if entry.process.is_alive():
             try:

--- a/tests/smoke_notify_surface.py
+++ b/tests/smoke_notify_surface.py
@@ -1,0 +1,490 @@
+"""Smoke for the parent-side notification surface (issue #65).
+
+Drives `tell_subagent` and `peek_subagent` against real
+`_ChildState` IO threads with fake subagent pipes — the same
+pattern as `smoke_ask_parent.py` and `smoke_notify.py`.
+
+Locks:
+  1. `tell_subagent(sid, text)` emits a `parent_note` event on the
+     named pipe; refusal markers for empty text, empty/unknown
+     sid, dead subagent.
+  2. `peek_subagent(sid)` with `since=None` returns all ring
+     entries plus a JSON-shaped `next_cursor:` line.
+  3. `peek_subagent(sid, since="N")` returns only entries with
+     seq > N; `since="0"` is the round-trip starting point.
+  4. `peek_subagent()` with no sid surveys all live subagents,
+     one section per sid, and returns a multi-sid JSON cursor.
+  5. Multi-sid `since` accepts JSON object format; missing keys
+     treated as 0.
+  6. Invalid `since` (bad JSON, non-int values, integer with
+     no sid) returns refusal markers.
+  7. Ring overflow drop-marker visible: peek with `since` below
+     the ring's earliest seq surfaces the missing-count line.
+  8. `peek_subagent()` with no live subagents returns
+     `<no live subagents>` marker.
+  9. Ring is cleared on `terminate_subagent`; later peek of that
+     sid returns the unknown-subagent marker.
+ 10. Ring is cleared on unexpected pipe close (subagent crash
+     simulated by sending EOF on the fake pipe).
+
+In-process — no real LLM, no subprocesses. Run with:
+
+    .venv/bin/python -m tests.smoke_notify_surface
+"""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import os
+import queue as _queue
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+from pyagent import agent_proc
+from pyagent import subagent as subagent_mod
+from pyagent.agent import Agent
+from pyagent.llms.pyagent import EchoClient
+from pyagent.session import Session
+from pyagent.subagent import SubagentEntry
+
+
+class _FakeProcess:
+    def __init__(self, alive: bool = True) -> None:
+        self._alive = alive
+
+    def is_alive(self) -> bool:
+        return self._alive
+
+    def kill(self) -> None:
+        self._alive = False
+
+
+def _fake_subagent(
+    pstate: agent_proc._ChildState,
+    pagent: Agent,
+    name: str,
+    sid: str,
+) -> tuple["multiprocessing.connection.Connection", SubagentEntry]:
+    ctx = multiprocessing.get_context("spawn")
+    fake_sub_end, fake_parent_end = ctx.Pipe(duplex=True)
+    rq: _queue.Queue = _queue.Queue()
+    pstate._subagent_conns[sid] = fake_parent_end
+    pstate._subagent_reply_queues[sid] = rq
+    entry = SubagentEntry(
+        id=sid,
+        name=name,
+        process=_FakeProcess(alive=True),  # type: ignore[arg-type]
+        conn=fake_parent_end,
+        reply_queue=rq,
+        depth=1,
+    )
+    pagent._subagents[sid] = entry
+    return fake_sub_end, entry
+
+
+def _drain_pipe(conn) -> list[dict]:
+    out: list[dict] = []
+    while conn.poll(0.05):
+        try:
+            out.append(conn.recv())
+        except (EOFError, OSError):
+            break
+    return out
+
+
+def _wait_for(predicate, timeout: float = 2.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.02)
+    return False
+
+
+def main() -> None:
+    tmp = Path(tempfile.mkdtemp(prefix="pyagent-notify-surface-smoke-"))
+    os.chdir(tmp)
+    print(f"cwd: {tmp}")
+
+    parent_session = Session(root=tmp / "sessions")
+    ctx = multiprocessing.get_context("spawn")
+    upstream_test_end, upstream_state_end = ctx.Pipe(duplex=True)
+    pstate = agent_proc._ChildState(conn=upstream_state_end)
+    pagent = Agent(client=EchoClient(), session=parent_session, depth=0)
+    pstate.agent = pagent
+
+    # Wire the notes_unread emitter manually since the smoke skips
+    # _bootstrap. Capture deltas so we can assert the CLI footer
+    # signal fires correctly (issue #65 comment / #67 footer prep).
+    emitted_unread: list[tuple[int, dict[str, int]]] = []
+
+    def _capture_unread(count: int, by_sev: dict[str, int]) -> None:
+        emitted_unread.append((count, dict(by_sev)))
+
+    pagent._notes_unread_emitter = _capture_unread
+
+    pio = threading.Thread(target=pstate.io_loop, daemon=True)
+    pio.start()
+
+    tell = subagent_mod.make_tell_subagent(pstate, pagent)
+    peek = subagent_mod.make_peek_subagent(pstate, pagent)
+
+    sid_a = "fake-a-deadbeef"
+    sid_b = "fake-b-cafef00d"
+    sub_a, entry_a = _fake_subagent(pstate, pagent, "alpha", sid_a)
+    sub_b, entry_b = _fake_subagent(pstate, pagent, "beta", sid_b)
+
+    try:
+        # =========================================================
+        # tell_subagent
+        # =========================================================
+        # 1. happy path
+        result = tell(sid_a, "drop the test framework, switch to pytest")
+        assert result == f"sent to {sid_a}", result
+        ev = None
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            if sub_a.poll(0.1):
+                ev = sub_a.recv()
+                break
+        assert ev is not None and ev["type"] == "parent_note", ev
+        assert "switch to pytest" in ev["text"], ev
+        print(f"✓ tell_subagent emitted parent_note: {ev['text']!r}")
+
+        # 2. refusals
+        assert tell("", "x") == "<refused: empty sid>", tell("", "x")
+        assert tell(sid_a, "") == "<refused: empty text>", tell(sid_a, "")
+        assert tell(sid_a, "   ") == "<refused: empty text>"
+        assert tell("ghost", "x").startswith("<unknown subagent"), tell("ghost", "x")
+        # dead subagent
+        entry_a.process._alive = False  # type: ignore[attr-defined]
+        assert "no longer running" in tell(sid_a, "still here?"), tell(
+            sid_a, "still here?"
+        )
+        # restore for later tests
+        entry_a.process._alive = True  # type: ignore[attr-defined]
+        # drain anything that did make it onto sub_a
+        _drain_pipe(sub_a)
+        print("✓ tell_subagent refusals: empty sid, empty text, unknown, dead")
+
+        # =========================================================
+        # peek_subagent — populate rings first
+        # =========================================================
+        # Drive the parent IO thread by sending subagent_note events
+        # from each fake child. Use _append_subagent_note directly
+        # for some entries so we don't have to wait on the pipe.
+        sub_a.send({
+            "type": "subagent_note",
+            "severity": "info",
+            "text": "tests pass on darwin",
+        })
+        sub_a.send({
+            "type": "subagent_note",
+            "severity": "warn",
+            "text": "migration assumes pg>=14",
+        })
+        sub_b.send({
+            "type": "subagent_note",
+            "severity": "info",
+            "text": "build still running",
+        })
+        sub_b.send({
+            "type": "subagent_note",
+            "severity": "warn",
+            "text": "lint failures upstream",
+        })
+        # Wait for IO thread to process all 4.
+        ok = _wait_for(
+            lambda: pagent.pending_async_replies.qsize() >= 4, timeout=3.0
+        )
+        assert ok, (
+            f"IO thread did not process notes "
+            f"(qsize={pagent.pending_async_replies.qsize()})"
+        )
+        # Drain inbox so it doesn't pollute later tests.
+        while pagent.pending_async_replies.qsize():
+            pagent.pending_async_replies.get_nowait()
+        # Drain upstream forwards.
+        _drain_pipe(upstream_test_end)
+
+        # 3. single-sid peek with since=None — returns all ring entries.
+        out = peek(sid=sid_a)
+        assert f"[subagent alpha ({sid_a}) notes since cursor=0]:" in out, out
+        assert "tests pass on darwin" in out, out
+        assert "migration assumes pg>=14" in out, out
+        # next_cursor JSON-shaped, points at latest seq (1)
+        assert f'next_cursor: {{"{sid_a}": 1}}' in out, out
+        print(f"✓ single-sid peek (since=None): cursor advances to 1")
+
+        # 4. single-sid peek with since="0" — entries with seq > 0.
+        out = peek(sid=sid_a, since="0")
+        assert f"cursor=0]:" in out, out
+        assert "migration assumes pg>=14" in out, out  # seq=1 visible
+        # seq=0 was "tests pass on darwin" — should NOT appear since
+        # cursor=0 means "I've already seen up through seq 0."
+        assert "tests pass on darwin" not in out, out
+        assert f'next_cursor: {{"{sid_a}": 1}}' in out, out
+        print("✓ single-sid peek (since='0'): only seq>0 visible")
+
+        # 5. single-sid peek with since="1" — no new notes.
+        out = peek(sid=sid_a, since="1")
+        assert "no new notes; cursor=1" in out, out
+        print("✓ single-sid peek (since='1'): no new notes line")
+
+        # 6. multi-sid survey (sid=None, since=None) — both sections.
+        out = peek()
+        assert f"[subagent alpha ({sid_a}) notes since cursor=0]:" in out, out
+        assert f"[subagent beta ({sid_b}) notes since cursor=0]:" in out, out
+        # next_cursor is JSON object with both sids
+        # latest seq for alpha=1, beta=1
+        assert f'"{sid_a}": 1' in out, out
+        assert f'"{sid_b}": 1' in out, out
+        print("✓ multi-sid peek (since=None): both sections + JSON cursor")
+
+        # 7. multi-sid peek with JSON since — missing keys treated as 0.
+        # Pass cursor for alpha only; beta should be surveyed from 0,
+        # which surfaces beta's seq=1 note (the warn one).
+        out = peek(since=json.dumps({sid_a: 1}))
+        # Alpha section: "no new notes; cursor=1"
+        assert f"[subagent alpha ({sid_a}) notes since cursor=1]:" in out, out
+        assert "no new notes; cursor=1" in out, out
+        # Beta section: cursor=0 (defaulted), shows entries with seq > 0.
+        assert f"[subagent beta ({sid_b}) notes since cursor=0]:" in out, out
+        assert "lint failures upstream" in out, out
+        print("✓ multi-sid peek (JSON since, missing key=0)")
+
+        # 8. invalid since formats.
+        bad = peek(sid=sid_a, since="not-an-int-not-json")
+        assert bad.startswith("<refused: invalid since"), bad
+        bad = peek(sid=sid_a, since='{"a": "not-int"}')
+        assert bad.startswith("<refused: invalid since"), bad
+        bad = peek(sid=sid_a, since='["array"]')
+        assert bad.startswith("<refused: invalid since"), bad
+        # integer since without sid → refused
+        bad = peek(since="3")
+        assert bad.startswith("<refused: integer since requires sid"), bad
+        print("✓ invalid since refused: bad str, non-int values, no-sid int")
+
+        # 9. unknown sid / empty sid.
+        bad = peek(sid="ghost")
+        assert bad.startswith("<unknown subagent"), bad
+        bad = peek(sid="   ")
+        assert bad == "<refused: empty sid>", bad
+        print("✓ peek refusals: unknown sid, empty sid")
+
+        # =========================================================
+        # Ring overflow + drop marker
+        # =========================================================
+        # Flood alpha's ring past maxlen. Already 2 entries (seq 0,1).
+        # Add 64 more — 1 should be dropped (seq 0).
+        for i in range(64):
+            sub_a.send({
+                "type": "subagent_note",
+                "severity": "info",
+                "text": f"flood-{i}",
+            })
+        ok = _wait_for(
+            lambda: pagent.pending_async_replies.qsize() >= 64, timeout=5.0
+        )
+        assert ok, (
+            f"IO thread didn't drain flood "
+            f"(qsize={pagent.pending_async_replies.qsize()})"
+        )
+        while pagent.pending_async_replies.qsize():
+            pagent.pending_async_replies.get_nowait()
+        _drain_pipe(upstream_test_end)
+
+        with pagent._notes_lock:
+            ring = list(pagent._subagent_notes[sid_a])
+            drops = pagent._subagent_note_drops[sid_a]
+        # alpha had 2 notes (seqs 0,1); +64 flood = 66 total; ring=64;
+        # drops = 66 - 64 = 2; earliest seq in ring = 2.
+        assert drops == 2, f"drops should be 2, got {drops}"
+        assert ring[0][0] == 2, f"earliest seq should be 2, got {ring[0][0]}"
+
+        # Peek with cursor=1 — entry seqs in (1, 2) is empty, so no
+        # missing marker; but we should see all 64 ring entries
+        # (seqs 2..65).
+        out = peek(sid=sid_a, since="1")
+        assert "dropped from ring" not in out, out
+        # Force a wider gap: continue overflow until many seqs are dropped.
+        for i in range(64):
+            sub_a.send({
+                "type": "subagent_note",
+                "severity": "info",
+                "text": f"more-{i}",
+            })
+        ok = _wait_for(
+            lambda: pagent.pending_async_replies.qsize() >= 64, timeout=5.0
+        )
+        assert ok
+        while pagent.pending_async_replies.qsize():
+            pagent.pending_async_replies.get_nowait()
+        _drain_pipe(upstream_test_end)
+
+        with pagent._notes_lock:
+            ring = list(pagent._subagent_notes[sid_a])
+            drops = pagent._subagent_note_drops[sid_a]
+            seq_next = pagent._subagent_note_seq[sid_a]
+        # 2 + 64 + 64 = 130 notes added; ring holds 64; drops = 66;
+        # earliest seq = 66; seq_next = 130.
+        assert drops == 66, f"drops should be 66, got {drops}"
+        assert ring[0][0] == 66, f"earliest seq should be 66, got {ring[0][0]}"
+        assert seq_next == 130, f"seq_next should be 130, got {seq_next}"
+
+        # Peek with cursor=10 — entries with seq in (10, 66) were
+        # dropped: that's seqs 11..65 = 55 entries.
+        out = peek(sid=sid_a, since="10")
+        assert "dropped from ring" in out, out
+        assert "55 note(s)" in out, out
+        print(
+            f"✓ ring overflow visible in peek: drops={drops}, "
+            f"earliest_seq={ring[0][0]}, peek shows missing-count"
+        )
+
+        # =========================================================
+        # Lifecycle: terminate clears ring
+        # =========================================================
+        # 10. terminate_subagent path. The factory also tries to
+        #     send shutdown / SIGTERM / SIGKILL to the (fake) process.
+        #     _FakeProcess doesn't implement terminate(), so wrap it.
+        terminate = subagent_mod.make_terminate_subagent(pstate, pagent)
+        # Patch in a join + terminate that no-op for the fake.
+        entry_b.process.join = lambda timeout=None: None  # type: ignore[assignment]
+        entry_b.process.terminate = lambda: None  # type: ignore[assignment]
+        entry_b.process.exitcode = 0  # type: ignore[attr-defined]
+        # Also need pid attr for the SIGKILL fallback.
+        entry_b.process.pid = -1  # type: ignore[attr-defined]
+        entry_b.process._alive = False  # type: ignore[attr-defined]  # skip kill path
+        result = terminate(sid_b)
+        assert "terminated" in result, result
+        # Ring for sid_b should be gone.
+        with pagent._notes_lock:
+            assert sid_b not in pagent._subagent_notes
+            assert sid_b not in pagent._subagent_note_seq
+            assert sid_b not in pagent._subagent_note_drops
+        # Peek of dead sid → unknown marker.
+        bad = peek(sid=sid_b)
+        assert bad.startswith("<unknown subagent"), bad
+        print(f"✓ terminate clears ring: peek of {sid_b[:12]} → unknown")
+
+        # 11. Unexpected pipe close: rather than fight multiprocessing
+        #     edge cases (closing one end of a Pipe and racing the IO
+        #     thread's `wait()` snapshot is brittle in tests), exercise
+        #     the cleanup path that the close handler runs:
+        #     unregister + _clear_subagent_notes. The handler in
+        #     agent_proc.py:336-356 calls exactly these two when EOF
+        #     hits.
+        with pagent._notes_lock:
+            assert sid_a in pagent._subagent_notes
+        pstate.unregister_subagent_pipe(sid_a)
+        pagent._clear_subagent_notes(sid_a)
+        with pagent._notes_lock:
+            assert sid_a not in pagent._subagent_notes
+        print(f"✓ pipe-close cleanup path clears ring for {sid_a[:12]}")
+
+        # 12. No live subagents.
+        # Remove sid_a from the registry to simulate full shutdown.
+        pagent._subagents.pop(sid_a, None)
+        out = peek()
+        assert out == "<no live subagents>", out
+        print("✓ no live subagents → marker")
+
+        # =========================================================
+        # notes_unread emitter (issue #65 comment / #67 footer prep)
+        # =========================================================
+        # Reset the capture and counters; do a clean run.
+        emitted_unread.clear()
+        with pagent._notes_lock:
+            pagent._unread_notes_total = 0
+            pagent._unread_notes_by_severity = {
+                "info": 0, "warn": 0, "alert": 0,
+            }
+
+        # Re-register a fake child for the emitter test.
+        sid_c = "fake-c-12345678"
+        sub_c, entry_c = _fake_subagent(pstate, pagent, "gamma", sid_c)
+        # Append three notes via the IO thread; expect three emit
+        # events with monotonically rising counts and severity buckets.
+        sub_c.send({"type": "subagent_note", "severity": "info", "text": "a"})
+        sub_c.send({"type": "subagent_note", "severity": "warn", "text": "b"})
+        sub_c.send({"type": "subagent_note", "severity": "info", "text": "c"})
+        ok = _wait_for(lambda: len(emitted_unread) >= 3, timeout=3.0)
+        assert ok, f"emit count = {len(emitted_unread)}"
+        # Expect counts 1, 2, 3.
+        counts = [e[0] for e in emitted_unread]
+        assert counts == [1, 2, 3], counts
+        # Last by_severity snapshot: info=2, warn=1, alert=0.
+        last_by_sev = emitted_unread[-1][1]
+        assert last_by_sev["info"] == 2, last_by_sev
+        assert last_by_sev["warn"] == 1, last_by_sev
+        assert last_by_sev.get("alert", 0) == 0, last_by_sev
+        print(
+            f"✓ notes_unread fires per append: counts={counts}, "
+            f"final by_severity={last_by_sev}"
+        )
+
+        # Drain reset: simulate a turn picking up all queued notes.
+        emitted_unread.clear()
+        n = pagent._drain_pending_async()
+        assert n >= 3, f"drain returned {n}"
+        # Exactly one emit event with zeros (the drain reset).
+        assert len(emitted_unread) == 1, emitted_unread
+        zeroed_count, zeroed_by_sev = emitted_unread[0]
+        assert zeroed_count == 0
+        assert zeroed_by_sev == {"info": 0, "warn": 0, "alert": 0}
+        # Counters reset.
+        with pagent._notes_lock:
+            assert pagent._unread_notes_total == 0
+            assert pagent._unread_notes_by_severity == {
+                "info": 0, "warn": 0, "alert": 0,
+            }
+        print(f"✓ drain resets unread counters; emitted zeroed snapshot")
+
+        # Idempotent drain: no emit when there were no unread notes.
+        emitted_unread.clear()
+        pagent._drain_pending_async()
+        assert emitted_unread == [], (
+            "drain emitted spurious zero event when nothing was unread"
+        )
+        print("✓ drain with no unread → no spurious emit")
+
+        # =========================================================
+        # Structured collector reusable for /notes (issue #65 comment)
+        # =========================================================
+        # Append two notes and verify _collect_subagent_notes returns
+        # the records a future /notes slash command would consume.
+        emitted_unread.clear()
+        sub_c.send({"type": "subagent_note", "severity": "info", "text": "x"})
+        sub_c.send({
+            "type": "subagent_note", "severity": "alert", "text": "y"
+        })
+        ok = _wait_for(lambda: len(emitted_unread) >= 2, timeout=2.0)
+        assert ok
+        record = subagent_mod._collect_subagent_notes(pagent, sid_c, cursor=None)
+        assert record["sid"] == sid_c, record
+        assert record["name"] == "gamma", record
+        assert record["missing"] == 0, record
+        assert len(record["entries"]) == 5, record  # 3 + 2
+        # Each entry has structured fields the CLI can render.
+        e = record["entries"][-1]
+        assert {"seq", "ts", "severity", "text"} <= set(e.keys()), e
+        assert e["text"] == "y"
+        assert e["severity"] == "alert"
+        print(
+            f"✓ _collect_subagent_notes returns structured records "
+            f"(reusable for /notes follow-up)"
+        )
+
+    finally:
+        pstate.shutdown_event.set()
+        pio.join(timeout=2)
+
+    print("\nALL CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #65. Builds on #64 (notification protocol foundation).

Also addresses [the comment](https://github.com/derekwisong/pyagent/issues/65#issuecomment-...) from the #67 footer agent: ships the `notes_unread` event and refactors peek's data layer for future `/notes` reuse.

## Summary

- **`tell_subagent(sid, text)`** — parent → child non-blocking note. Refuses empty text, empty/unknown sid, dead subagent.
- **`peek_subagent(sid=None, since=None)`** — read the per-sid ring without a turn boundary.
  - `since` is always a string: parses as int (single-sid) or JSON object (multi-sid). Missing keys in the JSON form are treated as 0. Invalid format returns a `<refused: ...>` marker.
  - Output ends with a `next_cursor:` line that is always JSON-shaped, so the model can echo it back regardless of single vs. multi-sid mode.
  - Tool docstring opens with "do not call this reflexively" — model pattern-matches on the docstring more than on PRIMER.
- **Structured data layer** under peek (`_collect_subagent_notes` returns dicts; `_format_peek_section` renders them as text). Future `/notes` slash command can ship the dicts over the pipe without re-parsing rendered text.
- **Ring cleanup wired into both lifecycle paths**: `terminate_subagent` and `_handle_subagent_event` unexpected-close branch each call `agent._clear_subagent_notes(sid)`. Late peek of a dead sid returns `<unknown subagent ...>`.
- **`notes_unread` event** for the CLI footer (issue #67 prep). `_append_subagent_note` increments counters and calls a per-agent emitter (wired in `_bootstrap` on root only — deeper notes don't bubble per the existing rule). `_drain_pending_async` resets counters and emits a zeroed snapshot only when at least one note was unread.
- **CLI transcript render** for `subagent_note`: severity-colored prefix instead of the generic event dump. `notes_unread` events stash `{count, by_severity}` onto `agents_state["root"]["notes_unread"]` so the footer agent can read it.
- **PRIMER paragraph** for tell/peek, balanced with the existing notify guidance. Default is "don't peek; let notifications surface naturally."

## Test plan

- [x] `tests/smoke_notify_surface.py` — covers:
  - tell_subagent happy + 4 refusal paths (empty sid, empty text, unknown sid, dead subagent)
  - peek_subagent: single-sid with `since=None`, with `since="0"`, with `since="1"` (no new notes)
  - multi-sid survey with `since=None` (both sections + JSON cursor)
  - multi-sid with JSON `since` and missing keys treated as 0
  - invalid `since`: bad str, non-int values in JSON, integer with no sid
  - peek refusals: unknown sid, empty sid
  - ring overflow visible in peek (drops=66, 55-note missing-marker)
  - ring cleared on terminate; later peek returns unknown-subagent marker
  - ring cleared on pipe-close cleanup path (exercised directly to avoid multiprocessing race)
  - `<no live subagents>` marker
  - `notes_unread` fires once per append with monotonic counts and accurate severity buckets
  - drain reset emits a single zeroed snapshot
  - drain with no unread → no spurious emit
  - `_collect_subagent_notes` returns structured records with the expected keys
- [x] `tests/smoke_notify.py`, `smoke_ask_parent.py`, `smoke_subagent.py`, `smoke_async_subagent.py`, `smoke_subagent_routing.py`, `smoke_recursive_subagent.py`, `smoke_input_queue.py` — no regression
- [ ] `pyagent_self_audit.toml` bench — not run; user-controlled.

## Notes

- The unexpected-pipe-close test exercises the cleanup path (`unregister_subagent_pipe + _clear_subagent_notes`) directly rather than racing `multiprocessing.connection.wait` semantics. The handler in `agent_proc.py:336-356` now calls both — the smoke verifies they wipe the ring as expected.
- `notes_unread` is root-only by design: deeper notes don't bubble per the `subagent_note` handler rule from #64, so subagent-internal note traffic stays out of the CLI footer.
- The `/notes` slash command itself is **not** in this PR — it'd want a `peek_request` / `peek_response` event pair so the CLI can query on demand. The structured data shape is now ready for it.