### PR TITLE
v2 hook tightening: replace_result→str, after_tool gains is_error

### DIFF
--- a/docs/plugin-design.md
+++ b/docs/plugin-design.md
@@ -194,10 +194,17 @@ v2 plugins (manifest `api_version = "2"`) may return a
 `ToolHookResult` to block / mutate / inject feedback — see
 "Controlling hooks (v2)" below."""
 
-api.after_tool_call(fn: Callable[[str, dict, Any], AfterToolHookResult | None])
-"""Fired after each tool call with (name, args, result). v1 plugins
-return None (observer). v2 plugins may return an
-`AfterToolHookResult` to replace the tool result or inject feedback."""
+api.after_tool_call(fn: Callable[..., AfterToolHookResult | None])
+"""Fired after each tool call.
+
+v1 signature: (name, args, result)            — observer only.
+v2 signature: (name, args, result, is_error)  — may return a
+              ``AfterToolHookResult`` to replace the tool result or
+              inject feedback.
+
+`is_error` is the harness-computed failure signal (True iff the tool
+raised or returned a `<…>` error marker; see `pyagent.tools.is_error_result`
+for the contract). Plugins no longer have to sniff result strings."""
 ```
 
 Utility (1):
@@ -307,14 +314,20 @@ from pyagent.plugins import AfterToolHookResult
 @dataclass(frozen=True)
 class AfterToolHookResult:
     extra_user_message: str = ""
-    replace_result: Any = _SENTINEL  # if set, replaces the tool result
+    replace_result: str | None = None  # if not None, replaces the tool result
 ```
+
+v2 hook signature: `fn(name, args, result, is_error)`. `is_error` is
+True iff the tool raised or returned a `<…>` error marker (see
+`pyagent.tools.is_error_result` for the contract). Use it instead of
+sniffing result strings yourself.
 
 - `extra_user_message` — same shape as in `ToolHookResult`.
 - `replace_result` — overrides the tool result string the model
   sees on this turn. Useful for secret redaction, summarising a
-  huge log, etc. The sentinel default means "no replacement";
-  `None` is a legal replacement value.
+  huge log, etc. `None` (default) means "no replacement". Tool
+  results are strings by contract; non-string replacements are
+  dropped with a warning.
 
 ### Conflict resolution across multiple plugins
 

--- a/pyagent/agent.py
+++ b/pyagent/agent.py
@@ -364,21 +364,30 @@ class Agent:
                 # hooks — the contract is "after the tool runs"; no
                 # tool ran.
                 return content
+        is_error = False
         try:
             content = self._execute_tool(name, args)
         except Exception as e:
             logger.exception("tool %s raised", name)
             content = f"Error: {type(e).__name__}: {e}"
+            is_error = True
+        else:
+            # Errors-as-data convention: tools encode refusals /
+            # failures as `<…>`-prefixed strings. See
+            # `pyagent.tools.is_error_result` for the full contract.
+            from pyagent.tools import is_error_result
+            is_error = is_error_result(content)
         if self.plugins is not None:
-            after = self.plugins.call_after_tool_call(name, args, content)
+            after = self.plugins.call_after_tool_call(
+                name, args, content, is_error
+            )
             for note in after.extra_user_messages:
                 self.pending_async_replies.put(note)
             if after.replaced:
-                content = (
-                    after.result
-                    if isinstance(after.result, str)
-                    else str(after.result)
-                )
+                # AfterToolHookResult.replace_result is typed as
+                # `str | None`; the dispatch loop already drops
+                # non-strings with a warning, so this is safe.
+                content = after.result
         if on_tool_result:
             on_tool_result(name, content)
         # Scrub bulky string args from the conversation so they don't

--- a/pyagent/plugins/__init__.py
+++ b/pyagent/plugins/__init__.py
@@ -60,10 +60,6 @@ ENTRY_POINT_GROUP = "pyagent.plugins"
 SUPPORTED_API_VERSIONS: set[str] = {"1", "2"}
 RECENT_MESSAGES_WINDOW = 8
 
-# Sentinel for "no replacement" on AfterToolHookResult.replace_result
-# — `None` is a legitimate result value, so we need a distinct marker.
-_REPLACE_RESULT_SENTINEL = object()
-
 
 # ---- Public types ----------------------------------------------
 
@@ -132,18 +128,20 @@ class AfterToolHookResult:
     Both fields are optional. Returning ``None`` is a no-op observer.
 
     Fields:
-      - ``replace_result``: if set, replaces the tool result that the
-        model sees. Multiple plugins chain in registration order —
-        each later plugin sees the *replaced* result. Useful for
-        secret redaction or huge-log summarisation. Sentinel default
-        means "no replacement"; ``None`` is a legal replacement value.
+      - ``replace_result``: if not ``None``, replaces the tool result
+        string that the model sees. Multiple plugins chain in
+        registration order — each later plugin sees the *replaced*
+        result. Useful for secret redaction or huge-log summarisation.
+        ``None`` (default) means "no replacement". Tool results are
+        strings by contract; non-string replacements are not allowed
+        (the dispatch loop drops them with a warning).
       - ``extra_user_message``: same shape as in ``ToolHookResult`` —
         prepended to the next assistant turn as a user-role message
         tagged with the plugin name.
     """
 
     extra_user_message: str = ""
-    replace_result: Any = _REPLACE_RESULT_SENTINEL
+    replace_result: str | None = None
 
 
 @dataclass
@@ -179,12 +177,13 @@ class AfterToolDispatch:
     for one tool call.
 
     - ``result``: the (possibly replaced) result the model should see.
-    - ``replaced``: True iff at least one plugin returned a
-      ``replace_result`` other than the sentinel.
+      Always a string.
+    - ``replaced``: True iff at least one plugin returned a non-None
+      ``replace_result``.
     - ``extra_user_messages``: same shape as on ``BeforeToolDispatch``.
     """
 
-    result: Any
+    result: str
     replaced: bool = False
     extra_user_messages: list[str] = field(default_factory=list)
 
@@ -1045,14 +1044,23 @@ class LoadedPlugins:
         return dispatch
 
     def call_after_tool_call(
-        self, name: str, args: dict, result: Any
+        self, name: str, args: dict, result: str, is_error: bool
     ) -> "AfterToolDispatch":
         """Fire every plugin's after_tool hook in registration order.
+
+        v1 hooks accept ``(name, args, result)`` and have their return
+        value ignored. v2 hooks accept ``(name, args, result, is_error)``
+        and may return an ``AfterToolHookResult`` to replace the result
+        or inject a user-role message.
 
         ``replace_result`` chains in registration order — each later
         plugin's hook is invoked with the result the previous plugin
         replaced. ``extra_user_message`` accumulates the same way as
         in ``call_before_tool_call``.
+
+        ``is_error`` is the harness-computed failure signal (see
+        ``pyagent.tools.is_error_result`` for the contract). Plugins
+        no longer have to sniff for ``<...>`` markers themselves.
         """
         dispatch = AfterToolDispatch(result=result)
         for state in self.states:
@@ -1060,7 +1068,10 @@ class LoadedPlugins:
             plugin_name = state.manifest.name
             for fn in state.after_tool_hooks:
                 try:
-                    rv = fn(name, args, dispatch.result)
+                    if is_v2:
+                        rv = fn(name, args, dispatch.result, is_error)
+                    else:
+                        rv = fn(name, args, dispatch.result)
                 except Exception:
                     logger.exception(
                         "plugin %s after_tool_call raised",
@@ -1083,7 +1094,15 @@ class LoadedPlugins:
                             plugin_name, rv.extra_user_message
                         )
                     )
-                if rv.replace_result is not _REPLACE_RESULT_SENTINEL:
+                if rv.replace_result is not None:
+                    if not isinstance(rv.replace_result, str):
+                        logger.warning(
+                            "plugin %s after_tool_call replace_result "
+                            "must be str | None, got %r; ignoring",
+                            plugin_name,
+                            type(rv.replace_result).__name__,
+                        )
+                        continue
                     dispatch.result = rv.replace_result
                     dispatch.replaced = True
         return dispatch

--- a/pyagent/plugins/strategic_reevaluation/__init__.py
+++ b/pyagent/plugins/strategic_reevaluation/__init__.py
@@ -18,8 +18,12 @@ Counter resets on:
     write_file, grep — any of these are evidence the agent is
     actually inspecting the situation rather than blind-retrying).
 
+Failure detection uses the harness-provided ``is_error`` flag
+introduced alongside the v2 hook tightening — no string-sniffing,
+robust against any future change to the error-marker convention.
+
 This plugin is the canonical worked example for the "controlling
-hooks" feature: ~80 lines, zero tools registered, demonstrates that
+hooks" feature: ~70 lines, zero tools registered, demonstrates that
 plugin-injected mid-turn feedback is now a 30-line plugin instead of
 a paragraph baked into PRIMER.
 """
@@ -36,15 +40,6 @@ CONSECUTIVE_FAILURE_THRESHOLD = 3
 # only ever lives in the root agent's process.
 _consecutive_fails: dict[str, int] = {}
 
-# A tool result counts as a failure if the tool returned an error
-# marker. pyagent's `<...>` convention covers most cases:
-# `<file not found: ...>`, `<error: old_string ... not found>`, etc.
-# We also flag `_denied(path)` results (which start with
-# `<permission denied to ...>`) as failures.
-_FAILURE_PREFIXES = ("<error", "<file not found", "<permission denied",
-                     "<is a directory", "<cannot decode", "<no match",
-                     "<old_string", "<the original", "<")
-
 
 RECONSIDER_NOTE = (
     "You've now had several consecutive edit_file failures on the "
@@ -56,21 +51,6 @@ RECONSIDER_NOTE = (
 )
 
 
-def _is_failure(result: Any) -> bool:
-    """edit_file returns a string; failures start with `<...>` markers
-    (the codebase's `tools.py` `<...>` convention). A confirmation
-    starts with `Wrote ...` or `Replaced ...`."""
-    if not isinstance(result, str):
-        return False
-    s = result.lstrip()
-    if not s:
-        return False
-    # Cheap test: confirmations start with Wrote/Replaced/etc., not
-    # with `<`. Anything starting with `<` is a marker per the
-    # tools.py convention.
-    return s.startswith("<")
-
-
 def _path_from_args(args: dict) -> str | None:
     if not isinstance(args, dict):
         return None
@@ -78,7 +58,9 @@ def _path_from_args(args: dict) -> str | None:
     return p if isinstance(p, str) and p else None
 
 
-def _on_after_tool(name: str, args: dict, result: Any) -> AfterToolHookResult | None:
+def _on_after_tool(
+    name: str, args: dict, result: Any, is_error: bool
+) -> AfterToolHookResult | None:
     path = _path_from_args(args)
     if path is None:
         return None
@@ -89,7 +71,7 @@ def _on_after_tool(name: str, args: dict, result: Any) -> AfterToolHookResult | 
         _consecutive_fails.pop(path, None)
         return None
 
-    if not _is_failure(result):
+    if not is_error:
         # Successful edit. Reset.
         _consecutive_fails.pop(path, None)
         return None

--- a/pyagent/tools.py
+++ b/pyagent/tools.py
@@ -1,4 +1,23 @@
-"""Built-in tools for the agent."""
+"""Built-in tools for the agent.
+
+## Error-marker contract
+
+Tool results are strings. When a tool wants to signal failure or
+refusal *as data* — without raising — it returns a string starting
+with the `<` character. By convention the rest of the marker is a
+short categorising word followed by a colon, e.g.
+``<refused: …>``, ``<unknown sid …>``, ``<no answer from …>``,
+``<send failed: …>``. Raised exceptions caught at the dispatch
+boundary (``Agent._route_tool``) are also rendered into the same
+``<…>`` shape (``Error: <type>: <msg>``).
+
+**Non-error tool results MUST NOT start with ``<``.** Plugins (and
+session-audit code) rely on this to detect failures structurally
+without a per-tool keyword list. The helper ``is_error_result(s)``
+encodes the contract; controlling-hook plugins receive the same
+signal as a boolean ``is_error`` argument to the ``after_tool``
+hook.
+"""
 
 import fnmatch
 import os
@@ -15,6 +34,27 @@ import requests
 
 from pyagent import permissions
 from pyagent.session import Attachment
+
+#: Prefix character that marks an errors-as-data tool result.
+ERROR_MARKER_PREFIX = "<"
+
+
+def is_error_result(content: str) -> bool:
+    """Return True iff ``content`` is a tool error/refusal marker.
+
+    Encodes the contract documented in this module's docstring:
+    non-error tool results MUST NOT start with ``<``. Used by the
+    plugin dispatch loop to give v2 ``after_tool`` hooks a clean
+    boolean failure signal so they don't have to sniff for the
+    prefix themselves.
+
+    Tolerant of leading whitespace (some tools format with a
+    leading newline for readability).
+    """
+    if not isinstance(content, str):
+        return False
+    s = content.lstrip()
+    return s.startswith(ERROR_MARKER_PREFIX)
 
 # Track in-flight execute() shell subprocesses so the cancel pathway
 # can kill them on Esc. Within a single agent process the tool loop

--- a/tests/smoke_controlling_hooks.py
+++ b/tests/smoke_controlling_hooks.py
@@ -134,7 +134,7 @@ def test_allow_no_change() -> None:
             "    def before(name, args):\n"
             "        events.append(('before', name, dict(args)))\n"
             "        return ToolHookResult(decision='allow')\n"
-            "    def after(name, args, result):\n"
+            "    def after(name, args, result, is_error):\n"
             "        events.append(('after', name, result))\n"
             "        return None\n"
             "    api.before_tool_call(before)\n"
@@ -294,7 +294,7 @@ def test_extra_user_message_before_and_after() -> None:
             "        return ToolHookResult(\n"
             "            extra_user_message='heads up: tool incoming',\n"
             "        )\n"
-            "    def after(name, args, result):\n"
+            "    def after(name, args, result, is_error):\n"
             "        return AfterToolHookResult(\n"
             "            extra_user_message='heads up: tool ran',\n"
             "        )\n"
@@ -332,7 +332,7 @@ def test_extra_user_message_drains_to_next_turn() -> None:
         plugin_py = (
             "from pyagent.plugins import AfterToolHookResult\n"
             "def register(api):\n"
-            "    def after(name, args, result):\n"
+            "    def after(name, args, result, is_error):\n"
             "        return AfterToolHookResult(\n"
             "            extra_user_message='reconsider',\n"
             "        )\n"
@@ -472,7 +472,7 @@ def test_replace_result_chaining() -> None:
         plugin_a = (
             "from pyagent.plugins import AfterToolHookResult\n"
             "def register(api):\n"
-            "    def after(name, args, result):\n"
+            "    def after(name, args, result, is_error):\n"
             "        return AfterToolHookResult(replace_result='A')\n"
             "    api.after_tool_call(after)\n"
         )
@@ -480,7 +480,7 @@ def test_replace_result_chaining() -> None:
             "from pyagent.plugins import AfterToolHookResult\n"
             "seen = []\n"
             "def register(api):\n"
-            "    def after(name, args, result):\n"
+            "    def after(name, args, result, is_error):\n"
             "        seen.append(result)\n"
             "        return AfterToolHookResult(\n"
             "            replace_result=result + '-then-B',\n"
@@ -684,7 +684,130 @@ def test_strategic_reevaluation_resets_on_success() -> None:
         restore()
 
 
+def test_is_error_helper_contract() -> None:
+    """The errors-as-data contract: any tool result starting with `<`
+    is an error marker; non-error results MUST NOT start with `<`.
+    """
+    from pyagent.tools import is_error_result, ERROR_MARKER_PREFIX
+
+    assert ERROR_MARKER_PREFIX == "<", ERROR_MARKER_PREFIX
+    assert is_error_result("<refused: empty>") is True
+    assert is_error_result("<unknown sid 'foo'>") is True
+    assert is_error_result("Error: ValueError: bad") is False
+    assert is_error_result("Wrote 1 replacement to /x") is False
+    assert is_error_result("") is False
+    # Tolerant of leading whitespace.
+    assert is_error_result("\n  <error: something>") is True
+    # Defensive against non-string defenders.
+    assert is_error_result(None) is False  # type: ignore[arg-type]
+    assert is_error_result(42) is False  # type: ignore[arg-type]
+    print("✓ tools.is_error_result encodes the <…>-prefix contract")
+
+
+def test_after_hook_receives_is_error_flag() -> None:
+    """v2 after_tool hooks receive `is_error` as the 4th positional
+    argument, set by the harness from (raised exception OR result
+    starts with `<`).
+    """
+    cfg, restore = _isolated_config_dir()
+    try:
+        plugin_py = (
+            "from pyagent.plugins import AfterToolHookResult\n"
+            "calls = []\n"
+            "def register(api):\n"
+            "    def after(name, args, result, is_error):\n"
+            "        calls.append((name, result[:24], is_error))\n"
+            "        return None\n"
+            "    api.after_tool_call(after)\n"
+        )
+        _write_plugin(
+            cfg / "plugins",
+            dirname="errflag",
+            name="errflag",
+            plugin_py=plugin_py,
+        )
+        loaded = plugins_mod.load()
+        agent = _mk_agent(loaded)
+        # Override widget to be deterministic.
+        agent.add_tool(
+            "widget",
+            lambda path="", value="": "happy result",
+            auto_offload=False,
+        )
+        # Add a failing-marker tool.
+        agent.add_tool(
+            "fail_marker",
+            lambda: "<error: simulated failure>",
+            auto_offload=False,
+        )
+        # Add a raising tool.
+        def boom() -> str:
+            raise RuntimeError("boom")
+        agent.add_tool("boom", boom, auto_offload=False)
+
+        agent._route_tool({"id": "1", "name": "widget", "args": {}})
+        agent._route_tool({"id": "2", "name": "fail_marker", "args": {}})
+        agent._route_tool({"id": "3", "name": "boom", "args": {}})
+
+        mod = next(
+            m for n, m in sys.modules.items()
+            if n.startswith("pyagent_plugin_errflag")
+        )
+        assert len(mod.calls) == 3, mod.calls
+        # Success → is_error False.
+        assert mod.calls[0] == ("widget", "happy result", False), mod.calls[0]
+        # `<…>` marker → is_error True.
+        assert mod.calls[1][0] == "fail_marker"
+        assert mod.calls[1][2] is True, mod.calls[1]
+        # Raised exception → is_error True (rendered into Error: …
+        # which doesn't start with `<` but the harness tracks the
+        # raise separately).
+        assert mod.calls[2][0] == "boom"
+        assert mod.calls[2][2] is True, mod.calls[2]
+        print("✓ after_tool receives is_error: success=False, marker=True, raise=True")
+    finally:
+        restore()
+
+
+def test_replace_result_must_be_string() -> None:
+    """v2 contract: replace_result is `str | None`. Non-string values
+    are dropped with a warning; the original tool result stands."""
+    cfg, restore = _isolated_config_dir()
+    try:
+        plugin_py = (
+            "from pyagent.plugins import AfterToolHookResult\n"
+            "def register(api):\n"
+            "    def after(name, args, result, is_error):\n"
+            "        # Returning a non-string replace_result must be\n"
+            "        # ignored (typed as str|None per the v2 contract).\n"
+            "        return AfterToolHookResult(replace_result=42)\n"
+            "    api.after_tool_call(after)\n"
+        )
+        _write_plugin(
+            cfg / "plugins",
+            dirname="badtype",
+            name="badtype",
+            plugin_py=plugin_py,
+        )
+        loaded = plugins_mod.load()
+        agent = _mk_agent(loaded)
+        result = agent._route_tool({
+            "id": "1", "name": "widget",
+            "args": {"path": "/x", "value": "v"},
+        })
+        # Non-string replace_result was dropped; original tool output
+        # stands.
+        assert "widget(path='/x'" in result, result
+        assert result != "42", result
+        print("✓ replace_result non-string dropped with warning")
+    finally:
+        restore()
+
+
 def main() -> None:
+    test_is_error_helper_contract()
+    test_after_hook_receives_is_error_flag()
+    test_replace_result_must_be_string()
     test_allow_no_change()
     test_block_short_circuits_before_permission()
     test_mutate_args()


### PR DESCRIPTION
Follow-up to #66 — closes the two design refinements I flagged on PR #71's review.

## Q1 — `replace_result` is `str | None`

`AfterToolHookResult.replace_result` was `Any` with a sentinel default. Restricted to `str | None` with `None` meaning "no replacement":

- Tool results are strings by contract (both Anthropic and OpenAI APIs require string content, `_route_tool` stringifies anyway).
- Removes the chain-sees-raw vs. final-stringified ambiguity — every plugin in the chain sees a string, and so does the model.
- The dispatch loop drops non-string `replace_result` values with a warning so a misbehaving plugin can't silently corrupt results.
- Sentinel constant deleted; `None` is now the unambiguous "don't replace" signal.

## Q2 — `after_tool` gains `is_error: bool`

The brittleness flagged on #71: `strategic_reevaluation` was sniffing `<…>` prefixes against a 10-element keyword list to detect failures. Replaced with a clean harness-provided flag.

- `pyagent.tools.is_error_result(content)` — public helper. Encodes the contract: a tool result starting with `<` is a refusal/failure marker.
- `ERROR_MARKER_PREFIX = "<"` — formalizes the prefix.
- `tools.py` module docstring documents the contract: **non-error tool results MUST NOT start with `<`**.
- `Agent._route_tool` computes `is_error` from `(raised_exception OR is_error_result(content))` and passes it to `plugins.call_after_tool_call`.
- v2 `after_tool` hook signature gains a 4th positional arg: `def my_hook(name, args, result, is_error)`.
- v1 hooks unchanged (still `(name, args, result)`); v1 dispatch path preserved.
- `strategic_reevaluation` rewritten to use `is_error` directly — 10 lines simpler, robust against any future change to error-marker conventions.

## Test plan

- [x] `tests/smoke_controlling_hooks.py` — 14 tests, 3 new:
  - `test_is_error_helper_contract` — `<…>` prefix (with leading whitespace tolerance) returns True; success strings, empty, non-strings return False.
  - `test_after_hook_receives_is_error_flag` — exercises the three paths: success result (False), `<error: …>` marker (True), raised exception (True).
  - `test_replace_result_must_be_string` — `replace_result=42` is dropped with a warning; original tool result stands.
  - Existing v2 plugin literals updated to the 4-arg `after` signature.
  - Existing `strategic_reevaluation` tests pass unchanged — the plugin's behaviour is identical, just the failure detection is now structural.
- [x] All other smokes still pass (notify, notify_surface, ask_parent, subagent, async_subagent, subagent_routing, recursive_subagent, subagent_caps, submit_handler, permission_handler, status_footer, kill_active, session_replay, session_audit, prompt_environment, glob, edit_file, read_file_ceiling, html_tools, arg_scrubbing, skill_eviction, plugins, plugin_provider).
- [ ] `pyagent_self_audit.toml` bench — not run; user-controlled.

**Pre-existing unrelated failure**: `smoke_py_dev_toolkit` fails on the `lint cites E401` assertion (ruff isn't citing the rule). Verified failing on `main` without these changes — independent issue, worth tracking separately.

## Breaking change for v2 plugin authors

v2 plugins with an `after_tool_call` hook need to update the signature from `(name, args, result)` to `(name, args, result, is_error)`. Only impact: the bundled `strategic_reevaluation` (updated in this PR) — no external v2 plugins exist yet.

Series complete after this lands.