### PR TITLE
Fix smokes after the dynamic-feedback merges

### DIFF
--- a/tests/smoke_plugins.py
+++ b/tests/smoke_plugins.py
@@ -422,7 +422,9 @@ def test_lifecycle_hooks_fire() -> None:
 
         loaded.call_after_assistant_response("hello there")
         loaded.call_before_tool_call("read_file", {"path": "/x"})
-        loaded.call_after_tool_call("read_file", {"path": "/x"}, "file content here")
+        loaded.call_after_tool_call(
+            "read_file", {"path": "/x"}, "file content here", False
+        )
         loaded.call_on_session_end(session=None)
 
         assert events[0] == "start"

--- a/tests/smoke_prompt_toolkit.py
+++ b/tests/smoke_prompt_toolkit.py
@@ -81,17 +81,21 @@ def main() -> None:
         assert b">" in out, f"no prompt rendered:\n{out!r}"
         print("✓ ready, prompt rendered under PTY")
 
-        # Issue /queue while idle — confirms the new async REPL
-        # routes the slash command through `_handle_queue_command`
-        # locally (no IPC round-trip) and prints "queue empty".
-        os.write(fd, b"/queue\r")
-        slash_out = _read_until(fd, b"queue empty", timeout_s=5.0)
-        assert b"queue empty" in slash_out, (
-            f"/queue did not produce expected output:\n{slash_out!r}"
+        # Issue /perms while idle — confirms the async REPL routes
+        # the slash command through `_handle_perms_command` locally
+        # (no IPC round-trip) and prints "no pending permission
+        # requests". Replaces the old `/queue` smoke now that the
+        # local input queue is gone (issues #68/#69).
+        os.write(fd, b"/perms\r")
+        slash_out = _read_until(
+            fd, b"no pending permission requests", timeout_s=5.0,
         )
-        print("✓ /queue routed locally, printed 'queue empty'")
+        assert b"no pending permission requests" in slash_out, (
+            f"/perms did not produce expected output:\n{slash_out!r}"
+        )
+        print("✓ /perms routed locally, printed 'no pending permission requests'")
 
-        # Brief pause so /queue's redraw settles before we send EOF;
+        # Brief pause so /perms' redraw settles before we send EOF;
         # otherwise prompt_toolkit can swallow the Ctrl-D inside the
         # in-flight repaint.
         time.sleep(0.5)


### PR DESCRIPTION
Two regressions caught by a clean-main smoke run after #70/#71/#72/#73/#74 all landed.

## Fixes

- **`tests/smoke_plugins.py`** — `test_lifecycle_hooks_fire` called `loaded.call_after_tool_call("read_file", {...}, "...")` with 3 args. PR #74 added `is_error` as the 4th positional. Pass `False` explicitly to keep the test exercising a successful-result path.
- **`tests/smoke_prompt_toolkit.py`** — drove `/queue` under a real PTY to verify slash-command routing. PR #73 deleted the `/queue` family when it replaced the local input queue with mid-turn `user_note` injection. Switched to `/perms` (which is what's there now and serves the same purpose for this smoke — local routing without IPC round-trip).

## Test plan

- [x] `tests/smoke_plugins` — passes
- [x] `tests/smoke_prompt_toolkit` — passes
- [x] Full smoke suite: 39/40 pass. The remaining failure is the pre-existing `smoke_py_dev_toolkit` (ruff not citing E401), independent of the dynamic-feedback work.