### PR TITLE
ollama provider plugin + --list-models CLI

### DIFF
--- a/pyagent/cli.py
+++ b/pyagent/cli.py
@@ -133,6 +133,43 @@ from pyagent.pricing import (
 )
 
 
+def _render_models_listing() -> str:
+    """Aggregate every provider's advertised models into a printable
+    block.
+
+    Built-in providers ship hardcoded lists (zero network, no key
+    required). Plugin providers can register a live callable —
+    ollama's hits `/api/tags`. Per-provider exceptions are caught
+    upstream in `llms.list_all_models()` and rendered as
+    `(unavailable: <reason>)` so a stopped local server doesn't
+    silence the rest of the catalog.
+
+    Plugin providers are surfaced only if `plugins.load()` has
+    populated them. Caller is responsible for the load — this
+    function only formats.
+    """
+    listings = llms.list_all_models()
+    plugin_names = set(llms._PLUGIN_PROVIDERS)
+
+    lines: list[str] = [
+        "Available models — pass with `--model provider/model`:",
+        "",
+    ]
+    for listing in listings:
+        suffix = " (plugin)" if listing.name in plugin_names else ""
+        lines.append(f"[bold]{listing.name}[/bold]{suffix}:")
+        if listing.error:
+            lines.append(f"  [yellow](unavailable: {listing.error})[/yellow]")
+        elif not listing.models:
+            lines.append("  [dim](no models advertised)[/dim]")
+        else:
+            for m in listing.models:
+                tag = "  [dim](default)[/dim]" if m == listing.default_model else ""
+                lines.append(f"  - {m}{tag}")
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
 def _resolve_model(cli_model: str | None) -> str:
     """Pick a model string. Precedence: --model > config.default_model
     > auto-detect from API-key env vars. Raises a click error if all
@@ -967,6 +1004,18 @@ async def _repl_async(
     ),
 )
 @click.option(
+    "--list-models",
+    "list_models_flag",
+    is_flag=True,
+    help=(
+        "Print every model each provider advertises and exit. "
+        "Built-ins return a hardcoded canonical list (no API key "
+        "needed); plugin providers like ollama query their backend "
+        "live. One unreachable backend renders as "
+        "`(unavailable: ...)` and never blocks the rest."
+    ),
+)
+@click.option(
     "--resume",
     "resume_id",
     is_flag=False,
@@ -1025,6 +1074,7 @@ def main(
     tools_md: Path | None,
     primer: Path | None,
     model: str | None,
+    list_models_flag: bool,
     resume_id: str | None,
     reset_soul: bool,
     reset_tools: bool,
@@ -1039,6 +1089,17 @@ def main(
 
     if verbose:
         logging.getLogger("pyagent").setLevel(logging.INFO)
+
+    if list_models_flag:
+        # Plugins must be loaded so plugin-registered providers (like
+        # ollama) show up in the listing. plugins.load() only runs
+        # register() — no session-start hooks fire — so this is cheap
+        # and side-effect-free for the CLI exit path.
+        from pyagent import plugins as _plugins
+
+        _plugins.load()
+        console.print(_render_models_listing())
+        return
 
     will_reset_soul = reset_soul or reset_all
     will_reset_tools = reset_tools or reset_all

--- a/pyagent/cli.py
+++ b/pyagent/cli.py
@@ -139,14 +139,18 @@ def _render_models_listing() -> str:
 
     Built-in providers ship hardcoded lists (zero network, no key
     required). Plugin providers can register a live callable —
-    ollama's hits `/api/tags`. Per-provider exceptions are caught
-    upstream in `llms.list_all_models()` and rendered as
-    `(unavailable: <reason>)` so a stopped local server doesn't
-    silence the rest of the catalog.
+    ollama's hits `/api/tags` + per-model `/api/show`. Per-provider
+    exceptions are caught upstream in `llms.list_all_models()` and
+    rendered as `(unavailable: <reason>)` so a stopped local server
+    doesn't silence the rest of the catalog.
 
-    Plugin providers are surfaced only if `plugins.load()` has
-    populated them. Caller is responsible for the load — this
-    function only formats.
+    pyagent's agent loop relies on tool-calling, so the renderer
+    flags ollama models that explicitly don't advertise the ``tools``
+    capability with a yellow ``(no tools — chat only)`` note. Models
+    where capabilities is empty (older Ollama servers, or built-ins
+    we don't enumerate) get no annotation rather than a misleading
+    one. Plugin providers are surfaced only if `plugins.load()` has
+    populated them.
     """
     listings = llms.list_all_models()
     plugin_names = set(llms._PLUGIN_PROVIDERS)
@@ -164,8 +168,15 @@ def _render_models_listing() -> str:
             lines.append("  [dim](no models advertised)[/dim]")
         else:
             for m in listing.models:
-                tag = "  [dim](default)[/dim]" if m == listing.default_model else ""
-                lines.append(f"  - {m}{tag}")
+                tags: list[str] = []
+                if m.name == listing.default_model:
+                    tags.append("[dim](default)[/dim]")
+                if m.capabilities:
+                    tags.append(f"[dim]({', '.join(m.capabilities)})[/dim]")
+                    if "tools" not in m.capabilities:
+                        tags.append("[yellow](no tools — chat only)[/yellow]")
+                tag_str = "  " + " ".join(tags) if tags else ""
+                lines.append(f"  - {m.name}{tag_str}")
         lines.append("")
     return "\n".join(lines).rstrip()
 

--- a/pyagent/config.py
+++ b/pyagent/config.py
@@ -58,6 +58,7 @@ DEFAULTS: dict[str, Any] = {
         "code-mapper",
         "web-search",
         "claude-code-cli",
+        "ollama",
         "echo-plugin",
         "py-dev-toolkit",
     ],

--- a/pyagent/llms/__init__.py
+++ b/pyagent/llms/__init__.py
@@ -19,6 +19,25 @@ from typing import Any, Callable, Protocol
 
 
 @dataclass(frozen=True)
+class ModelInfo:
+    """One model the provider can serve, plus optional capability tags.
+
+    `name` is the string callers pass after `provider/` in `--model`.
+    `capabilities` is a free-form tuple of tags the provider chose to
+    surface (e.g. ``"tools"``, ``"vision"``, ``"embedding"``) — used
+    by the CLI listing to flag models that are or aren't compatible
+    with pyagent's tool-using agent loop. Empty tuple means "the
+    provider didn't enumerate"; the CLI prints nothing rather than
+    over-claiming. We deliberately don't enumerate capabilities for
+    built-ins (anthropic / openai / gemini): that data is meaningful
+    only when it can vary per model, which is the ollama story.
+    """
+
+    name: str
+    capabilities: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class ProviderSpec:
     """One LLM provider's registration data.
 
@@ -34,20 +53,22 @@ class ProviderSpec:
         factory: Callable that takes optional `model=` and returns a client.
             The actual SDK import happens here, so unused providers don't
             pay the import cost.
-        list_models: Optional callable returning the model names this
-            provider can serve (the part after `provider/` in `--model`).
-            Built-in providers return a hardcoded canonical list — no
-            network, no API key required. Live providers (e.g. ollama,
-            which queries `/api/tags`) may raise to signal an unreachable
-            backend; the CLI catches and renders the error per-provider
-            so one bad source doesn't kill the listing.
+        list_models: Optional callable returning `ModelInfo` records
+            for the models this provider can serve. Built-in providers
+            return a hardcoded canonical list — no network, no API
+            key required, and capabilities are left empty (those
+            providers' models are uniformly tool-capable). Live
+            providers like ollama populate capabilities from the
+            backend (`/api/show`) so the CLI can flag tool/vision/
+            embedding variants. Callable may raise to signal an
+            unreachable backend; the aggregator catches per-provider.
     """
 
     name: str
     env_vars: tuple[str, ...]
     default_model: str
     factory: Callable[..., "LLMClient"]
-    list_models: Callable[[], list[str]] | None = None
+    list_models: Callable[[], list[ModelInfo]] | None = None
 
 
 # Canonical recent-and-popular model lists for each built-in. Hardcoded
@@ -55,34 +76,34 @@ class ProviderSpec:
 # keys, instantly. Bumping these is a one-line edit when a new model
 # ships; the alternative (live `/v1/models` calls) silently fails for
 # users without keys configured.
-def _anthropic_models() -> list[str]:
+def _anthropic_models() -> list[ModelInfo]:
     return [
-        "claude-opus-4-7",
-        "claude-sonnet-4-6",
-        "claude-haiku-4-5-20251001",
+        ModelInfo(name="claude-opus-4-7"),
+        ModelInfo(name="claude-sonnet-4-6"),
+        ModelInfo(name="claude-haiku-4-5-20251001"),
     ]
 
 
-def _openai_models() -> list[str]:
+def _openai_models() -> list[ModelInfo]:
     return [
-        "gpt-4o",
-        "gpt-4o-mini",
-        "o1",
-        "o1-mini",
-        "o3-mini",
+        ModelInfo(name="gpt-4o"),
+        ModelInfo(name="gpt-4o-mini"),
+        ModelInfo(name="o1"),
+        ModelInfo(name="o1-mini"),
+        ModelInfo(name="o3-mini"),
     ]
 
 
-def _gemini_models() -> list[str]:
+def _gemini_models() -> list[ModelInfo]:
     return [
-        "gemini-2.5-flash",
-        "gemini-2.5-pro",
-        "gemini-2.0-flash",
+        ModelInfo(name="gemini-2.5-flash"),
+        ModelInfo(name="gemini-2.5-pro"),
+        ModelInfo(name="gemini-2.0-flash"),
     ]
 
 
-def _pyagent_models() -> list[str]:
-    return ["echo", "loremipsum"]
+def _pyagent_models() -> list[ModelInfo]:
+    return [ModelInfo(name="echo"), ModelInfo(name="loremipsum")]
 
 
 def _anthropic_factory(**kw: Any) -> "LLMClient":
@@ -233,7 +254,7 @@ class ProviderListing:
 
     name: str
     default_model: str
-    models: tuple[str, ...] = ()
+    models: tuple[ModelInfo, ...] = ()
     error: str = ""
 
 

--- a/pyagent/llms/__init__.py
+++ b/pyagent/llms/__init__.py
@@ -34,12 +34,55 @@ class ProviderSpec:
         factory: Callable that takes optional `model=` and returns a client.
             The actual SDK import happens here, so unused providers don't
             pay the import cost.
+        list_models: Optional callable returning the model names this
+            provider can serve (the part after `provider/` in `--model`).
+            Built-in providers return a hardcoded canonical list — no
+            network, no API key required. Live providers (e.g. ollama,
+            which queries `/api/tags`) may raise to signal an unreachable
+            backend; the CLI catches and renders the error per-provider
+            so one bad source doesn't kill the listing.
     """
 
     name: str
     env_vars: tuple[str, ...]
     default_model: str
     factory: Callable[..., "LLMClient"]
+    list_models: Callable[[], list[str]] | None = None
+
+
+# Canonical recent-and-popular model lists for each built-in. Hardcoded
+# rather than queried so `pyagent --list-models` works without API
+# keys, instantly. Bumping these is a one-line edit when a new model
+# ships; the alternative (live `/v1/models` calls) silently fails for
+# users without keys configured.
+def _anthropic_models() -> list[str]:
+    return [
+        "claude-opus-4-7",
+        "claude-sonnet-4-6",
+        "claude-haiku-4-5-20251001",
+    ]
+
+
+def _openai_models() -> list[str]:
+    return [
+        "gpt-4o",
+        "gpt-4o-mini",
+        "o1",
+        "o1-mini",
+        "o3-mini",
+    ]
+
+
+def _gemini_models() -> list[str]:
+    return [
+        "gemini-2.5-flash",
+        "gemini-2.5-pro",
+        "gemini-2.0-flash",
+    ]
+
+
+def _pyagent_models() -> list[str]:
+    return ["echo", "loremipsum"]
 
 
 def _anthropic_factory(**kw: Any) -> "LLMClient":
@@ -82,24 +125,28 @@ PROVIDERS: list[ProviderSpec] = [
         env_vars=("ANTHROPIC_API_KEY",),
         default_model="claude-sonnet-4-6",
         factory=_anthropic_factory,
+        list_models=_anthropic_models,
     ),
     ProviderSpec(
         name="openai",
         env_vars=("OPENAI_API_KEY",),
         default_model="gpt-4o",
         factory=_openai_factory,
+        list_models=_openai_models,
     ),
     ProviderSpec(
         name="gemini",
         env_vars=("GEMINI_API_KEY", "GOOGLE_API_KEY"),
         default_model="gemini-2.5-flash",
         factory=_gemini_factory,
+        list_models=_gemini_models,
     ),
     ProviderSpec(
         name="pyagent",
         env_vars=(),
         default_model="echo",
         factory=_pyagent_factory,
+        list_models=_pyagent_models,
     ),
 ]
 
@@ -169,6 +216,69 @@ def resolve_model(model: str) -> str:
     if spec is None:
         return model
     return f"{provider}/{name or spec.default_model}"
+
+
+@dataclass(frozen=True)
+class ProviderListing:
+    """One provider's slice of the model catalog.
+
+    `models` is the names returned by the provider's `list_models`
+    callable. `error` is set instead when the callable raised — the
+    CLI renders this as `(unavailable: <error>)` so a stopped
+    Ollama server (or similar) doesn't kill the whole listing.
+    `default_model` mirrors `ProviderSpec.default_model` so renderers
+    can mark the active default with a `(default)` tag without a
+    second lookup.
+    """
+
+    name: str
+    default_model: str
+    models: tuple[str, ...] = ()
+    error: str = ""
+
+
+def list_all_models() -> list[ProviderListing]:
+    """Walk every registered provider (built-in + plugin) and collect
+    its advertised models.
+
+    Built-in providers come first (in `PROVIDERS` order); plugin
+    providers follow in registration order. Providers without a
+    `list_models` callable get a `ProviderListing` with empty
+    `models`. Providers whose callable raises get `error` populated
+    so the CLI can render `(unavailable: <reason>)` per-provider —
+    one bad source (e.g. ollama with the server stopped) never
+    kills the rest of the listing.
+    """
+    out: list[ProviderListing] = []
+    seen: set[str] = set()
+    for spec in PROVIDERS:
+        out.append(_listing_for(spec))
+        seen.add(spec.name)
+    for name, spec in _PLUGIN_PROVIDERS.items():
+        if name in seen:
+            continue
+        out.append(_listing_for(spec))
+    return out
+
+
+def _listing_for(spec: ProviderSpec) -> ProviderListing:
+    if spec.list_models is None:
+        return ProviderListing(
+            name=spec.name, default_model=spec.default_model
+        )
+    try:
+        models = spec.list_models()
+    except Exception as e:
+        return ProviderListing(
+            name=spec.name,
+            default_model=spec.default_model,
+            error=str(e) or e.__class__.__name__,
+        )
+    return ProviderListing(
+        name=spec.name,
+        default_model=spec.default_model,
+        models=tuple(models),
+    )
 
 
 def auto_detect_provider() -> ProviderSpec | None:

--- a/pyagent/plugins/__init__.py
+++ b/pyagent/plugins/__init__.py
@@ -244,6 +244,7 @@ class _RegisteredProvider:
     default_model: str
     env_vars: tuple[str, ...]
     plugin_name: str
+    list_models: Callable[[], list[str]] | None = None
 
 
 @dataclass
@@ -329,6 +330,7 @@ class PluginAPI:
         *,
         default_model: str = "",
         env_vars: tuple[str, ...] = (),
+        list_models: Callable[[], list[str]] | None = None,
     ) -> None:
         """Register an LLM provider exposed as `<name>/<model>` for `--model`.
 
@@ -343,6 +345,13 @@ class PluginAPI:
         suffix. `env_vars` is informational at this level — plugins
         should still gate their own loading on env presence via the
         manifest's `[requires] env`.
+
+        `list_models` is an optional callable returning the model
+        names the provider can serve (the part after `provider/` in
+        `--model`). Used by `pyagent --list-models`. Live providers
+        (e.g. a server query) may raise to signal an unreachable
+        backend; the CLI catches per-provider so one bad source
+        doesn't kill the whole listing.
 
         Conflicts with built-in providers raise immediately so the
         problem surfaces at plugin load time rather than at the next
@@ -371,6 +380,7 @@ class PluginAPI:
             default_model=default_model,
             env_vars=tuple(env_vars),
             plugin_name=self._state.manifest.name,
+            list_models=list_models,
         )
 
     def register_prompt_section(
@@ -1191,6 +1201,7 @@ def load(*, is_subagent: bool = False) -> LoadedPlugins:
                 env_vars=tuple(p.env_vars),
                 default_model=p.default_model,
                 factory=p.factory,
+                list_models=p.list_models,
             )
             for name, p in loaded._resolved_providers.items()
         }

--- a/pyagent/plugins/__init__.py
+++ b/pyagent/plugins/__init__.py
@@ -244,7 +244,7 @@ class _RegisteredProvider:
     default_model: str
     env_vars: tuple[str, ...]
     plugin_name: str
-    list_models: Callable[[], list[str]] | None = None
+    list_models: Callable[[], list[Any]] | None = None
 
 
 @dataclass
@@ -330,7 +330,7 @@ class PluginAPI:
         *,
         default_model: str = "",
         env_vars: tuple[str, ...] = (),
-        list_models: Callable[[], list[str]] | None = None,
+        list_models: Callable[[], list[Any]] | None = None,
     ) -> None:
         """Register an LLM provider exposed as `<name>/<model>` for `--model`.
 
@@ -346,12 +346,13 @@ class PluginAPI:
         should still gate their own loading on env presence via the
         manifest's `[requires] env`.
 
-        `list_models` is an optional callable returning the model
-        names the provider can serve (the part after `provider/` in
-        `--model`). Used by `pyagent --list-models`. Live providers
-        (e.g. a server query) may raise to signal an unreachable
-        backend; the CLI catches per-provider so one bad source
-        doesn't kill the whole listing.
+        `list_models` is an optional callable returning a list of
+        `pyagent.llms.ModelInfo` records — name plus optional
+        capability tags like ``"tools"`` / ``"vision"`` /
+        ``"embedding"``. Used by `pyagent --list-models`. Live
+        providers (e.g. a server query) may raise to signal an
+        unreachable backend; the CLI catches per-provider so one bad
+        source doesn't kill the whole listing.
 
         Conflicts with built-in providers raise immediately so the
         problem surfaces at plugin load time rather than at the next

--- a/pyagent/plugins/ollama/__init__.py
+++ b/pyagent/plugins/ollama/__init__.py
@@ -23,8 +23,17 @@ prevent loading other providers.
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Capabilities we filter from the per-model tag list before showing
+# them to the user. ``completion`` is reported by every chat model so
+# it carries no information; ``insert`` is fill-in-the-middle
+# infrastructure that pyagent doesn't surface as a feature.
+_BORING_CAPABILITIES = {"completion", "insert"}
 
 
 def _factory(**kw: Any):
@@ -52,6 +61,52 @@ def _format_size(size: Any) -> str:
     return f"{size / (1024**2):.0f} MB"
 
 
+def _list_models():
+    """Live query of `/api/tags` + per-model `/api/show` for the
+    `--list-models` CLI hook.
+
+    Lazy-imports the client so plugin load stays network-free. Raises
+    on the initial `/api/tags` failure so the aggregator can render
+    `(unavailable: <reason>)` — but per-model `/api/show` failures are
+    swallowed: a single 404 from a borked model entry shouldn't blank
+    capability data for every other model. The model still appears,
+    just without capability tags.
+
+    Capabilities come from Ollama's ``capabilities`` array (server
+    0.5+); on older servers that field is absent and `ModelInfo` ends
+    up with empty capabilities — same surface as a built-in provider,
+    which is fine. Per-model calls run sequentially because Ollama
+    tag lists are typically short and localhost-fast; if listings
+    grow we can revisit with a connection pool.
+    """
+    from pyagent.llms import ModelInfo
+    from pyagent.plugins.ollama.client import list_models, show_model
+
+    out: list[ModelInfo] = []
+    for entry in list_models():
+        name = (entry.get("name") or "").strip()
+        if not name:
+            continue
+        caps: tuple[str, ...] = ()
+        try:
+            info = show_model(name)
+            raw = info.get("capabilities") or []
+            if isinstance(raw, list):
+                caps = tuple(
+                    str(c)
+                    for c in raw
+                    if isinstance(c, str) and c not in _BORING_CAPABILITIES
+                )
+        except Exception as e:
+            logger.debug(
+                "ollama: /api/show for %r failed (%s); listing without caps",
+                name,
+                e,
+            )
+        out.append(ModelInfo(name=name, capabilities=caps))
+    return out
+
+
 def register(api):
     # Snapshot the env at register time so `default_model` on the
     # ProviderSpec is stable for the agent process. Reading later
@@ -64,6 +119,7 @@ def register(api):
         _factory,
         default_model=default_model,
         env_vars=(),  # local server, no required env
+        list_models=_list_models,
     )
 
     def list_ollama_models() -> str:

--- a/pyagent/plugins/ollama/__init__.py
+++ b/pyagent/plugins/ollama/__init__.py
@@ -1,0 +1,97 @@
+"""ollama — bundled plugin: routes through a local Ollama server.
+
+Registers the ``ollama`` LLM provider so ``--model ollama/<name>``
+goes through the local server's native ``/api/chat`` endpoint, plus
+a ``list_ollama_models`` tool the agent can call to enumerate what
+has been pulled locally.
+
+Configuration (all optional, all read at register time so plugin load
+never touches the network):
+
+  - ``OLLAMA_HOST``: server URL. Plain ``host:port`` is upgraded to
+    ``http://host:port``. Defaults to ``http://localhost:11434``.
+  - ``OLLAMA_MODEL``: default model name. Used when the user passes
+    ``--model ollama`` with no ``/<name>`` suffix. If unset, an empty
+    default flows through ``resolve_model`` and the factory raises a
+    clear error at call time — startup never fails just because no
+    model was chosen.
+
+Network calls are deferred to ``respond()`` and ``list_ollama_models``
+so a missing or stopped server doesn't block pyagent startup or
+prevent loading other providers.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+def _factory(**kw: Any):
+    # Lazy import: keeps `requests` and the client class out of the
+    # plugin-load critical path for users who never invoke ollama.
+    from pyagent.plugins.ollama.client import OllamaClient
+
+    model = kw.get("model") or ""
+    if not model:
+        raise ValueError(
+            "ollama provider requires an explicit model. Pass "
+            "--model ollama/<name>, or set OLLAMA_MODEL in your "
+            "environment. Use `ollama list` (or call the "
+            "list_ollama_models tool) to see what's installed."
+        )
+    return OllamaClient(model=model)
+
+
+def _format_size(size: Any) -> str:
+    if not isinstance(size, (int, float)) or size <= 0:
+        return ""
+    gb = size / (1024**3)
+    if gb >= 1:
+        return f"{gb:.1f} GB"
+    return f"{size / (1024**2):.0f} MB"
+
+
+def register(api):
+    # Snapshot the env at register time so `default_model` on the
+    # ProviderSpec is stable for the agent process. Reading later
+    # would mean different subagents (or the same agent after a hot
+    # config change) could see different defaults — surprising.
+    default_model = os.environ.get("OLLAMA_MODEL", "")
+
+    api.register_provider(
+        "ollama",
+        _factory,
+        default_model=default_model,
+        env_vars=(),  # local server, no required env
+    )
+
+    def list_ollama_models() -> str:
+        """List models pulled into the local Ollama server.
+
+        Use this when the user asks "what ollama models do I have?"
+        or before suggesting ``--model ollama/<name>`` so the choice
+        is one that's actually installed.
+
+        Returns:
+            Markdown bullet list — one line per model, formatted as
+            ``- name (size)``. ``<no models installed>`` if the
+            server is reachable but empty. ``<ollama error: ...>``
+            on connection failure or non-200 response.
+        """
+        from pyagent.plugins.ollama.client import list_models
+
+        try:
+            models = list_models()
+        except Exception as e:
+            return f"<ollama error: {e}>"
+        if not models:
+            return "<no models installed>"
+        lines: list[str] = []
+        for m in models:
+            name = m.get("name") or "(unnamed)"
+            size_str = _format_size(m.get("size"))
+            lines.append(f"- {name} ({size_str})" if size_str else f"- {name}")
+        return "\n".join(lines)
+
+    api.register_tool("list_ollama_models", list_ollama_models)

--- a/pyagent/plugins/ollama/client.py
+++ b/pyagent/plugins/ollama/client.py
@@ -1,0 +1,286 @@
+"""Ollama HTTP client implementing the LLMClient protocol.
+
+Talks to the local Ollama server's native ``/api/chat`` endpoint via
+``requests`` (already a pyagent dep — keeps this provider zero-extra-
+install). Uses a non-streaming POST: the ``respond()`` contract
+returns one fully-formed assistant turn, and Ollama hands one back
+when ``stream=False``.
+
+Tool-call translation mirrors OpenAI's chat-completions shape, which
+Ollama deliberately mimics. Two notable departures:
+
+  - Ollama tool calls have no ``id`` field. We synthesize ``call_<i>``
+    indices so downstream code in ``pyagent.agent`` (which keys tool
+    results by id) keeps working.
+  - Tool-result messages are routed by ``tool_name`` rather than
+    ``tool_call_id``. The internal pyagent message carries both, so
+    we just pass ``name`` through; Ollama models that don't honor it
+    still work because the call/response order in the conversation
+    is preserved.
+
+No usage cache stats — Ollama runs locally, billing is in watts.
+
+Tools-rejection handling: vision / embedding / base-no-template models
+respond to ``/api/chat`` with a 400 ``"<model> does not support tools"``
+when the request includes a ``tools`` field. The client catches that
+specific error, retries once without tools, and latches the decision
+on the instance so subsequent turns skip the failed round trip. Other
+4xx / 5xx errors propagate.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_HOST = "http://localhost:11434"
+# Long timeout because the first request after a cold start can sit
+# waiting for Ollama to mmap/load a multi-GB GGUF before any tokens
+# come back.
+DEFAULT_TIMEOUT = 600
+
+
+def _raise_with_body(resp: requests.Response, where: str) -> None:
+    """Like ``resp.raise_for_status()`` but folds Ollama's JSON error
+    body into the exception message.
+
+    Ollama's ``/api/chat`` 400s on real, actionable problems — e.g.
+    ``"<model> does not support tools"`` for vision/embedding models,
+    or ``"model not found"`` when a tag isn't pulled — and surfaces
+    the explanation in the response body's ``error`` field. The
+    default ``raise_for_status`` discards that body, leaving callers
+    with a bare ``400 Client Error`` they can't act on. This helper
+    pulls the body out and includes it in the raised ``HTTPError`` so
+    the agent's traceback shows the actual cause.
+    """
+    if resp.ok:
+        return
+    detail = ""
+    try:
+        body = resp.json()
+        if isinstance(body, dict):
+            detail = str(body.get("error") or "").strip()
+        else:
+            detail = str(body)
+    except (ValueError, requests.exceptions.JSONDecodeError):
+        # Non-JSON body — fall back to the raw text, capped so a stray
+        # HTML error page doesn't blow up the log.
+        detail = (resp.text or "").strip()[:500]
+    msg = f"Ollama {where} returned {resp.status_code}"
+    if detail:
+        msg = f"{msg}: {detail}"
+    raise requests.HTTPError(msg, response=resp)
+
+
+def _resolve_host() -> str:
+    """Resolve the Ollama server URL from env, with scheme normalised.
+
+    Ollama itself accepts bare ``host:port`` in ``OLLAMA_HOST``; we
+    upgrade to ``http://host:port`` so ``requests`` doesn't reject it.
+    """
+    raw = os.environ.get("OLLAMA_HOST", "").strip() or DEFAULT_HOST
+    if "://" not in raw:
+        raw = f"http://{raw}"
+    return raw.rstrip("/")
+
+
+def list_models(host: str | None = None, timeout: float = 30) -> list[dict[str, Any]]:
+    """Return the parsed ``models`` list from ``GET /api/tags``.
+
+    Raises whatever ``requests`` raises on connection/timeout failure
+    so callers can surface a tagged error string.
+    """
+    url = f"{(host or _resolve_host()).rstrip('/')}/api/tags"
+    resp = requests.get(url, timeout=timeout)
+    _raise_with_body(resp, "/api/tags")
+    data = resp.json()
+    models = data.get("models") or []
+    if not isinstance(models, list):
+        return []
+    return models
+
+
+class OllamaClient:
+    """Wraps a local Ollama HTTP server in the pyagent LLMClient interface.
+
+    Construction does not touch the network. The first request is
+    deferred to ``respond()`` so a missing or stopped server doesn't
+    block agent startup, and so a session that resolves to an
+    Ollama-backed model can still configure itself even if the server
+    is briefly down.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        host: str | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+    ) -> None:
+        if not model:
+            raise ValueError(
+                "OllamaClient requires a model name; got empty string"
+            )
+        self.model = model
+        self.provider_model = f"ollama/{model}"
+        self.host = (host or _resolve_host()).rstrip("/")
+        self.timeout = timeout
+        # Latched once we discover (via a 400 retry) that this model
+        # rejects the `tools` field. Subsequent turns skip tools so we
+        # don't burn a wasted round trip per call. We avoid a
+        # `/api/show` preflight on construction so the lazy-network
+        # contract holds — the cost is exactly one extra failed
+        # request the first time a no-tools model is used.
+        self._skip_tools = False
+
+    def respond(
+        self,
+        conversation: list[dict[str, Any]],
+        system: str | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        system_volatile: str | None = None,
+    ) -> dict[str, Any]:
+        messages: list[dict[str, Any]] = []
+        # Ollama has no prefix-cache surface to preserve, so stable +
+        # volatile concatenate into one system message — same shape
+        # the OpenAI client uses.
+        full_system = system or ""
+        if system_volatile:
+            full_system = (
+                f"{full_system}\n\n{system_volatile}"
+                if full_system
+                else system_volatile
+            )
+        if full_system:
+            messages.append({"role": "system", "content": full_system})
+        for m in conversation:
+            messages.extend(self._to_ollama(m))
+
+        body: dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "stream": False,
+        }
+        if tools and not self._skip_tools:
+            body["tools"] = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": t["name"],
+                        "description": t["description"],
+                        "parameters": t["input_schema"],
+                    },
+                }
+                for t in tools
+            ]
+
+        resp = requests.post(
+            f"{self.host}/api/chat", json=body, timeout=self.timeout
+        )
+        try:
+            _raise_with_body(resp, "/api/chat")
+        except requests.HTTPError as e:
+            # If Ollama rejected the request because the model doesn't
+            # support tools, retry once without them and latch the
+            # decision so subsequent turns don't repeat the failed
+            # round trip. We also warn so the user knows the agent is
+            # operating without its tool surface.
+            if (
+                "does not support tools" in str(e).lower()
+                and "tools" in body
+            ):
+                logger.warning(
+                    "ollama model %r does not support tools; retrying "
+                    "without (subsequent turns in this session will skip "
+                    "tools too — pyagent's agent loop relies on tools, so "
+                    "consider switching to a tool-capable model)",
+                    self.model,
+                )
+                self._skip_tools = True
+                body.pop("tools")
+                resp = requests.post(
+                    f"{self.host}/api/chat",
+                    json=body,
+                    timeout=self.timeout,
+                )
+                _raise_with_body(resp, "/api/chat")
+            else:
+                raise
+        data = resp.json()
+
+        message = data.get("message") or {}
+        text = message.get("content") or ""
+        raw_calls = message.get("tool_calls") or []
+        tool_calls: list[dict[str, Any]] = []
+        for i, tc in enumerate(raw_calls):
+            fn = tc.get("function") or {}
+            args = fn.get("arguments")
+            if isinstance(args, str):
+                # Some Ollama versions/models hand back JSON-stringified
+                # arguments; normalise to dict so the agent sees a
+                # uniform shape regardless of model quirks.
+                try:
+                    args = json.loads(args)
+                except json.JSONDecodeError:
+                    args = {"_raw": args}
+            tool_calls.append(
+                {
+                    "id": tc.get("id") or f"call_{i}",
+                    "name": fn.get("name") or "",
+                    "args": args or {},
+                }
+            )
+
+        return {
+            "role": "assistant",
+            "text": text,
+            "tool_calls": tool_calls,
+            "usage": {
+                "input": int(data.get("prompt_eval_count") or 0),
+                "output": int(data.get("eval_count") or 0),
+                "cache_creation": 0,
+                "cache_read": 0,
+                "model": self.provider_model,
+            },
+        }
+
+    @staticmethod
+    def _to_ollama(message: dict[str, Any]) -> list[dict[str, Any]]:
+        if message["role"] == "user":
+            if "tool_results" in message:
+                # Ollama's tool-result wire shape is just role="tool"
+                # with content; tool_name is a hint that newer models
+                # honor and older ones ignore safely.
+                return [
+                    {
+                        "role": "tool",
+                        "tool_name": r.get("name", ""),
+                        "content": r.get("content") or "",
+                    }
+                    for r in message["tool_results"]
+                ]
+            return [{"role": "user", "content": message["content"]}]
+
+        # assistant — content is required even when only tool_calls
+        # are present, so default to "" rather than omitting.
+        msg: dict[str, Any] = {
+            "role": "assistant",
+            "content": message.get("text") or "",
+        }
+        if message.get("tool_calls"):
+            msg["tool_calls"] = [
+                {
+                    "function": {
+                        "name": tc["name"],
+                        "arguments": tc["args"],
+                    },
+                }
+                for tc in message["tool_calls"]
+            ]
+        return [msg]

--- a/pyagent/plugins/ollama/client.py
+++ b/pyagent/plugins/ollama/client.py
@@ -107,6 +107,23 @@ def list_models(host: str | None = None, timeout: float = 30) -> list[dict[str, 
     return models
 
 
+def show_model(
+    name: str, host: str | None = None, timeout: float = 30
+) -> dict[str, Any]:
+    """Return the parsed ``POST /api/show`` payload for one model.
+
+    Used to extract capability tags (``"tools"``, ``"vision"``,
+    ``"embedding"``, ...) — Ollama 0.5+ surfaces these in the
+    ``capabilities`` array. Older servers return this field empty,
+    so callers must treat the absence of capabilities as
+    "unknown", not "none".
+    """
+    url = f"{(host or _resolve_host()).rstrip('/')}/api/show"
+    resp = requests.post(url, json={"name": name}, timeout=timeout)
+    _raise_with_body(resp, "/api/show")
+    return resp.json()
+
+
 class OllamaClient:
     """Wraps a local Ollama HTTP server in the pyagent LLMClient interface.
 

--- a/pyagent/plugins/ollama/manifest.toml
+++ b/pyagent/plugins/ollama/manifest.toml
@@ -1,0 +1,17 @@
+name = "ollama"
+version = "0.1.0"
+description = "Ollama LLM provider — talks to a local Ollama server via its native HTTP API."
+api_version = "1"
+
+# Registers the `ollama` provider so `--model ollama/<name>` routes
+# through `/api/chat`, plus a `list_ollama_models` tool the agent can
+# call to see what's been pulled locally.
+[provides]
+providers = ["ollama"]
+tools = ["list_ollama_models"]
+
+# Stateless and lazy — no SDK, no network at load time. A stopped or
+# missing Ollama server only surfaces on first call, so loading this
+# plugin never blocks pyagent startup.
+[load]
+in_subagents = true

--- a/tests/smoke_list_models.py
+++ b/tests/smoke_list_models.py
@@ -5,7 +5,7 @@ Concerns:
 
   1. **Built-in providers carry hardcoded canonical lists.** Each
      of anthropic / openai / gemini / pyagent must return a non-empty
-     `list[str]` from `list_models()` and include its own
+     `list[ModelInfo]` from `list_models()` and include its own
      `default_model` so the CLI can flag the active default.
   2. **Aggregator surfaces both pools.** `llms.list_all_models()`
      walks built-ins in PROVIDERS order, then plugin providers in
@@ -17,6 +17,12 @@ Concerns:
   4. **Plugin hook plumbs through.** `register_provider(...,
      list_models=...)` from a plugin lands on the resulting
      `ProviderSpec` after `plugins.load()`.
+  5. **CLI prints and exits 0.** `pyagent --list-models` invokes
+     the renderer, marks defaults, surfaces per-model capability
+     tags, and never reaches model resolution / session start.
+     Tested via click's CliRunner with no env keys present so a
+     normal launch would have errored on missing keys — proves the
+     exit short-circuits before resolution.
 
 Run with:
 
@@ -25,9 +31,18 @@ Run with:
 
 from __future__ import annotations
 
+import tempfile
 from pathlib import Path
+from unittest import mock
 
-from pyagent import llms, plugins
+from click.testing import CliRunner
+
+from pyagent import (
+    cli as cli_mod,
+    llms,
+    paths as paths_mod,
+    plugins,
+)
 
 
 def _check(label: str, cond: bool, detail: str = "") -> None:
@@ -39,8 +54,9 @@ def _check(label: str, cond: bool, detail: str = "") -> None:
 
 
 def _check_builtin_canonical_lists() -> None:
-    """Each built-in returns a non-empty list that includes its
-    default — the CLI relies on the default to render `(default)`."""
+    """Each built-in returns a non-empty list of `ModelInfo` records
+    that includes its default — the CLI relies on the default to
+    render `(default)`."""
     for spec in llms.PROVIDERS:
         _check(
             f"{spec.name} has list_models callable",
@@ -53,9 +69,15 @@ def _check_builtin_canonical_lists() -> None:
             repr(models),
         )
         _check(
+            f"{spec.name} entries are ModelInfo",
+            all(isinstance(m, llms.ModelInfo) for m in models),
+            repr(models),
+        )
+        names = [m.name for m in models]
+        _check(
             f"{spec.name} default ({spec.default_model!r}) is in its own list",
-            spec.default_model in models,
-            f"default={spec.default_model!r} list={models}",
+            spec.default_model in names,
+            f"default={spec.default_model!r} list={names}",
         )
 
 
@@ -152,7 +174,10 @@ def _check_plugin_list_models_hook_plumbs_through() -> None:
         source=Path("/dev/null"),
     )
     api = PluginAPI(_PluginState(manifest=m))
-    sentinel_models = ["alpha", "beta"]
+    sentinel_models = [
+        llms.ModelInfo(name="alpha", capabilities=("tools",)),
+        llms.ModelInfo(name="beta"),
+    ]
     api.register_provider(
         "hooky",
         lambda **kw: None,
@@ -168,11 +193,146 @@ def _check_plugin_list_models_hook_plumbs_through() -> None:
     )
 
 
+class _FakeResponse:
+    """Minimal `requests.Response` stand-in used by the CLI fixture.
+
+    The ollama client's `_raise_with_body` reads `ok` before
+    deciding whether to raise, so we expose it here. Tests for the
+    error-path live in `smoke_ollama_plugin.py`; this fixture only
+    needs the success-shape surface.
+    """
+
+    status_code = 200
+    ok = True
+
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+
+    def json(self) -> dict:
+        return self._payload
+
+    @property
+    def text(self) -> str:
+        import json as _json
+        return _json.dumps(self._payload)
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+def _check_cli_prints_and_exits() -> None:
+    """`pyagent --list-models` runs in a clean env and prints every
+    built-in plus the loaded plugin providers — without going
+    anywhere near `_resolve_model`. Test under an empty env so a
+    normal launch would have UsageError'd on missing keys.
+
+    The CLI runs its own `plugins.load()` internally, so we patch
+    the underlying ``requests`` in the ollama client module — that
+    way the live `list_models` callable resolves to a stable fixture
+    no matter how many times the spec is rebuilt.
+
+    Two mocked calls per ollama model: `/api/tags` (one GET) and one
+    `/api/show` POST per model returned. The `/api/show` fixture
+    populates a ``capabilities`` array so we can verify capability
+    tags render in the CLI output and the no-tools warning fires for
+    a model without ``tools`` in its capability list.
+    """
+    from pyagent.plugins.ollama import client as ollama_client_mod
+
+    runner = CliRunner()
+    tmp = Path(tempfile.mkdtemp(prefix="pyagent-smoke-listmodels-"))
+    fake_tags = _FakeResponse(
+        {
+            "models": [
+                {"name": "fake-tools:1b"},
+                {"name": "fake-vision:11b"},
+            ]
+        }
+    )
+
+    def fake_show(url, json=None, timeout=None):
+        # Distinct capability arrays per model so the renderer can
+        # exercise both the tool-capable and no-tools branches.
+        name = (json or {}).get("name", "")
+        caps = ["tools", "completion"] if "tools" in name else ["vision", "completion"]
+        return _FakeResponse({"capabilities": caps})
+
+    with mock.patch.object(paths_mod, "config_dir", return_value=tmp):
+        with mock.patch.object(
+            plugins, "LOCAL_PLUGINS_DIR", Path(tmp / "no_local_plugins")
+        ):
+            with mock.patch.object(
+                ollama_client_mod.requests, "get", return_value=fake_tags
+            ):
+                with mock.patch.object(
+                    ollama_client_mod.requests,
+                    "post",
+                    side_effect=fake_show,
+                ):
+                    # Empty env so the test doesn't depend on what's
+                    # set in the host environment — also forces
+                    # _resolve_host to fall back to localhost default.
+                    result = runner.invoke(
+                        cli_mod.main,
+                        ["--list-models"],
+                        env={
+                            "ANTHROPIC_API_KEY": "",
+                            "OPENAI_API_KEY": "",
+                            "GEMINI_API_KEY": "",
+                            "GOOGLE_API_KEY": "",
+                            "OLLAMA_HOST": "",
+                            "OLLAMA_MODEL": "",
+                        },
+                    )
+
+    _check(
+        "exit code 0",
+        result.exit_code == 0,
+        f"code={result.exit_code} output={result.output!r}",
+    )
+    out = result.output
+    _check("header printed", "Available models" in out, out)
+    _check("anthropic block printed", "anthropic" in out, out)
+    _check("default tag printed somewhere", "(default)" in out, out)
+    _check("plugin tag printed", "(plugin)" in out, out)
+    _check(
+        "stubbed ollama tool-capable model surfaces in output",
+        "fake-tools:1b" in out,
+        out,
+    )
+    _check(
+        "stubbed ollama vision model surfaces in output",
+        "fake-vision:11b" in out,
+        out,
+    )
+    _check(
+        "tools capability tag rendered",
+        "(tools)" in out,
+        out,
+    )
+    _check(
+        "vision capability tag rendered",
+        "(vision)" in out,
+        out,
+    )
+    _check(
+        "no-tools warning rendered for vision model",
+        "no tools — chat only" in out,
+        out,
+    )
+    _check(
+        "boring `completion` capability filtered out of output",
+        "completion" not in out,
+        out,
+    )
+
+
 def main() -> None:
     _check_builtin_canonical_lists()
     _check_aggregator_walks_both_pools()
     _check_failing_provider_renders_error()
     _check_plugin_list_models_hook_plumbs_through()
+    _check_cli_prints_and_exits()
     print("smoke_list_models: all checks passed")
 
 

--- a/tests/smoke_list_models.py
+++ b/tests/smoke_list_models.py
@@ -1,0 +1,180 @@
+"""End-to-end smoke for `pyagent --list-models` and the
+`ProviderSpec.list_models` protocol it sits on top of.
+
+Concerns:
+
+  1. **Built-in providers carry hardcoded canonical lists.** Each
+     of anthropic / openai / gemini / pyagent must return a non-empty
+     `list[str]` from `list_models()` and include its own
+     `default_model` so the CLI can flag the active default.
+  2. **Aggregator surfaces both pools.** `llms.list_all_models()`
+     walks built-ins in PROVIDERS order, then plugin providers in
+     registration order. Plugins without a `list_models` callable
+     surface as a `ProviderListing` with empty `models`.
+  3. **Per-provider failures don't kill the listing.** A provider
+     whose `list_models` raises produces a `ProviderListing` with
+     `error=<reason>` and the rest of the catalog still renders.
+  4. **Plugin hook plumbs through.** `register_provider(...,
+     list_models=...)` from a plugin lands on the resulting
+     `ProviderSpec` after `plugins.load()`.
+
+Run with:
+
+    .venv/bin/python -m tests.smoke_list_models
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pyagent import llms, plugins
+
+
+def _check(label: str, cond: bool, detail: str = "") -> None:
+    sym = "✓" if cond else "✗"
+    extra = f" — {detail}" if detail else ""
+    print(f"{sym} {label}{extra}")
+    if not cond:
+        raise SystemExit(1)
+
+
+def _check_builtin_canonical_lists() -> None:
+    """Each built-in returns a non-empty list that includes its
+    default — the CLI relies on the default to render `(default)`."""
+    for spec in llms.PROVIDERS:
+        _check(
+            f"{spec.name} has list_models callable",
+            spec.list_models is not None,
+        )
+        models = spec.list_models()
+        _check(
+            f"{spec.name} list non-empty",
+            isinstance(models, list) and len(models) > 0,
+            repr(models),
+        )
+        _check(
+            f"{spec.name} default ({spec.default_model!r}) is in its own list",
+            spec.default_model in models,
+            f"default={spec.default_model!r} list={models}",
+        )
+
+
+def _check_aggregator_walks_both_pools() -> None:
+    """`list_all_models` returns built-ins in PROVIDERS order, then
+    plugin providers — and includes every loaded plugin provider."""
+    plugins.load()
+    listings = llms.list_all_models()
+    names = [l.name for l in listings]
+
+    builtin_names = [p.name for p in llms.PROVIDERS]
+    _check(
+        "built-ins precede plugins in aggregator output",
+        names[: len(builtin_names)] == builtin_names,
+        repr(names),
+    )
+    for plugin_provider in llms._PLUGIN_PROVIDERS:
+        _check(
+            f"plugin provider {plugin_provider!r} present in aggregator",
+            plugin_provider in names,
+            repr(names),
+        )
+
+
+def _check_failing_provider_renders_error() -> None:
+    """A `list_models` callable that raises must surface as a
+    `ProviderListing.error` so the CLI can render `(unavailable: ...)`
+    without nuking the whole listing."""
+
+    def boom() -> list[str]:
+        raise RuntimeError("kaboom")
+
+    fake_spec = llms.ProviderSpec(
+        name="brokenly",
+        env_vars=(),
+        default_model="x",
+        factory=lambda **kw: None,
+        list_models=boom,
+    )
+    listing = llms._listing_for(fake_spec)
+    _check(
+        "failing list_models → ProviderListing.error populated",
+        listing.error == "kaboom" and listing.models == (),
+        repr(listing),
+    )
+
+    # The aggregator must keep going even when one provider's listing
+    # raises — patch one built-in to fail and verify the rest still
+    # appear.
+    plugins.load()
+    original = llms.PROVIDERS[0].list_models
+    object.__setattr__(llms.PROVIDERS[0], "list_models", boom)
+    try:
+        listings = llms.list_all_models()
+    finally:
+        object.__setattr__(llms.PROVIDERS[0], "list_models", original)
+    by_name = {l.name: l for l in listings}
+    _check(
+        "broken provider entry has error",
+        by_name[llms.PROVIDERS[0].name].error == "kaboom",
+        repr(by_name[llms.PROVIDERS[0].name]),
+    )
+    _check(
+        "siblings still rendered after a sibling fails",
+        all(
+            l.name in by_name
+            for l in listings
+            if l.name != llms.PROVIDERS[0].name
+        ),
+    )
+
+
+def _check_plugin_list_models_hook_plumbs_through() -> None:
+    """A plugin that calls `register_provider(..., list_models=...)`
+    sees that callable land on its `ProviderSpec` after load()."""
+    from pyagent.plugins import (
+        Manifest,
+        PluginAPI,
+        _PluginState,
+    )
+
+    m = Manifest(
+        name="hooky",
+        version="0",
+        description="",
+        api_version="1",
+        provides_tools=(),
+        provides_prompt_sections=(),
+        provides_providers=("hooky",),
+        requires_python="",
+        requires_env=(),
+        requires_binaries=(),
+        in_subagents=True,
+        source=Path("/dev/null"),
+    )
+    api = PluginAPI(_PluginState(manifest=m))
+    sentinel_models = ["alpha", "beta"]
+    api.register_provider(
+        "hooky",
+        lambda **kw: None,
+        default_model="alpha",
+        list_models=lambda: sentinel_models,
+    )
+    rec = api._state.providers["hooky"]
+    _check(
+        "_RegisteredProvider carries list_models",
+        rec.list_models is not None
+        and rec.list_models() == sentinel_models,
+        repr(rec),
+    )
+
+
+def main() -> None:
+    _check_builtin_canonical_lists()
+    _check_aggregator_walks_both_pools()
+    _check_failing_provider_renders_error()
+    _check_plugin_list_models_hook_plumbs_through()
+    print("smoke_list_models: all checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/smoke_ollama_plugin.py
+++ b/tests/smoke_ollama_plugin.py
@@ -522,6 +522,118 @@ def _check_http_error_surfaces_ollama_body() -> None:
             _check("HTTPError raised on 502 with HTML body", False)
 
 
+def _check_provider_list_models_hook() -> None:
+    """The ollama provider exposes a `list_models` callable on its
+    ProviderSpec — that's how `pyagent --list-models` discovers what
+    a remote Ollama has pulled, and how it tags each model's
+    capabilities."""
+    plugins.load()
+    spec = llms._PLUGIN_PROVIDERS["ollama"]
+    _check(
+        "ollama ProviderSpec carries list_models",
+        spec.list_models is not None,
+    )
+
+    tags_payload = {
+        "models": [
+            {"name": "llama3.2:latest"},
+            {"name": "llava:7b"},
+            {"name": ""},  # filtered: blank-name entries dropped
+        ]
+    }
+
+    def fake_post(url, json=None, timeout=None):
+        # /api/show payload — capabilities array varies per model so
+        # we exercise both the tool and vision tag paths plus the
+        # ``completion`` filter.
+        name = (json or {}).get("name", "")
+        if "llama3.2" in name:
+            return _FakeResponse(
+                {"capabilities": ["completion", "tools"]}
+            )
+        if "llava" in name:
+            return _FakeResponse(
+                {"capabilities": ["completion", "vision"]}
+            )
+        return _FakeResponse({"capabilities": []})
+
+    with mock.patch.object(
+        ollama_client_mod.requests,
+        "get",
+        return_value=_FakeResponse(tags_payload),
+    ):
+        with mock.patch.object(
+            ollama_client_mod.requests, "post", side_effect=fake_post
+        ):
+            infos = spec.list_models()
+
+    _check(
+        "list_models returns ModelInfo records",
+        all(isinstance(m, llms.ModelInfo) for m in infos),
+        repr(infos),
+    )
+    by_name = {m.name: m for m in infos}
+    _check(
+        "blank-name entries filtered",
+        list(by_name) == ["llama3.2:latest", "llava:7b"],
+        repr(list(by_name)),
+    )
+    _check(
+        "tool-capable model gets ('tools',) capability",
+        by_name["llama3.2:latest"].capabilities == ("tools",),
+        repr(by_name["llama3.2:latest"]),
+    )
+    _check(
+        "vision model gets ('vision',) capability",
+        by_name["llava:7b"].capabilities == ("vision",),
+        repr(by_name["llava:7b"]),
+    )
+
+    # An /api/show failure for one model must not blank capabilities
+    # for siblings — the model still appears, just without tags.
+    def half_broken(url, json=None, timeout=None):
+        if (json or {}).get("name") == "llava:7b":
+            raise ConnectionError("model gone")
+        return _FakeResponse({"capabilities": ["tools"]})
+
+    with mock.patch.object(
+        ollama_client_mod.requests,
+        "get",
+        return_value=_FakeResponse(tags_payload),
+    ):
+        with mock.patch.object(
+            ollama_client_mod.requests, "post", side_effect=half_broken
+        ):
+            infos = spec.list_models()
+    by_name = {m.name: m for m in infos}
+    _check(
+        "per-model show failure leaves the model in the list",
+        "llava:7b" in by_name,
+        repr(list(by_name)),
+    )
+    _check(
+        "per-model show failure → empty capabilities, not raise",
+        by_name["llava:7b"].capabilities == (),
+        repr(by_name["llava:7b"]),
+    )
+
+    # The initial /api/tags failure does still raise — that's the
+    # signal the aggregator turns into "(unavailable: ...)".
+    def boom(*a, **kw):
+        raise ConnectionError("refused")
+
+    with mock.patch.object(ollama_client_mod.requests, "get", side_effect=boom):
+        try:
+            spec.list_models()
+        except ConnectionError as e:
+            _check(
+                "list_models raises on /api/tags connection failure",
+                "refused" in str(e),
+            )
+        else:
+            _check("list_models raised on /api/tags failure", False)
+
+
 def _check_no_tools_auto_retry() -> None:
     """When a model 400s with `does not support tools`, the client
     must transparently retry without tools, latch the decision so
@@ -648,6 +760,7 @@ def main() -> None:
     _check_list_ollama_models_empty()
     _check_http_error_surfaces_ollama_body()
     _check_no_tools_auto_retry()
+    _check_provider_list_models_hook()
     print("smoke_ollama_plugin: all checks passed")
 
 

--- a/tests/smoke_ollama_plugin.py
+++ b/tests/smoke_ollama_plugin.py
@@ -1,0 +1,655 @@
+"""End-to-end smoke for the bundled `ollama` plugin.
+
+Concerns:
+
+  1. **Default config carries it.** The plugin loads under default
+     ``built_in_plugins_enabled`` and registers the ``ollama``
+     provider plus the ``list_ollama_models`` tool — no env, no
+     network.
+  2. **Lazy network.** Plugin load and ``OllamaClient.__init__`` are
+     network-free; only ``respond()`` and ``list_ollama_models`` ever
+     hit the wire. Verified by leaving ``requests`` un-mocked during
+     load and only patching for the call paths.
+  3. **Provider routing wires up.** ``get_client("ollama/<name>")``
+     returns an ``OllamaClient`` whose ``provider_model`` is
+     ``ollama/<name>``. ``get_client("ollama")`` (no model) raises a
+     clear, action-oriented error so users with no ``OLLAMA_MODEL``
+     get a useful message at call time instead of a silent default.
+  4. **OLLAMA_MODEL feeds the spec.** When the env is set,
+     ``resolve_model("ollama")`` fills the default; when unset, it
+     resolves to ``"ollama/"`` and the factory raises.
+  5. **Wire shape is right.** ``respond()`` translates pyagent's
+     internal conversation into Ollama's ``/api/chat`` JSON: system
+     prefix, user/assistant/tool roles, ``tools`` block, ``stream:
+     False``. The response path synthesizes ``call_<i>`` ids,
+     normalises JSON-string arguments, and surfaces token counts.
+  6. **OLLAMA_HOST normalisation.** Bare ``host:port`` upgrades to
+     ``http://host:port`` and a trailing slash is stripped — matches
+     what the Ollama CLI accepts.
+  7. **list_ollama_models formatting.** Tags response renders as
+     markdown bullets with size; an unreachable server yields the
+     ``<ollama error: ...>`` marker rather than raising.
+  8. **HTTP error body propagates.** A 4xx from ``/api/chat`` carries
+     Ollama's JSON ``error`` body into the raised ``HTTPError`` so
+     callers see the actual cause, not just a bare status code.
+  9. **No-tools auto-retry.** When a model 400s with ``does not
+     support tools``, the client transparently retries without tools,
+     latches ``_skip_tools`` so subsequent turns skip the failed
+     round trip, and propagates non-tools 4xx errors unchanged.
+
+Run with:
+
+    .venv/bin/python -m tests.smoke_ollama_plugin
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+from pyagent import (
+    config as config_mod,
+    llms,
+    paths as paths_mod,
+    plugins,
+)
+from pyagent.llms import get_client, resolve_model
+from pyagent.plugins.ollama import client as ollama_client_mod
+
+
+def _check(label: str, cond: bool, detail: str = "") -> None:
+    sym = "✓" if cond else "✗"
+    extra = f" — {detail}" if detail else ""
+    print(f"{sym} {label}{extra}")
+    if not cond:
+        raise SystemExit(1)
+
+
+def _check_default_config_lists_ollama() -> None:
+    """`ollama` is shipped in built_in_plugins_enabled."""
+    tmp = Path(tempfile.mkdtemp(prefix="pyagent-smoke-ollama-"))
+    with mock.patch.object(paths_mod, "config_dir", return_value=tmp):
+        with mock.patch.object(
+            plugins, "LOCAL_PLUGINS_DIR", Path(tmp / "no_local_plugins")
+        ):
+            cfg = config_mod.load()
+    _check(
+        "ollama in built_in_plugins_enabled",
+        "ollama" in cfg["built_in_plugins_enabled"],
+        repr(cfg["built_in_plugins_enabled"]),
+    )
+
+
+def _check_plugin_loads_and_registers() -> None:
+    """Plugin loads under default config; provider + tool register;
+    no network is touched during load."""
+    tmp = Path(tempfile.mkdtemp(prefix="pyagent-smoke-ollama-"))
+    # Patch requests inside the ollama client module to a sentinel
+    # that raises if called — proves load() never hits the wire.
+    sentinel = mock.MagicMock(side_effect=AssertionError("network during load"))
+    with mock.patch.object(paths_mod, "config_dir", return_value=tmp):
+        with mock.patch.object(
+            plugins, "LOCAL_PLUGINS_DIR", Path(tmp / "no_local_plugins")
+        ):
+            with mock.patch.object(ollama_client_mod, "requests", sentinel):
+                # Also ensure OLLAMA_MODEL isn't set so default_model="".
+                with mock.patch.dict("os.environ", {}, clear=False):
+                    import os as _os
+                    _os.environ.pop("OLLAMA_MODEL", None)
+                    loaded = plugins.load()
+
+    plugin_names = [s.manifest.name for s in loaded.states]
+    _check("ollama plugin loaded", "ollama" in plugin_names, repr(plugin_names))
+    _check(
+        "ollama in LoadedPlugins.providers()",
+        "ollama" in loaded.providers(),
+        repr(list(loaded.providers())),
+    )
+    _check(
+        "ollama published to llms._PLUGIN_PROVIDERS",
+        "ollama" in llms._PLUGIN_PROVIDERS,
+    )
+    _check(
+        "list_ollama_models tool registered",
+        "list_ollama_models" in loaded.tools(),
+        repr(list(loaded.tools())),
+    )
+
+
+def _check_get_client_with_explicit_model() -> None:
+    plugins.load()
+    client = get_client("ollama/llama3.2")
+    _check(
+        "OllamaClient.provider_model is ollama/llama3.2",
+        client.provider_model == "ollama/llama3.2",
+        client.provider_model,
+    )
+    _check("OllamaClient.model is llama3.2", client.model == "llama3.2")
+
+
+def _check_get_client_without_model_raises() -> None:
+    """`--model ollama` (no slash) with no OLLAMA_MODEL → clear error
+    only at call time, never at load time."""
+    import os as _os
+    saved = _os.environ.pop("OLLAMA_MODEL", None)
+    try:
+        plugins.load()  # must not raise even though no default model
+        raised = False
+        try:
+            get_client("ollama")
+        except ValueError as e:
+            raised = True
+            msg = str(e)
+            _check(
+                "missing-model error mentions OLLAMA_MODEL",
+                "OLLAMA_MODEL" in msg,
+                msg,
+            )
+            _check(
+                "missing-model error mentions list_ollama_models",
+                "list_ollama_models" in msg,
+                msg,
+            )
+        _check("get_client('ollama') raised when no default", raised)
+    finally:
+        if saved is not None:
+            _os.environ["OLLAMA_MODEL"] = saved
+
+
+def _check_ollama_model_env_feeds_default() -> None:
+    """`OLLAMA_MODEL=foo` → resolve_model('ollama') == 'ollama/foo'."""
+    import os as _os
+    saved = _os.environ.get("OLLAMA_MODEL")
+    _os.environ["OLLAMA_MODEL"] = "qwen2.5"
+    try:
+        plugins.load()
+        resolved = resolve_model("ollama")
+        _check(
+            "resolve_model('ollama') honors OLLAMA_MODEL",
+            resolved == "ollama/qwen2.5",
+            resolved,
+        )
+    finally:
+        if saved is None:
+            _os.environ.pop("OLLAMA_MODEL", None)
+        else:
+            _os.environ["OLLAMA_MODEL"] = saved
+    # Re-load with env unset so later tests see a clean default.
+    _os.environ.pop("OLLAMA_MODEL", None)
+    plugins.load()
+
+
+def _check_resolve_host_normalises() -> None:
+    import os as _os
+    saved = _os.environ.get("OLLAMA_HOST")
+
+    _os.environ["OLLAMA_HOST"] = "remote-box:11434"
+    _check(
+        "OLLAMA_HOST without scheme upgrades to http://",
+        ollama_client_mod._resolve_host() == "http://remote-box:11434",
+        ollama_client_mod._resolve_host(),
+    )
+
+    _os.environ["OLLAMA_HOST"] = "https://ollama.example.com/"
+    _check(
+        "trailing slash stripped",
+        ollama_client_mod._resolve_host() == "https://ollama.example.com",
+        ollama_client_mod._resolve_host(),
+    )
+
+    _os.environ.pop("OLLAMA_HOST", None)
+    _check(
+        "default host when env unset",
+        ollama_client_mod._resolve_host() == "http://localhost:11434",
+        ollama_client_mod._resolve_host(),
+    )
+
+    if saved is None:
+        _os.environ.pop("OLLAMA_HOST", None)
+    else:
+        _os.environ["OLLAMA_HOST"] = saved
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        payload: dict | None = None,
+        status_code: int = 200,
+        text: str | None = None,
+    ) -> None:
+        self._payload = payload
+        self.status_code = status_code
+        # `text` overrides JSON for cases where the body isn't valid
+        # JSON — exercises the fallback in `_raise_with_body`.
+        self._text = text
+
+    @property
+    def ok(self) -> bool:
+        return self.status_code < 400
+
+    @property
+    def text(self) -> str:
+        if self._text is not None:
+            return self._text
+        if self._payload is None:
+            return ""
+        import json as _json
+        return _json.dumps(self._payload)
+
+    def json(self) -> dict:
+        if self._payload is None:
+            raise ValueError("no JSON body")
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+def _check_respond_request_shape_and_response_parse() -> None:
+    """End-to-end mocked turn — verifies request body and response
+    parsing including tool-call id synthesis and string-args
+    normalisation."""
+    captured: dict = {}
+
+    def fake_post(url, json=None, timeout=None):
+        captured["url"] = url
+        captured["body"] = json
+        captured["timeout"] = timeout
+        return _FakeResponse(
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "thinking…",
+                    "tool_calls": [
+                        {
+                            "function": {
+                                "name": "lookup",
+                                # Stringified arguments — older models do this.
+                                "arguments": '{"q": "weather"}',
+                            }
+                        },
+                        {
+                            "function": {
+                                "name": "noop",
+                                "arguments": {"x": 1},
+                            }
+                        },
+                    ],
+                },
+                "prompt_eval_count": 42,
+                "eval_count": 7,
+            }
+        )
+
+    client = ollama_client_mod.OllamaClient(model="llama3.2", host="http://h:1")
+    with mock.patch.object(ollama_client_mod.requests, "post", side_effect=fake_post):
+        out = client.respond(
+            conversation=[
+                {"role": "user", "content": "hello"},
+                {
+                    "role": "assistant",
+                    "text": "calling lookup",
+                    "tool_calls": [
+                        {"id": "abc", "name": "lookup", "args": {"q": "weather"}}
+                    ],
+                },
+                {
+                    "role": "user",
+                    "tool_results": [
+                        {"id": "abc", "name": "lookup", "content": "sunny"}
+                    ],
+                },
+            ],
+            system="STABLE",
+            system_volatile="VOL",
+            tools=[
+                {
+                    "name": "lookup",
+                    "description": "Look stuff up",
+                    "input_schema": {"type": "object", "properties": {}},
+                }
+            ],
+        )
+
+    body = captured["body"]
+    _check("POST hit /api/chat", captured["url"].endswith("/api/chat"), captured["url"])
+    _check("stream is False", body["stream"] is False)
+    _check("model carried through", body["model"] == "llama3.2", body["model"])
+
+    msgs = body["messages"]
+    _check(
+        "system block prefixes conversation",
+        msgs[0] == {"role": "system", "content": "STABLE\n\nVOL"},
+        repr(msgs[0]),
+    )
+    _check("user message present", msgs[1] == {"role": "user", "content": "hello"})
+    _check("assistant content carried", msgs[2]["role"] == "assistant")
+    _check(
+        "assistant tool_calls translated",
+        msgs[2]["tool_calls"][0]["function"]["name"] == "lookup",
+        repr(msgs[2]),
+    )
+    _check(
+        "tool result becomes role=tool",
+        msgs[3]["role"] == "tool" and msgs[3]["tool_name"] == "lookup",
+        repr(msgs[3]),
+    )
+    _check(
+        "tools block formatted as openai-shaped function decls",
+        body["tools"][0]["function"]["name"] == "lookup",
+        repr(body["tools"]),
+    )
+
+    _check("response text parsed", out["text"] == "thinking…", repr(out["text"]))
+    _check("two tool_calls returned", len(out["tool_calls"]) == 2)
+    _check(
+        "first call id synthesized as call_0",
+        out["tool_calls"][0]["id"] == "call_0",
+        repr(out["tool_calls"][0]),
+    )
+    _check(
+        "stringified arguments normalised to dict",
+        out["tool_calls"][0]["args"] == {"q": "weather"},
+        repr(out["tool_calls"][0]["args"]),
+    )
+    _check(
+        "dict arguments passed through unchanged",
+        out["tool_calls"][1]["args"] == {"x": 1},
+        repr(out["tool_calls"][1]["args"]),
+    )
+    _check(
+        "usage carries token counts",
+        out["usage"]["input"] == 42 and out["usage"]["output"] == 7,
+        repr(out["usage"]),
+    )
+    _check(
+        "usage cache fields zeroed (no Ollama prompt cache)",
+        out["usage"]["cache_creation"] == 0 and out["usage"]["cache_read"] == 0,
+    )
+    _check(
+        "usage.model is provider/model",
+        out["usage"]["model"] == "ollama/llama3.2",
+        out["usage"]["model"],
+    )
+
+
+def _check_list_ollama_models_formatting() -> None:
+    payload = {
+        "models": [
+            {"name": "llama3.2:latest", "size": 2 * 1024**3},
+            {"name": "qwen2.5:1.5b", "size": 950 * 1024**2},
+            {"name": "tiny", "size": 0},
+        ]
+    }
+    from pyagent.plugins.ollama import register as register_plugin
+
+    captured: dict = {}
+
+    class _FakeAPI:
+        def register_provider(self, *a, **kw):
+            pass
+
+        def register_tool(self, name, fn):
+            captured[name] = fn
+
+    register_plugin(_FakeAPI())
+    list_tool = captured["list_ollama_models"]
+
+    with mock.patch.object(
+        ollama_client_mod.requests,
+        "get",
+        return_value=_FakeResponse(payload),
+    ):
+        out = list_tool()
+    _check("output is markdown bullets", out.startswith("- "), repr(out))
+    _check("size in GB rendered", "2.0 GB" in out, out)
+    _check("size in MB rendered", "950 MB" in out, out)
+    _check("zero-size omits parenthetical", out.rstrip().endswith("- tiny"), out)
+
+
+def _check_list_ollama_models_error_path() -> None:
+    from pyagent.plugins.ollama import register as register_plugin
+
+    captured: dict = {}
+
+    class _FakeAPI:
+        def register_provider(self, *a, **kw):
+            pass
+
+        def register_tool(self, name, fn):
+            captured[name] = fn
+
+    register_plugin(_FakeAPI())
+    list_tool = captured["list_ollama_models"]
+
+    def boom(*a, **kw):
+        raise ConnectionError("connection refused")
+
+    with mock.patch.object(ollama_client_mod.requests, "get", side_effect=boom):
+        out = list_tool()
+    _check(
+        "unreachable server → <ollama error: ...> marker",
+        out.startswith("<ollama error:") and "connection refused" in out,
+        out,
+    )
+
+
+def _check_list_ollama_models_empty() -> None:
+    from pyagent.plugins.ollama import register as register_plugin
+
+    captured: dict = {}
+
+    class _FakeAPI:
+        def register_provider(self, *a, **kw):
+            pass
+
+        def register_tool(self, name, fn):
+            captured[name] = fn
+
+    register_plugin(_FakeAPI())
+    list_tool = captured["list_ollama_models"]
+
+    with mock.patch.object(
+        ollama_client_mod.requests,
+        "get",
+        return_value=_FakeResponse({"models": []}),
+    ):
+        out = list_tool()
+    _check(
+        "empty server → <no models installed> marker",
+        out.strip() == "<no models installed>",
+        out,
+    )
+
+
+def _check_http_error_surfaces_ollama_body() -> None:
+    """A 400 from `/api/chat` must carry Ollama's `error` body into
+    the raised exception. Without this, vision/embedding models that
+    reject the `tools` field surface as a bare HTTP 400 with no clue
+    about the cause."""
+    import requests as _requests
+
+    fail = _FakeResponse(
+        payload={"error": "registry/llama3.2-vision:11b does not support tools"},
+        status_code=400,
+    )
+    client = ollama_client_mod.OllamaClient(model="llama3.2-vision:11b")
+    with mock.patch.object(
+        ollama_client_mod.requests, "post", return_value=fail
+    ):
+        try:
+            client.respond(conversation=[{"role": "user", "content": "hi"}])
+        except _requests.HTTPError as e:
+            msg = str(e)
+            _check(
+                "exception message includes Ollama's error string",
+                "does not support tools" in msg,
+                msg,
+            )
+            _check(
+                "exception message names the endpoint",
+                "/api/chat" in msg,
+                msg,
+            )
+            _check(
+                "exception message names the status code",
+                "400" in msg,
+                msg,
+            )
+        else:
+            _check("HTTPError raised on 400", False)
+
+    # Non-JSON body (e.g. nginx HTML error page) falls back to the
+    # raw text rather than blowing up.
+    fail_html = _FakeResponse(
+        payload=None, status_code=502, text="<html>bad gateway</html>"
+    )
+    with mock.patch.object(
+        ollama_client_mod.requests, "get", return_value=fail_html
+    ):
+        try:
+            ollama_client_mod.list_models()
+        except _requests.HTTPError as e:
+            _check(
+                "non-JSON body falls back to raw text in error",
+                "bad gateway" in str(e),
+                str(e),
+            )
+        else:
+            _check("HTTPError raised on 502 with HTML body", False)
+
+
+def _check_no_tools_auto_retry() -> None:
+    """When a model 400s with `does not support tools`, the client
+    must transparently retry without tools, latch the decision so
+    later turns skip tools, and not double-fail on success."""
+    import copy as _copy
+
+    import requests as _requests
+
+    error_resp = _FakeResponse(
+        payload={"error": "model llava:7b does not support tools"},
+        status_code=400,
+    )
+    success_resp = _FakeResponse(
+        payload={
+            "message": {"role": "assistant", "content": "ok", "tool_calls": []},
+            "prompt_eval_count": 1,
+            "eval_count": 1,
+        }
+    )
+
+    posts: list[dict] = []
+
+    def fake_post(url, json=None, timeout=None):
+        # Deep-copy: respond() mutates the dict in place during the
+        # tools-stripping retry, so a shallow capture would lose the
+        # pre-mutation state.
+        posts.append(_copy.deepcopy(json))
+        if "tools" in (json or {}):
+            return error_resp
+        return success_resp
+
+    client = ollama_client_mod.OllamaClient(model="llava:7b")
+    with mock.patch.object(
+        ollama_client_mod.requests, "post", side_effect=fake_post
+    ):
+        out = client.respond(
+            conversation=[{"role": "user", "content": "hi"}],
+            tools=[
+                {
+                    "name": "noop",
+                    "description": "x",
+                    "input_schema": {"type": "object", "properties": {}},
+                }
+            ],
+        )
+    _check(
+        "first turn: two POSTs (tools then retry)",
+        len(posts) == 2,
+        repr(posts),
+    )
+    _check(
+        "first POST included tools",
+        "tools" in posts[0],
+        repr(posts[0]),
+    )
+    _check(
+        "retry POST stripped tools",
+        "tools" not in posts[1],
+        repr(posts[1]),
+    )
+    _check("retry returned success body", out["text"] == "ok", repr(out))
+    _check(
+        "client latched the no-tools decision",
+        client._skip_tools is True,
+    )
+
+    # Second turn should skip tools up-front (no failed round trip).
+    posts.clear()
+    with mock.patch.object(
+        ollama_client_mod.requests, "post", side_effect=fake_post
+    ):
+        client.respond(
+            conversation=[{"role": "user", "content": "again"}],
+            tools=[
+                {
+                    "name": "noop",
+                    "description": "x",
+                    "input_schema": {"type": "object", "properties": {}},
+                }
+            ],
+        )
+    _check(
+        "second turn: single POST (latch held)",
+        len(posts) == 1,
+        repr(posts),
+    )
+    _check(
+        "second POST has no tools",
+        "tools" not in posts[0],
+        repr(posts[0]),
+    )
+
+    # And a non-tools 400 must still propagate — we don't blanket-
+    # retry every error.
+    other_error = _FakeResponse(
+        payload={"error": "model not found"}, status_code=404
+    )
+    fresh = ollama_client_mod.OllamaClient(model="nope")
+    with mock.patch.object(
+        ollama_client_mod.requests, "post", return_value=other_error
+    ):
+        try:
+            fresh.respond(conversation=[{"role": "user", "content": "x"}])
+        except _requests.HTTPError as e:
+            _check(
+                "non-tools 4xx still propagates",
+                "model not found" in str(e),
+                str(e),
+            )
+        else:
+            _check("non-tools 4xx propagated", False)
+
+
+def main() -> None:
+    _check_default_config_lists_ollama()
+    _check_plugin_loads_and_registers()
+    _check_get_client_with_explicit_model()
+    _check_get_client_without_model_raises()
+    _check_ollama_model_env_feeds_default()
+    _check_resolve_host_normalises()
+    _check_respond_request_shape_and_response_parse()
+    _check_list_ollama_models_formatting()
+    _check_list_ollama_models_error_path()
+    _check_list_ollama_models_empty()
+    _check_http_error_surfaces_ollama_body()
+    _check_no_tools_auto_retry()
+    print("smoke_ollama_plugin: all checks passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds an Ollama provider plugin (zero extra deps — uses `requests`) and a `pyagent --list-models` CLI that aggregates the catalog across every provider. Three logical commits.

### `bc4a6b2` ollama provider plugin
- Bundled drop-in at `pyagent/plugins/ollama/`, enabled by default.
- `--model ollama/<name>`; `OLLAMA_MODEL` for default; `OLLAMA_HOST` (bare host:port auto-prefixed `http://`).
- Lazy: nothing touches the network at register time.
- Auto-retry without tools when a model 400s with `does not support tools` (vision / embedding / no-template variants), with `_skip_tools` latched so subsequent turns skip the failed round trip.
- HTTP error bodies fold into raised `HTTPError` so 4xx/5xx surface their actual cause.
- `list_ollama_models` tool the agent can call mid-session.

### `afb342a` `--list-models` CLI + `ProviderSpec.list_models` hook
- Built-ins ship hardcoded canonical lists (anthropic / openai / gemini / pyagent) — instant, no API key required.
- Plugin providers can opt in via `register_provider(..., list_models=…)`.
- `list_all_models()` aggregator catches per-provider failures so one stopped backend doesn't silence the rest — they render as `(unavailable: <reason>)`.
- CLI loads plugins, prints the catalog, exits before model resolution (works without API keys configured).

### `32bc539` `ModelInfo` + capability tags via Ollama `/api/show`
- `ProviderSpec.list_models` returns `list[ModelInfo]` (name + optional capability tuple).
- Ollama plugin queries `/api/show` per model to extract Ollama's `capabilities` array (server 0.5+); filters boring tags (`completion`, `insert`); swallows per-model show failures so a single broken model doesn't blank capabilities for siblings.
- CLI renders `(tools)` / `(vision)` / `(embedding)` parentheticals and a yellow `(no tools — chat only)` warning for any model whose capabilities are non-empty but missing `tools` — pyagent's agent loop relies on tools, so this points users at models that actually work.

Live output flags exactly which local Ollama models are agent-compatible:
```
ollama (plugin):
  - llama3.2:latest  (tools)
  - qwen2.5:14b-instruct  (tools)
  - llama3.2-vision:11b  (vision) (no tools — chat only)
  - nomic-embed-text:latest  (embedding) (no tools — chat only)
  - deepseek-r1:14b  (thinking) (no tools — chat only)
```

## Test plan

- [ ] `python -m tests.smoke_ollama_plugin` passes (37 checks)
- [ ] `python -m tests.smoke_list_models` passes (CLI integration with mocked /api/tags + /api/show)
- [ ] `python -m tests.smoke_plugin_provider` still passes (no regressions on existing plugin-provider surface)
- [ ] `python -m tests.smoke_plugins` still passes
- [ ] `pyagent --list-models` against a live Ollama server tags installed models correctly (manual)
- [ ] `pyagent --model ollama/llama3.2 hi` does a real turn (manual)
- [ ] `pyagent --model ollama/llama3.2-vision:11b hi` no longer 400s — auto-retries without tools, warns once (manual)

## Phase 2 (separate work, not in this PR)
- Streaming (`respond_stream` on the LLMClient protocol; agent-loop drain; cross-provider).
- Per-model context-window awareness (cross-provider metadata table + budget-aware trimming).
- Vision / image attachments — punted indefinitely.