### PR TITLE
streaming: on_text_delta hook + Ollama NDJSON stream + CLI live render

### DIFF
--- a/pyagent/agent.py
+++ b/pyagent/agent.py
@@ -171,13 +171,23 @@ class Agent:
         messages: list[Any],
         system: str | None,
         system_volatile: str | None = None,
+        on_text_delta: Callable[[str], None] | None = None,
     ) -> Any:
-        """One model turn. Sends conversation + tool schemas, returns the assistant turn."""
+        """One model turn. Sends conversation + tool schemas, returns the assistant turn.
+
+        `on_text_delta`, when set, receives incremental text chunks as
+        the provider streams them. The returned dict still carries the
+        fully-accumulated `text` field — streaming is a UX channel,
+        not a flow-control change. Providers that haven't implemented
+        streaming silently ignore the callback and return the same
+        dict at end-of-call.
+        """
         return self.client.respond(
             conversation=messages,
             system=system,
             tools=self._tool_schemas(),
             system_volatile=system_volatile,
+            on_text_delta=on_text_delta,
         )
 
     def _execute_tool(self, name: str, args: dict[str, Any]) -> str:
@@ -577,6 +587,7 @@ class Agent:
         self,
         prompt: str,
         on_text: Callable[[str], None] | None = None,
+        on_text_delta: Callable[[str], None] | None = None,
         on_tool_call: Callable[[str, dict[str, Any]], None] | None = None,
         on_tool_result: Callable[[str, str], None] | None = None,
         on_usage: Callable[[dict[str, int]], None] | None = None,
@@ -594,7 +605,10 @@ class Agent:
             # ⇒ prompt cache stays warm.
             stable, volatile = self._system_prompt_segments()
             turn = self._call_llm(
-                self.conversation, stable, system_volatile=volatile
+                self.conversation,
+                stable,
+                system_volatile=volatile,
+                on_text_delta=on_text_delta,
             )
             self.conversation.append(turn)
             # After every assistant turn, evict stale single-shot tool

--- a/pyagent/agent_proc.py
+++ b/pyagent/agent_proc.py
@@ -931,6 +931,12 @@ def _run_turn(
         final_text = agent.run(
             prompt,
             on_text=lambda t: state.send("assistant_text", text=t),
+            # Streaming text deltas — fire as the provider produces
+            # them. The CLI accumulates and renders incrementally;
+            # the trailing `assistant_text` event still carries the
+            # full, completed text so non-streaming consumers (and
+            # the markdown re-render at end-of-turn) work uniformly.
+            on_text_delta=lambda t: state.send("assistant_text_delta", text=t),
             on_tool_call=lambda n, a: state.send(
                 "tool_call_started", name=n, args=a
             ),

--- a/pyagent/cli.py
+++ b/pyagent/cli.py
@@ -81,6 +81,42 @@ def _on_text(text: str, agent_id: str | None = None) -> None:
     console.print()
 
 
+# Per-agent streaming state. Keys are agent_id strings (or "root" for
+# the main agent); values are True from the first `assistant_text_delta`
+# of a text segment until the closing `assistant_text` arrives. Used
+# by the renderer to (a) emit a leading blank line + label exactly
+# once per streamed segment, and (b) decide whether the closing
+# `assistant_text` should re-render as markdown (provider didn't
+# stream) or just close out the line (provider did stream).
+_streaming_open: dict[str, bool] = {}
+
+
+def _on_text_delta(chunk: str, agent_id: str | None = None) -> None:
+    """Print one streaming text chunk inline, no markdown formatting.
+
+    Markdown rendering happens at end-of-turn via the closing
+    `assistant_text` event in the non-streaming case. While streaming
+    we lose markdown emphasis (bold, headers, lists) — the tradeoff
+    for getting characters on screen as the model produces them.
+    Worth it: the user can react to the response shape immediately,
+    and the raw text is still readable for any well-formed reply.
+
+    Each text segment in a turn (one per LLM call before/between/
+    after tool batches) gets its own leading blank line + agent
+    label exactly once, on the first delta.
+    """
+    key = agent_id or "root"
+    if not _streaming_open.get(key):
+        console.print()
+        if agent_id:
+            console.print(_agent_label(agent_id))
+        _streaming_open[key] = True
+    # `style="dim"` matches the non-streaming render so the streamed
+    # text doesn't visually pop while the user's prompt is still the
+    # most-prominent thing on screen.
+    console.print(chunk, end="", style="dim", soft_wrap=True, highlight=False)
+
+
 def _on_tool_call(
     name: str, args: dict[str, Any], agent_id: str | None = None
 ) -> None:
@@ -1014,8 +1050,23 @@ def _print_event(event: dict) -> None:
     """
     kind = event.get("type")
     agent_id = event.get("agent_id")
+    if kind == "assistant_text_delta":
+        _on_text_delta(event["text"], agent_id=agent_id)
+        return
     if kind == "assistant_text":
-        _on_text(event["text"], agent_id=agent_id)
+        key = agent_id or "root"
+        if _streaming_open.get(key):
+            # Provider streamed — the buffer already shows the full
+            # text in plain form. Close out with the trailing blank
+            # line and clear the streaming flag; do NOT re-render
+            # as markdown over the top (would force a flicker /
+            # scroll-back that's worse UX than losing markdown).
+            console.print()
+            console.print()
+            _streaming_open.pop(key, None)
+        else:
+            # Non-streaming provider — full markdown render as before.
+            _on_text(event["text"], agent_id=agent_id)
     elif kind == "tool_call_started":
         _on_tool_call(event["name"], event["args"], agent_id=agent_id)
     elif kind == "tool_result":

--- a/pyagent/llms/__init__.py
+++ b/pyagent/llms/__init__.py
@@ -327,7 +327,23 @@ class LLMClient(Protocol):
       - Assistant:    {"role": "assistant", "text": "...",
                        "tool_calls": [{"id", "name", "args"}, ...]}
 
-    The return value is a single assistant message in that same shape.
+    The return value is a single assistant message in that same shape,
+    even when streaming is in use — the contract is "one turn out per
+    call." Streaming is purely a UX channel: incremental text chunks
+    flow through `on_text_delta` while the call is in flight, and the
+    final dict still carries the fully-accumulated text + tool_calls +
+    usage at end-of-stream. The agent loop's tool-dispatch logic
+    relies on the complete tool_calls list, so tool calls are never
+    streamed piecemeal — only text is.
+
+    `on_text_delta` is optional. Providers that haven't implemented
+    streaming ignore the kwarg and behave exactly as before; the
+    callback simply doesn't fire. Providers that do stream call the
+    callback zero-or-more times with a chunk of plain text each
+    (whatever granularity the wire format hands them — tokens,
+    sentences, server-sent-event frames). Implementations must
+    accumulate the same text into the returned dict's `text` field
+    so a non-streaming consumer of the dict sees the full reply.
     """
 
     def respond(
@@ -336,4 +352,5 @@ class LLMClient(Protocol):
         system: str | None = None,
         tools: list[dict[str, Any]] | None = None,
         system_volatile: str | None = None,
+        on_text_delta: Callable[[str], None] | None = None,
     ) -> dict[str, Any]: ...

--- a/pyagent/llms/anthropic.py
+++ b/pyagent/llms/anthropic.py
@@ -1,7 +1,7 @@
 """Anthropic implementation of the LLM client interface."""
 
 import os
-from typing import Any
+from typing import Any, Callable
 
 from anthropic import Anthropic
 
@@ -39,7 +39,14 @@ class AnthropicClient:
         system: str | None = None,
         tools: list[dict[str, Any]] | None = None,
         system_volatile: str | None = None,
+        on_text_delta: Callable[[str], None] | None = None,
     ) -> dict[str, Any]:
+        # `on_text_delta` is the streaming hook on the LLMClient
+        # protocol. The Anthropic client doesn't stream yet — its
+        # follow-up PR will switch to `messages.stream()` and emit
+        # incremental text. For now the kwarg is accepted-and-ignored
+        # so the agent can pass it uniformly to every provider.
+        del on_text_delta
         kwargs: dict[str, Any] = {
             "model": self.model,
             "max_tokens": self.max_tokens,

--- a/pyagent/llms/anthropic.py
+++ b/pyagent/llms/anthropic.py
@@ -41,12 +41,37 @@ class AnthropicClient:
         system_volatile: str | None = None,
         on_text_delta: Callable[[str], None] | None = None,
     ) -> dict[str, Any]:
-        # `on_text_delta` is the streaming hook on the LLMClient
-        # protocol. The Anthropic client doesn't stream yet — its
-        # follow-up PR will switch to `messages.stream()` and emit
-        # incremental text. For now the kwarg is accepted-and-ignored
-        # so the agent can pass it uniformly to every provider.
-        del on_text_delta
+        kwargs = self._build_kwargs(conversation, system, tools, system_volatile)
+        if on_text_delta is None:
+            response = self._client.messages.create(**kwargs)
+            return self._build_response(response)
+        # Streaming path: `messages.stream()` is a context manager that
+        # yields incremental text via `text_stream` and assembles the
+        # full message (content blocks + usage) at exit. We forward
+        # text chunks through the callback while the stream is in
+        # flight, then read `get_final_message()` outside the context
+        # so the SDK has finalised the assembly.
+        with self._client.messages.stream(**kwargs) as stream:
+            for chunk in stream.text_stream:
+                if chunk:
+                    on_text_delta(chunk)
+            final = stream.get_final_message()
+        return self._build_response(final)
+
+    def _build_kwargs(
+        self,
+        conversation: list[dict[str, Any]],
+        system: str | None,
+        tools: list[dict[str, Any]] | None,
+        system_volatile: str | None,
+    ) -> dict[str, Any]:
+        """Translate pyagent's internal conversation into the kwargs
+        dict accepted by both ``messages.create`` and ``messages.stream``.
+
+        The two SDK methods share parameter shape exactly, so the
+        translation lives here once and feeds both branches of
+        ``respond()``.
+        """
         kwargs: dict[str, Any] = {
             "model": self.model,
             "max_tokens": self.max_tokens,
@@ -102,12 +127,20 @@ class AnthropicClient:
                 tools = [{**t} for t in tools]
                 tools[-1]["cache_control"] = {"type": "ephemeral"}
             kwargs["tools"] = tools
+        return kwargs
 
-        response = self._client.messages.create(**kwargs)
+    def _build_response(self, message: Any) -> dict[str, Any]:
+        """Translate one Anthropic ``Message`` into the agent-facing
+        assistant turn dict.
 
+        Used by both branches of ``respond()`` — the streaming branch
+        reads ``stream.get_final_message()`` (same Message shape as
+        ``messages.create`` returns) so this helper handles both cases
+        without conditionals.
+        """
         text_parts: list[str] = []
         tool_calls: list[dict[str, Any]] = []
-        for block in response.content:
+        for block in message.content:
             if block.type == "text":
                 text_parts.append(block.text)
             elif block.type == "tool_use":
@@ -115,7 +148,7 @@ class AnthropicClient:
                     {"id": block.id, "name": block.name, "args": dict(block.input)}
                 )
 
-        usage = getattr(response, "usage", None)
+        usage = getattr(message, "usage", None)
         return {
             "role": "assistant",
             "text": "".join(text_parts),

--- a/pyagent/llms/gemini.py
+++ b/pyagent/llms/gemini.py
@@ -55,14 +55,62 @@ class GeminiClient:
         system_volatile: str | None = None,
         on_text_delta: Callable[[str], None] | None = None,
     ) -> dict[str, Any]:
-        # `on_text_delta` is the streaming hook on the LLMClient
-        # protocol. The Gemini client doesn't stream yet — its
-        # follow-up PR will switch to `generate_content_stream()`.
-        # Accepted-and-ignored here so the agent can pass it
-        # uniformly to every provider.
-        del on_text_delta
         contents = [self._to_gemini(m) for m in conversation]
+        config = self._build_config(system, tools, system_volatile)
 
+        if on_text_delta is None:
+            response = self._client.models.generate_content(
+                model=self.model, contents=contents, config=config
+            )
+            return self._build_response_from_candidate(
+                response.candidates[0].content.parts or [],
+                getattr(response, "usage_metadata", None),
+            )
+
+        # Streaming: each chunk has `candidates[0].content.parts` with
+        # text and/or function_call parts. Gemini emits text in chunks
+        # but tool calls usually arrive complete in one chunk (not
+        # incrementally), so accumulation is straightforward — text
+        # parts append, function_call parts append once.
+        text_parts: list[str] = []
+        tool_calls: list[dict[str, Any]] = []
+        usage_meta = None
+        next_call_idx = 0
+        for chunk in self._client.models.generate_content_stream(
+            model=self.model, contents=contents, config=config
+        ):
+            if chunk.candidates:
+                for part in chunk.candidates[0].content.parts or []:
+                    if part.text:
+                        on_text_delta(part.text)
+                        text_parts.append(part.text)
+                    if part.function_call:
+                        tool_calls.append(
+                            {
+                                "id": part.function_call.id
+                                or f"call_{next_call_idx}",
+                                "name": part.function_call.name,
+                                "args": _to_plain(
+                                    part.function_call.args or {}
+                                ),
+                            }
+                        )
+                        next_call_idx += 1
+            if chunk.usage_metadata is not None:
+                usage_meta = chunk.usage_metadata
+
+        return self._build_response_from_parts(
+            "".join(text_parts), tool_calls, usage_meta
+        )
+
+    def _build_config(
+        self,
+        system: str | None,
+        tools: list[dict[str, Any]] | None,
+        system_volatile: str | None,
+    ) -> "types.GenerateContentConfig | None":
+        """Build the shared `GenerateContentConfig` accepted by both
+        `generate_content` and `generate_content_stream`."""
         # Gemini implicit caching keys on the prefix; concatenate
         # stable + volatile into one system_instruction. Volatile
         # mutating defeats the cache for its bytes; stable prefix
@@ -90,15 +138,19 @@ class GeminiClient:
                     ]
                 )
             ]
-        config = types.GenerateContentConfig(**config_kwargs) if config_kwargs else None
-
-        response = self._client.models.generate_content(
-            model=self.model, contents=contents, config=config
+        return (
+            types.GenerateContentConfig(**config_kwargs)
+            if config_kwargs
+            else None
         )
 
+    def _build_response_from_candidate(
+        self, parts: list[Any], usage_meta: Any
+    ) -> dict[str, Any]:
+        """Translate the parts list from a non-streaming response into
+        the agent-facing dict."""
         text_parts: list[str] = []
         tool_calls: list[dict[str, Any]] = []
-        parts = response.candidates[0].content.parts or []
         for i, part in enumerate(parts):
             if part.text:
                 text_parts.append(part.text)
@@ -110,11 +162,19 @@ class GeminiClient:
                         "args": _to_plain(part.function_call.args or {}),
                     }
                 )
+        return self._build_response_from_parts(
+            "".join(text_parts), tool_calls, usage_meta
+        )
 
-        usage_meta = getattr(response, "usage_metadata", None)
+    def _build_response_from_parts(
+        self,
+        text: str,
+        tool_calls: list[dict[str, Any]],
+        usage_meta: Any,
+    ) -> dict[str, Any]:
         return {
             "role": "assistant",
-            "text": "".join(text_parts),
+            "text": text,
             "tool_calls": tool_calls,
             "usage": {
                 "input": getattr(usage_meta, "prompt_token_count", 0) or 0,

--- a/pyagent/llms/gemini.py
+++ b/pyagent/llms/gemini.py
@@ -1,7 +1,7 @@
 """Gemini implementation of the LLM client interface."""
 
 import os
-from typing import Any
+from typing import Any, Callable
 
 from google import genai
 from google.genai import types
@@ -53,7 +53,14 @@ class GeminiClient:
         system: str | None = None,
         tools: list[dict[str, Any]] | None = None,
         system_volatile: str | None = None,
+        on_text_delta: Callable[[str], None] | None = None,
     ) -> dict[str, Any]:
+        # `on_text_delta` is the streaming hook on the LLMClient
+        # protocol. The Gemini client doesn't stream yet — its
+        # follow-up PR will switch to `generate_content_stream()`.
+        # Accepted-and-ignored here so the agent can pass it
+        # uniformly to every provider.
+        del on_text_delta
         contents = [self._to_gemini(m) for m in conversation]
 
         # Gemini implicit caching keys on the prefix; concatenate

--- a/pyagent/llms/openai.py
+++ b/pyagent/llms/openai.py
@@ -39,12 +39,70 @@ class OpenAIClient:
         system_volatile: str | None = None,
         on_text_delta: Callable[[str], None] | None = None,
     ) -> dict[str, Any]:
-        # `on_text_delta` is the streaming hook on the LLMClient
-        # protocol. The OpenAI client doesn't stream yet — its
-        # follow-up PR will pass `stream=True` and consume the SSE
-        # delta stream. Accepted-and-ignored here so the agent can
-        # pass it uniformly to every provider.
-        del on_text_delta
+        kwargs = self._build_kwargs(conversation, system, tools, system_volatile)
+        if on_text_delta is None:
+            response = self._client.chat.completions.create(**kwargs)
+            return self._build_response_from_message(
+                response.choices[0].message, getattr(response, "usage", None)
+            )
+        # Streaming: include_usage so the trailing chunk carries the
+        # token counters; OpenAI omits them otherwise. Tool calls
+        # arrive incrementally and are keyed by `index` — the model
+        # interleaves arg-string fragments across many chunks for the
+        # same call, so we accumulate per-index and join at the end.
+        kwargs["stream"] = True
+        kwargs["stream_options"] = {"include_usage": True}
+        text_parts: list[str] = []
+        tc_acc: dict[int, dict[str, Any]] = {}
+        usage = None
+        for chunk in self._client.chat.completions.create(**kwargs):
+            choices = getattr(chunk, "choices", None) or []
+            if choices:
+                delta = choices[0].delta
+                if getattr(delta, "content", None):
+                    on_text_delta(delta.content)
+                    text_parts.append(delta.content)
+                for tc_delta in getattr(delta, "tool_calls", None) or []:
+                    idx = tc_delta.index
+                    slot = tc_acc.setdefault(
+                        idx, {"id": "", "name": "", "args_str": ""}
+                    )
+                    if getattr(tc_delta, "id", None):
+                        slot["id"] = tc_delta.id
+                    fn = getattr(tc_delta, "function", None)
+                    if fn is not None:
+                        if getattr(fn, "name", None):
+                            slot["name"] = fn.name
+                        if getattr(fn, "arguments", None):
+                            slot["args_str"] += fn.arguments
+            chunk_usage = getattr(chunk, "usage", None)
+            if chunk_usage is not None:
+                usage = chunk_usage
+
+        tool_calls: list[dict[str, Any]] = []
+        for idx in sorted(tc_acc):
+            slot = tc_acc[idx]
+            try:
+                args = json.loads(slot["args_str"] or "{}")
+            except json.JSONDecodeError:
+                args = {"_raw": slot["args_str"]}
+            tool_calls.append(
+                {"id": slot["id"], "name": slot["name"], "args": args}
+            )
+        return self._build_response_from_parts(
+            "".join(text_parts), tool_calls, usage
+        )
+
+    def _build_kwargs(
+        self,
+        conversation: list[dict[str, Any]],
+        system: str | None,
+        tools: list[dict[str, Any]] | None,
+        system_volatile: str | None,
+    ) -> dict[str, Any]:
+        """Translate pyagent's internal conversation into the kwargs
+        dict accepted by both the streaming and non-streaming branches
+        of ``chat.completions.create``."""
         messages: list[dict[str, Any]] = []
         # OpenAI prompt caching is automatic on the prefix; concatenate
         # stable + volatile into one system message. Volatile content
@@ -82,10 +140,13 @@ class OpenAIClient:
                 }
                 for t in tools
             ]
+        return kwargs
 
-        response = self._client.chat.completions.create(**kwargs)
-        message = response.choices[0].message
-
+    def _build_response_from_message(
+        self, message: Any, usage: Any
+    ) -> dict[str, Any]:
+        """Translate one non-streaming ``ChatCompletionMessage`` into
+        the agent-facing assistant turn dict."""
         tool_calls: list[dict[str, Any]] = []
         for tc in message.tool_calls or []:
             tool_calls.append(
@@ -95,13 +156,23 @@ class OpenAIClient:
                     "args": json.loads(tc.function.arguments or "{}"),
                 }
             )
+        return self._build_response_from_parts(
+            message.content or "", tool_calls, usage
+        )
 
-        usage = getattr(response, "usage", None)
+    def _build_response_from_parts(
+        self,
+        text: str,
+        tool_calls: list[dict[str, Any]],
+        usage: Any,
+    ) -> dict[str, Any]:
+        """Common shape-builder. Both branches converge here so the
+        returned dict's structure is identical regardless of mode."""
         prompt_details = getattr(usage, "prompt_tokens_details", None)
         cache_read = getattr(prompt_details, "cached_tokens", 0) or 0
         return {
             "role": "assistant",
-            "text": message.content or "",
+            "text": text,
             "tool_calls": tool_calls,
             "usage": {
                 "input": getattr(usage, "prompt_tokens", 0) or 0,

--- a/pyagent/llms/openai.py
+++ b/pyagent/llms/openai.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-from typing import Any
+from typing import Any, Callable
 
 from openai import OpenAI
 
@@ -37,7 +37,14 @@ class OpenAIClient:
         system: str | None = None,
         tools: list[dict[str, Any]] | None = None,
         system_volatile: str | None = None,
+        on_text_delta: Callable[[str], None] | None = None,
     ) -> dict[str, Any]:
+        # `on_text_delta` is the streaming hook on the LLMClient
+        # protocol. The OpenAI client doesn't stream yet — its
+        # follow-up PR will pass `stream=True` and consume the SSE
+        # delta stream. Accepted-and-ignored here so the agent can
+        # pass it uniformly to every provider.
+        del on_text_delta
         messages: list[dict[str, Any]] = []
         # OpenAI prompt caching is automatic on the prefix; concatenate
         # stable + volatile into one system message. Volatile content

--- a/pyagent/llms/pyagent.py
+++ b/pyagent/llms/pyagent.py
@@ -7,7 +7,7 @@ spending real tokens. Selected with `--model pyagent/<stub-name>`.
 """
 
 import random
-from typing import Any
+from typing import Any, Callable
 
 
 class EchoClient:
@@ -35,6 +35,7 @@ class EchoClient:
         system: str | None = None,
         tools: list[dict[str, Any]] | None = None,
         system_volatile: str | None = None,
+        on_text_delta: Callable[[str], None] | None = None,
     ) -> dict[str, Any]:
         text = ""
         for msg in reversed(conversation):
@@ -44,6 +45,13 @@ class EchoClient:
             if isinstance(content, str):
                 text = content
                 break
+        # Word-by-word streaming so the protocol exercise covers the
+        # multi-delta path even on the simplest stub. Fires
+        # synchronously — no sleep — so tests stay fast.
+        if on_text_delta and text:
+            for i, word in enumerate(text.split(" ")):
+                chunk = word if i == 0 else f" {word}"
+                on_text_delta(chunk)
         return {
             "text": text,
             "tool_calls": [],
@@ -100,6 +108,7 @@ class LoremClient:
         system: str | None = None,
         tools: list[dict[str, Any]] | None = None,
         system_volatile: str | None = None,
+        on_text_delta: Callable[[str], None] | None = None,
     ) -> dict[str, Any]:
         paragraphs = []
         for _ in range(random.randint(1, 5)):
@@ -107,8 +116,20 @@ class LoremClient:
                 _LOREM_SENTENCES, k=random.randint(2, 6)
             )
             paragraphs.append(" ".join(sentences))
+        text = "\n\n".join(paragraphs)
+        # Sentence-by-sentence streaming gives a realistic pacing
+        # cadence when used with a CLI renderer (paragraphs flow in
+        # noticeable chunks, mid-sentence lag is rare). No sleeps —
+        # the consumer drives any pacing it wants.
+        if on_text_delta:
+            buf: list[str] = []
+            remaining = text
+            for sent in _split_for_stream(text):
+                buf.append(sent)
+                on_text_delta(sent)
+                remaining = remaining[len(sent):]
         return {
-            "text": "\n\n".join(paragraphs),
+            "text": text,
             "tool_calls": [],
             "usage": {
                 "input": 0,
@@ -118,3 +139,28 @@ class LoremClient:
                 "model": self.provider_model,
             },
         }
+
+
+def _split_for_stream(text: str) -> list[str]:
+    """Break the lorem text into bite-sized streaming chunks.
+
+    Splits on sentence-ending punctuation while keeping the trailing
+    delimiter + any whitespace attached to the chunk that ends with
+    it, so concatenating the chunks reproduces the input exactly.
+    Used only by `LoremClient` — real providers' streaming chunks
+    come pre-segmented from the wire.
+    """
+    chunks: list[str] = []
+    start = 0
+    for i, ch in enumerate(text):
+        if ch in ".!?\n":
+            # consume trailing whitespace into this chunk so the next
+            # one starts cleanly with a non-space character
+            end = i + 1
+            while end < len(text) and text[end] in " \t":
+                end += 1
+            chunks.append(text[start:end])
+            start = end
+    if start < len(text):
+        chunks.append(text[start:])
+    return chunks

--- a/pyagent/plugins/ollama/client.py
+++ b/pyagent/plugins/ollama/client.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import json
 import logging
 import os
-from typing import Any
+from typing import Any, Callable
 
 import requests
 
@@ -162,6 +162,7 @@ class OllamaClient:
         system: str | None = None,
         tools: list[dict[str, Any]] | None = None,
         system_volatile: str | None = None,
+        on_text_delta: Callable[[str], None] | None = None,
     ) -> dict[str, Any]:
         messages: list[dict[str, Any]] = []
         # Ollama has no prefix-cache surface to preserve, so stable +
@@ -179,10 +180,16 @@ class OllamaClient:
         for m in conversation:
             messages.extend(self._to_ollama(m))
 
+        # Streaming hinges entirely on the on_text_delta callback. When
+        # set, ask Ollama to NDJSON-stream and surface chunks as they
+        # arrive; when unset, ask for a single-shot reply so callers
+        # like the audit / bench paths that just want the final dict
+        # don't pay any iteration overhead.
+        streaming = on_text_delta is not None
         body: dict[str, Any] = {
             "model": self.model,
             "messages": messages,
-            "stream": False,
+            "stream": streaming,
         }
         if tools and not self._skip_tools:
             body["tools"] = [
@@ -197,17 +204,35 @@ class OllamaClient:
                 for t in tools
             ]
 
+        resp = self._post_chat(body)
+        if not streaming:
+            return self._build_response(resp.json())
+        return self._consume_stream(resp, on_text_delta)
+
+    def _post_chat(self, body: dict[str, Any]) -> requests.Response:
+        """POST /api/chat, with the no-tools-auto-retry path applied.
+
+        Honors ``body["stream"]`` to decide whether the underlying
+        ``requests`` call streams the response body — without this
+        flag, a streaming chat would buffer fully before
+        ``iter_lines`` even runs, defeating the point.
+
+        On a 400 ``"does not support tools"``, retries once without
+        ``tools`` and latches ``_skip_tools`` so subsequent turns
+        skip the failed round trip. Other 4xx / 5xx propagate. The
+        first response object is closed before the retry so a
+        partially-buffered streaming connection doesn't linger.
+        """
+        streaming = bool(body.get("stream"))
         resp = requests.post(
-            f"{self.host}/api/chat", json=body, timeout=self.timeout
+            f"{self.host}/api/chat",
+            json=body,
+            timeout=self.timeout,
+            stream=streaming,
         )
         try:
             _raise_with_body(resp, "/api/chat")
         except requests.HTTPError as e:
-            # If Ollama rejected the request because the model doesn't
-            # support tools, retry once without them and latch the
-            # decision so subsequent turns don't repeat the failed
-            # round trip. We also warn so the user knows the agent is
-            # operating without its tool surface.
             if (
                 "does not support tools" in str(e).lower()
                 and "tools" in body
@@ -221,16 +246,30 @@ class OllamaClient:
                 )
                 self._skip_tools = True
                 body.pop("tools")
+                try:
+                    resp.close()
+                except Exception:
+                    pass
                 resp = requests.post(
                     f"{self.host}/api/chat",
                     json=body,
                     timeout=self.timeout,
+                    stream=streaming,
                 )
                 _raise_with_body(resp, "/api/chat")
             else:
                 raise
-        data = resp.json()
+        return resp
 
+    def _build_response(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Translate one parsed `/api/chat` payload into the agent-
+        facing assistant turn dict.
+
+        Used by the non-streaming path directly and by the streaming
+        path after it has assembled `data` from accumulated chunks
+        — keeps tool-call id synthesis and arg normalisation in one
+        place so behavior is identical between modes.
+        """
         message = data.get("message") or {}
         text = message.get("content") or ""
         raw_calls = message.get("tool_calls") or []
@@ -266,6 +305,72 @@ class OllamaClient:
                 "model": self.provider_model,
             },
         }
+
+    def _consume_stream(
+        self,
+        resp: requests.Response,
+        on_text_delta: Callable[[str], None],
+    ) -> dict[str, Any]:
+        """Drain Ollama's NDJSON stream, firing text deltas as they
+        arrive, and assemble the final agent-facing turn dict.
+
+        Wire format: each line is one JSON object with optional
+        ``message.content`` chunk, optional ``message.tool_calls``,
+        and a final line carrying ``done=true`` plus
+        ``prompt_eval_count`` / ``eval_count`` token counters.
+
+        Tool-call accumulation strategy: we keep the latest non-empty
+        ``tool_calls`` payload from any chunk. Ollama's streaming
+        usually emits the complete call object once per call (not
+        char-by-char), so the last value is the canonical batch.
+        Empty arrays are ignored so a late "no more tool calls"
+        signal doesn't blank a real call we already captured.
+        """
+        text_parts: list[str] = []
+        latest_tool_calls: list[dict[str, Any]] = []
+        final_meta: dict[str, Any] = {}
+
+        try:
+            for raw in resp.iter_lines(decode_unicode=True):
+                if not raw:
+                    continue
+                try:
+                    chunk = json.loads(raw)
+                except json.JSONDecodeError:
+                    # Malformed line — skip rather than blow up the
+                    # whole turn. Real Ollama servers don't emit
+                    # these but a flaky proxy might.
+                    logger.debug("ollama: skipping malformed NDJSON line: %r", raw)
+                    continue
+
+                msg = chunk.get("message") or {}
+                content = msg.get("content") or ""
+                if content:
+                    on_text_delta(content)
+                    text_parts.append(content)
+                tc = msg.get("tool_calls")
+                if tc:
+                    latest_tool_calls = tc
+
+                if chunk.get("done"):
+                    final_meta = chunk
+        finally:
+            try:
+                resp.close()
+            except Exception:
+                pass
+
+        # Reconstruct a single-shot-shaped payload so _build_response
+        # can do the rest. The accumulated text wins over whatever
+        # `message.content` ended up on the final chunk (which is
+        # typically empty in streaming mode anyway).
+        synthetic = dict(final_meta)
+        synthetic["message"] = {
+            "role": "assistant",
+            "content": "".join(text_parts),
+            "tool_calls": latest_tool_calls,
+        }
+        return self._build_response(synthetic)
 
     @staticmethod
     def _to_ollama(message: dict[str, Any]) -> list[dict[str, Any]]:

--- a/pyagent/protocol.py
+++ b/pyagent/protocol.py
@@ -51,8 +51,16 @@ agent → CLI
         Agent, Session, and tool registry. The CLI waits for this
         before accepting user input.
   - assistant_text {text: str}
-        Streamed assistant text from a turn (currently emitted whole
-        per turn, not chunked).
+        The full, completed text of one assistant turn. Always emitted
+        once per turn after any deltas have flowed; the CLI uses this
+        to swap the streamed plain-text buffer for a markdown render.
+  - assistant_text_delta {text: str}
+        Incremental text chunk produced by a streaming provider. Fired
+        zero-or-more times during a turn before the closing
+        `assistant_text` event. Concatenating every delta in order
+        equals the `text` field of the closing `assistant_text`. CLIs
+        that don't care about live rendering can ignore this event
+        entirely; the trailing `assistant_text` is still authoritative.
   - tool_call_started {name: str, args: dict}
         Mirror of the existing `on_tool_call` callback.
   - tool_result {name: str, content: str}

--- a/tests/smoke_list_models.py
+++ b/tests/smoke_list_models.py
@@ -250,7 +250,7 @@ def _check_cli_prints_and_exits() -> None:
         }
     )
 
-    def fake_show(url, json=None, timeout=None):
+    def fake_show(url, json=None, timeout=None, stream=False):
         # Distinct capability arrays per model so the renderer can
         # exercise both the tool-capable and no-tools branches.
         name = (json or {}).get("name", "")

--- a/tests/smoke_ollama_plugin.py
+++ b/tests/smoke_ollama_plugin.py
@@ -254,7 +254,7 @@ def _check_respond_request_shape_and_response_parse() -> None:
     normalisation."""
     captured: dict = {}
 
-    def fake_post(url, json=None, timeout=None):
+    def fake_post(url, json=None, timeout=None, stream=False):
         captured["url"] = url
         captured["body"] = json
         captured["timeout"] = timeout
@@ -522,6 +522,183 @@ def _check_http_error_surfaces_ollama_body() -> None:
             _check("HTTPError raised on 502 with HTML body", False)
 
 
+def _check_streaming_ndjson_path() -> None:
+    """When `on_text_delta` is set, OllamaClient must POST with
+    `stream=True`, drain NDJSON, fire deltas as they arrive, and
+    accumulate the final dict's text/tool_calls/usage from the
+    chunks. The non-streaming path stays untouched (no callback)
+    so existing audit/bench callers see no behavior change."""
+
+    chunks_wire = [
+        # Three text chunks then one done-chunk with usage.
+        b'{"message": {"role": "assistant", "content": "Hel"}, "done": false}\n',
+        b'{"message": {"role": "assistant", "content": "lo "}, "done": false}\n',
+        b'{"message": {"role": "assistant", "content": "world"}, "done": false}\n',
+        b'{"message": {"role": "assistant", "content": ""}, "done": true, '
+        b'"prompt_eval_count": 5, "eval_count": 12}\n',
+    ]
+
+    class _StreamResp:
+        """Minimal `requests.Response` stand-in that exposes
+        `iter_lines` and the OK-path attributes `_raise_with_body`
+        peeks at."""
+
+        status_code = 200
+        ok = True
+
+        def __init__(self, lines):
+            self._lines = lines
+
+        def iter_lines(self, decode_unicode=False):
+            for line in self._lines:
+                # The client passes decode_unicode=True; honor it so
+                # we hand back str, matching real `requests` behavior.
+                if decode_unicode and isinstance(line, bytes):
+                    yield line.decode("utf-8").rstrip("\n")
+                else:
+                    yield line.rstrip(b"\n") if isinstance(line, bytes) else line
+
+        def close(self):
+            pass
+
+    captured: dict = {}
+
+    def fake_post(url, json=None, timeout=None, stream=False):
+        captured["body"] = json
+        captured["stream"] = stream
+        return _StreamResp(list(chunks_wire))
+
+    deltas: list[str] = []
+    client = ollama_client_mod.OllamaClient(model="llama3.2")
+    with mock.patch.object(
+        ollama_client_mod.requests, "post", side_effect=fake_post
+    ):
+        out = client.respond(
+            conversation=[{"role": "user", "content": "hi"}],
+            on_text_delta=deltas.append,
+        )
+
+    _check(
+        "post called with stream=True when callback present",
+        captured["stream"] is True,
+        repr(captured),
+    )
+    _check(
+        "request body says stream: true",
+        captured["body"]["stream"] is True,
+        repr(captured["body"]),
+    )
+    _check(
+        "deltas arrived in chunk order",
+        deltas == ["Hel", "lo ", "world"],
+        repr(deltas),
+    )
+    _check(
+        "final text concatenates the deltas",
+        out["text"] == "Hello world",
+        repr(out["text"]),
+    )
+    _check(
+        "usage parsed from done-chunk",
+        out["usage"]["input"] == 5 and out["usage"]["output"] == 12,
+        repr(out["usage"]),
+    )
+
+    # Without a callback, the non-streaming path stays in effect —
+    # no stream=True, returns immediately from .json().
+    json_resp = _FakeResponse(
+        {
+            "message": {"role": "assistant", "content": "non-stream", "tool_calls": []},
+            "prompt_eval_count": 1,
+            "eval_count": 1,
+        }
+    )
+    captured.clear()
+
+    def fake_post_one_shot(url, json=None, timeout=None, stream=False):
+        captured["stream"] = stream
+        return json_resp
+
+    fresh = ollama_client_mod.OllamaClient(model="llama3.2")
+    with mock.patch.object(
+        ollama_client_mod.requests, "post", side_effect=fake_post_one_shot
+    ):
+        out = fresh.respond(conversation=[{"role": "user", "content": "x"}])
+    _check(
+        "no callback → stream=False on the wire",
+        captured["stream"] is False,
+        repr(captured),
+    )
+    _check(
+        "no callback → full text returned in dict",
+        out["text"] == "non-stream",
+        repr(out),
+    )
+
+
+def _check_streaming_tool_calls_accumulate() -> None:
+    """Tool calls in the stream — Ollama emits them as a complete
+    payload in one chunk (not char-by-char), so the client takes the
+    latest non-empty `tool_calls` value as the canonical batch."""
+
+    chunks = [
+        b'{"message": {"role": "assistant", "content": "Calling..."}, "done": false}\n',
+        b'{"message": {"role": "assistant", "content": "", "tool_calls": '
+        b'[{"function": {"name": "lookup", "arguments": {"q": "x"}}}]}, '
+        b'"done": false}\n',
+        b'{"message": {"role": "assistant", "content": ""}, "done": true, '
+        b'"prompt_eval_count": 3, "eval_count": 9}\n',
+    ]
+
+    class _StreamResp:
+        status_code = 200
+        ok = True
+
+        def __init__(self, lines):
+            self._lines = lines
+
+        def iter_lines(self, decode_unicode=False):
+            for line in self._lines:
+                yield line.decode("utf-8").rstrip("\n") if isinstance(line, bytes) else line
+
+        def close(self):
+            pass
+
+    def fake_post(url, json=None, timeout=None, stream=False):
+        return _StreamResp(list(chunks))
+
+    deltas: list[str] = []
+    client = ollama_client_mod.OllamaClient(model="llama3.2")
+    with mock.patch.object(
+        ollama_client_mod.requests, "post", side_effect=fake_post
+    ):
+        out = client.respond(
+            conversation=[{"role": "user", "content": "hi"}],
+            tools=[
+                {
+                    "name": "lookup",
+                    "description": "x",
+                    "input_schema": {"type": "object", "properties": {}},
+                }
+            ],
+            on_text_delta=deltas.append,
+        )
+
+    _check("text delta still fired", deltas == ["Calling..."], repr(deltas))
+    _check(
+        "tool_calls captured from the chunk that carried them",
+        len(out["tool_calls"]) == 1
+        and out["tool_calls"][0]["name"] == "lookup"
+        and out["tool_calls"][0]["args"] == {"q": "x"},
+        repr(out["tool_calls"]),
+    )
+    _check(
+        "synthesized id present",
+        out["tool_calls"][0]["id"] == "call_0",
+        repr(out["tool_calls"][0]),
+    )
+
+
 def _check_provider_list_models_hook() -> None:
     """The ollama provider exposes a `list_models` callable on its
     ProviderSpec — that's how `pyagent --list-models` discovers what
@@ -542,7 +719,7 @@ def _check_provider_list_models_hook() -> None:
         ]
     }
 
-    def fake_post(url, json=None, timeout=None):
+    def fake_post(url, json=None, timeout=None, stream=False):
         # /api/show payload — capabilities array varies per model so
         # we exercise both the tool and vision tag paths plus the
         # ``completion`` filter.
@@ -591,7 +768,7 @@ def _check_provider_list_models_hook() -> None:
 
     # An /api/show failure for one model must not blank capabilities
     # for siblings — the model still appears, just without tags.
-    def half_broken(url, json=None, timeout=None):
+    def half_broken(url, json=None, timeout=None, stream=False):
         if (json or {}).get("name") == "llava:7b":
             raise ConnectionError("model gone")
         return _FakeResponse({"capabilities": ["tools"]})
@@ -656,7 +833,7 @@ def _check_no_tools_auto_retry() -> None:
 
     posts: list[dict] = []
 
-    def fake_post(url, json=None, timeout=None):
+    def fake_post(url, json=None, timeout=None, stream=False):
         # Deep-copy: respond() mutates the dict in place during the
         # tools-stripping retry, so a shallow capture would lose the
         # pre-mutation state.
@@ -761,6 +938,8 @@ def main() -> None:
     _check_http_error_surfaces_ollama_body()
     _check_no_tools_auto_retry()
     _check_provider_list_models_hook()
+    _check_streaming_ndjson_path()
+    _check_streaming_tool_calls_accumulate()
     print("smoke_ollama_plugin: all checks passed")
 
 

--- a/tests/smoke_streaming.py
+++ b/tests/smoke_streaming.py
@@ -30,6 +30,10 @@ Run with:
 
 from __future__ import annotations
 
+import json
+import os
+from unittest import mock
+
 from pyagent.agent import Agent
 from pyagent.llms.pyagent import EchoClient, LoremClient
 
@@ -148,12 +152,136 @@ def _check_agent_forwards_delta_callback() -> None:
     )
 
 
+# ---- Per-provider streaming (mocked SDKs) -----------------------
+#
+# Each provider is exercised via mock so the test runs without API
+# keys and without making any network calls. The mocks shape-match
+# what each SDK actually returns so the client's translation logic
+# is genuinely exercised, not stubbed away.
+
+
+class _Attr:
+    """Tiny record-style object — exposes whatever kwargs you hand it
+    as attributes. Used to build SDK-shaped mocks without dragging in
+    pydantic models."""
+
+    def __init__(self, **kw: object) -> None:
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+def _check_anthropic_streaming_mocked() -> None:
+    """AnthropicClient.respond with on_text_delta uses messages.stream
+    and assembles final dict from get_final_message()."""
+
+    os.environ.setdefault("ANTHROPIC_API_KEY", "dummy-for-smoke")
+    from pyagent.llms.anthropic import AnthropicClient
+
+    final_msg = _Attr(
+        content=[
+            _Attr(type="text", text="Hello world"),
+            _Attr(type="tool_use", id="t1", name="lookup", input={"q": "x"}),
+        ],
+        usage=_Attr(
+            input_tokens=5,
+            output_tokens=12,
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=0,
+        ),
+    )
+
+    class _FakeStreamCM:
+        def __init__(self, chunks, final):
+            self._chunks = chunks
+            self._final = final
+            self.text_stream = iter(chunks)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def get_final_message(self):
+            return self._final
+
+    captured: dict = {}
+
+    def fake_stream(**kwargs):
+        captured["called"] = True
+        captured["kwargs"] = kwargs
+        return _FakeStreamCM(["Hello ", "world"], final_msg)
+
+    client = AnthropicClient(model="claude-sonnet-4-6", api_key="dummy")
+    deltas: list[str] = []
+    with mock.patch.object(client._client.messages, "stream", side_effect=fake_stream):
+        out = client.respond(
+            conversation=[{"role": "user", "content": "hi"}],
+            on_text_delta=deltas.append,
+        )
+
+    _check("anthropic stream() invoked", captured.get("called") is True)
+    _check(
+        "anthropic deltas arrive in chunk order",
+        deltas == ["Hello ", "world"],
+        repr(deltas),
+    )
+    _check(
+        "anthropic concatenated text matches returned",
+        "".join(deltas) == out["text"] == "Hello world",
+        repr(out["text"]),
+    )
+    _check(
+        "anthropic tool_use captured into tool_calls",
+        len(out["tool_calls"]) == 1
+        and out["tool_calls"][0] == {"id": "t1", "name": "lookup", "args": {"q": "x"}},
+        repr(out["tool_calls"]),
+    )
+    _check(
+        "anthropic usage parsed",
+        out["usage"]["input"] == 5 and out["usage"]["output"] == 12,
+        repr(out["usage"]),
+    )
+
+    # No callback → uses messages.create, NOT messages.stream.
+    create_calls: list = []
+
+    def fake_create(**kwargs):
+        create_calls.append(kwargs)
+        return final_msg
+
+    stream_calls: list = []
+
+    def fake_stream_should_not_run(**kwargs):
+        stream_calls.append(kwargs)
+        return _FakeStreamCM([], final_msg)
+
+    fresh = AnthropicClient(model="claude-sonnet-4-6", api_key="dummy")
+    with mock.patch.object(fresh._client.messages, "create", side_effect=fake_create):
+        with mock.patch.object(
+            fresh._client.messages, "stream", side_effect=fake_stream_should_not_run
+        ):
+            out2 = fresh.respond(conversation=[{"role": "user", "content": "x"}])
+    _check(
+        "anthropic no-callback uses messages.create",
+        len(create_calls) == 1 and len(stream_calls) == 0,
+        f"create={len(create_calls)} stream={len(stream_calls)}",
+    )
+    _check(
+        "anthropic no-callback returns same dict shape",
+        out2["text"] == "Hello world" and len(out2["tool_calls"]) == 1,
+        repr(out2),
+    )
+
+
+
 def main() -> None:
     _check_echo_streams_word_by_word()
     _check_echo_no_callback_unchanged()
     _check_lorem_streams_sentences()
     _check_provider_signatures_accept_kwarg()
     _check_agent_forwards_delta_callback()
+    _check_anthropic_streaming_mocked()
     print("smoke_streaming: all checks passed")
 
 

--- a/tests/smoke_streaming.py
+++ b/tests/smoke_streaming.py
@@ -428,6 +428,142 @@ def _check_openai_streaming_mocked() -> None:
     )
 
 
+def _check_gemini_streaming_mocked() -> None:
+    """GeminiClient.respond with on_text_delta uses
+    generate_content_stream and folds usage from the final chunk."""
+
+    os.environ.setdefault("GEMINI_API_KEY", "dummy-for-smoke")
+    from pyagent.llms.gemini import GeminiClient
+
+    # Chunks: text deltas then a tool-call chunk then a final usage chunk.
+    # Each chunk has candidates[0].content.parts.
+    chunks = [
+        _Attr(
+            candidates=[
+                _Attr(content=_Attr(parts=[_Attr(text="Hel", function_call=None)]))
+            ],
+            usage_metadata=None,
+        ),
+        _Attr(
+            candidates=[
+                _Attr(content=_Attr(parts=[_Attr(text="lo", function_call=None)]))
+            ],
+            usage_metadata=None,
+        ),
+        _Attr(
+            candidates=[
+                _Attr(
+                    content=_Attr(
+                        parts=[
+                            _Attr(
+                                text=None,
+                                function_call=_Attr(
+                                    id=None, name="lookup", args={"q": "x"}
+                                ),
+                            )
+                        ]
+                    )
+                )
+            ],
+            usage_metadata=None,
+        ),
+        _Attr(
+            candidates=[],
+            usage_metadata=_Attr(
+                prompt_token_count=7,
+                candidates_token_count=11,
+                cached_content_token_count=3,
+            ),
+        ),
+    ]
+
+    captured: dict = {}
+
+    def fake_stream(**kwargs):
+        captured["called"] = True
+        captured["kwargs"] = kwargs
+        return iter(chunks)
+
+    client = GeminiClient(model="gemini-2.5-flash", api_key="dummy")
+    deltas: list[str] = []
+    with mock.patch.object(
+        client._client.models, "generate_content_stream", side_effect=fake_stream
+    ):
+        out = client.respond(
+            conversation=[{"role": "user", "content": "hi"}],
+            on_text_delta=deltas.append,
+        )
+
+    _check("gemini stream invoked", captured.get("called") is True)
+    _check(
+        "gemini deltas arrive in chunk order",
+        deltas == ["Hel", "lo"],
+        repr(deltas),
+    )
+    _check(
+        "gemini concat deltas == returned text",
+        "".join(deltas) == out["text"] == "Hello",
+        repr(out["text"]),
+    )
+    _check(
+        "gemini function_call captured",
+        len(out["tool_calls"]) == 1
+        and out["tool_calls"][0]["name"] == "lookup"
+        and out["tool_calls"][0]["args"] == {"q": "x"}
+        and out["tool_calls"][0]["id"].startswith("call_"),
+        repr(out["tool_calls"]),
+    )
+    _check(
+        "gemini usage parsed including cache_read",
+        out["usage"]["input"] == 7
+        and out["usage"]["output"] == 11
+        and out["usage"]["cache_read"] == 3,
+        repr(out["usage"]),
+    )
+
+    # No callback → non-streaming generate_content path.
+    one_shot = _Attr(
+        candidates=[
+            _Attr(
+                content=_Attr(
+                    parts=[_Attr(text="non-stream", function_call=None)]
+                )
+            )
+        ],
+        usage_metadata=_Attr(
+            prompt_token_count=1,
+            candidates_token_count=2,
+            cached_content_token_count=0,
+        ),
+    )
+    stream_calls: list = []
+
+    def fake_stream_should_not_run(**kwargs):
+        stream_calls.append(kwargs)
+        return iter([])
+
+    fresh = GeminiClient(model="gemini-2.5-flash", api_key="dummy")
+    with mock.patch.object(
+        fresh._client.models, "generate_content", return_value=one_shot
+    ):
+        with mock.patch.object(
+            fresh._client.models,
+            "generate_content_stream",
+            side_effect=fake_stream_should_not_run,
+        ):
+            out2 = fresh.respond(conversation=[{"role": "user", "content": "x"}])
+    _check(
+        "gemini no-callback uses generate_content (not stream)",
+        len(stream_calls) == 0,
+        f"stream_calls={len(stream_calls)}",
+    )
+    _check(
+        "gemini no-callback returns full text",
+        out2["text"] == "non-stream",
+        repr(out2),
+    )
+
+
 def main() -> None:
     _check_echo_streams_word_by_word()
     _check_echo_no_callback_unchanged()
@@ -436,6 +572,7 @@ def main() -> None:
     _check_agent_forwards_delta_callback()
     _check_anthropic_streaming_mocked()
     _check_openai_streaming_mocked()
+    _check_gemini_streaming_mocked()
     print("smoke_streaming: all checks passed")
 
 

--- a/tests/smoke_streaming.py
+++ b/tests/smoke_streaming.py
@@ -1,0 +1,161 @@
+"""End-to-end smoke for the streaming hook on the LLMClient protocol.
+
+Concerns:
+
+  1. **Protocol surface.** Every existing provider client accepts the
+     new ``on_text_delta`` kwarg without raising. Non-streaming
+     providers (anthropic / openai / gemini stubs in this PR) ignore
+     it; streaming providers (pyagent stubs, ollama) fire it.
+  2. **EchoClient streams word-by-word.** With a callback set, deltas
+     arrive in order and concatenate to the final ``text`` field. The
+     ``text`` is preserved on the returned dict so non-streaming
+     consumers still see the full reply.
+  3. **LoremClient streams sentence-by-sentence.** Same concatenation
+     invariant — `"".join(deltas) == returned["text"]`. Works without
+     mocking randomness because we just check the deltas
+     reconstruct the dict's text.
+  4. **Agent loop forwards deltas.** ``Agent.run(..., on_text_delta=cb)``
+     piping reaches the client's ``respond`` and the callback fires
+     while the turn is still in flight. The trailing ``on_text``
+     callback receives the same total text that the deltas summed to,
+     so a CLI consuming both sees consistent state.
+  5. **No-callback path is unchanged.** Calling ``respond()`` without
+     the kwarg returns the same shape as before — providers that
+     stream when set fall back to non-streaming behavior when unset.
+
+Run with:
+
+    .venv/bin/python -m tests.smoke_streaming
+"""
+
+from __future__ import annotations
+
+from pyagent.agent import Agent
+from pyagent.llms.pyagent import EchoClient, LoremClient
+
+
+def _check(label: str, cond: bool, detail: str = "") -> None:
+    sym = "✓" if cond else "✗"
+    extra = f" — {detail}" if detail else ""
+    print(f"{sym} {label}{extra}")
+    if not cond:
+        raise SystemExit(1)
+
+
+def _check_echo_streams_word_by_word() -> None:
+    deltas: list[str] = []
+    out = EchoClient().respond(
+        conversation=[{"role": "user", "content": "hello there friend"}],
+        on_text_delta=deltas.append,
+    )
+    _check("got at least one delta", len(deltas) > 0, repr(deltas))
+    _check(
+        "deltas concatenate to returned text",
+        "".join(deltas) == out["text"],
+        f"deltas={deltas!r} text={out['text']!r}",
+    )
+    _check(
+        "echo full text preserved",
+        out["text"] == "hello there friend",
+        out["text"],
+    )
+
+
+def _check_echo_no_callback_unchanged() -> None:
+    """Calling respond() without on_text_delta returns the same dict
+    shape as before — proves the kwarg is purely additive."""
+    out = EchoClient().respond(
+        conversation=[{"role": "user", "content": "hi"}],
+    )
+    _check(
+        "no-callback echo returns full text",
+        out["text"] == "hi" and out["tool_calls"] == [],
+        repr(out),
+    )
+
+
+def _check_lorem_streams_sentences() -> None:
+    deltas: list[str] = []
+    out = LoremClient().respond(
+        conversation=[{"role": "user", "content": "go"}],
+        on_text_delta=deltas.append,
+    )
+    _check("lorem produced text", bool(out["text"]))
+    _check(
+        "lorem deltas concatenate to returned text",
+        "".join(deltas) == out["text"],
+        f"text len={len(out['text'])} sum-of-deltas={len(''.join(deltas))}",
+    )
+    _check(
+        "lorem fired multiple deltas",
+        len(deltas) >= 2,
+        f"deltas={len(deltas)}",
+    )
+
+
+def _check_provider_signatures_accept_kwarg() -> None:
+    """Every built-in client must accept on_text_delta — even ones
+    that don't yet stream — so the agent loop can pass it
+    uniformly. Constructors that need API keys are skipped (env not
+    guaranteed); we only inspect the signature."""
+    import inspect
+
+    from pyagent.llms.anthropic import AnthropicClient
+    from pyagent.llms.gemini import GeminiClient
+    from pyagent.llms.openai import OpenAIClient
+    from pyagent.plugins.ollama.client import OllamaClient
+
+    for cls in (AnthropicClient, OpenAIClient, GeminiClient, OllamaClient):
+        sig = inspect.signature(cls.respond)
+        _check(
+            f"{cls.__name__}.respond accepts on_text_delta",
+            "on_text_delta" in sig.parameters,
+            str(sig),
+        )
+
+
+def _check_agent_forwards_delta_callback() -> None:
+    """Agent.run(on_text_delta=...) plumbing reaches the client.
+
+    Uses EchoClient as the model so the test runs without a live
+    Ollama server, doesn't burn API keys, and is deterministic.
+    """
+    deltas: list[str] = []
+    full_text: list[str] = []
+
+    agent = Agent(client=EchoClient(), system="x")
+    final = agent.run(
+        prompt="streaming please",
+        on_text=full_text.append,
+        on_text_delta=deltas.append,
+    )
+
+    _check("agent produced final_text", bool(final), final)
+    _check(
+        "agent.on_text fired with the full reply",
+        full_text == ["streaming please"],
+        repr(full_text),
+    )
+    _check(
+        "agent.on_text_delta fired with concatenable chunks",
+        "".join(deltas) == "streaming please",
+        repr(deltas),
+    )
+    _check(
+        "agent fired more than one delta (proves stream wasn't a single dump)",
+        len(deltas) > 1,
+        f"deltas={len(deltas)}",
+    )
+
+
+def main() -> None:
+    _check_echo_streams_word_by_word()
+    _check_echo_no_callback_unchanged()
+    _check_lorem_streams_sentences()
+    _check_provider_signatures_accept_kwarg()
+    _check_agent_forwards_delta_callback()
+    print("smoke_streaming: all checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/smoke_streaming.py
+++ b/tests/smoke_streaming.py
@@ -273,6 +273,159 @@ def _check_anthropic_streaming_mocked() -> None:
         repr(out2),
     )
 
+def _check_openai_streaming_mocked() -> None:
+    """OpenAIClient.respond with on_text_delta uses
+    chat.completions.create(stream=True) and accumulates tool-call
+    arguments by index across chunks."""
+
+    os.environ.setdefault("OPENAI_API_KEY", "dummy-for-smoke")
+    from pyagent.llms.openai import OpenAIClient
+
+    # Stream of chunks: text deltas, then tool-call argument
+    # fragments (OpenAI splits the JSON args string across chunks),
+    # then a final usage chunk.
+    chunks = [
+        _Attr(
+            choices=[_Attr(delta=_Attr(content="Looking ", tool_calls=None))],
+            usage=None,
+        ),
+        _Attr(
+            choices=[_Attr(delta=_Attr(content="this up...", tool_calls=None))],
+            usage=None,
+        ),
+        _Attr(
+            choices=[
+                _Attr(
+                    delta=_Attr(
+                        content=None,
+                        tool_calls=[
+                            _Attr(
+                                index=0,
+                                id="call_42",
+                                function=_Attr(name="lookup", arguments='{"q":'),
+                            )
+                        ],
+                    )
+                )
+            ],
+            usage=None,
+        ),
+        _Attr(
+            choices=[
+                _Attr(
+                    delta=_Attr(
+                        content=None,
+                        tool_calls=[
+                            _Attr(
+                                index=0,
+                                id=None,
+                                function=_Attr(name=None, arguments=' "x"}'),
+                            )
+                        ],
+                    )
+                )
+            ],
+            usage=None,
+        ),
+        _Attr(
+            choices=[],
+            usage=_Attr(
+                prompt_tokens=8,
+                completion_tokens=15,
+                prompt_tokens_details=_Attr(cached_tokens=2),
+            ),
+        ),
+    ]
+
+    captured: dict = {}
+
+    def fake_create(**kwargs):
+        captured["kwargs"] = kwargs
+        return iter(chunks)
+
+    client = OpenAIClient(model="gpt-4o", api_key="dummy")
+    deltas: list[str] = []
+    with mock.patch.object(
+        client._client.chat.completions, "create", side_effect=fake_create
+    ):
+        out = client.respond(
+            conversation=[{"role": "user", "content": "hi"}],
+            on_text_delta=deltas.append,
+        )
+
+    _check(
+        "openai create called with stream=True",
+        captured["kwargs"].get("stream") is True,
+        repr(captured["kwargs"].get("stream")),
+    )
+    _check(
+        "openai create called with include_usage option",
+        captured["kwargs"].get("stream_options") == {"include_usage": True},
+        repr(captured["kwargs"].get("stream_options")),
+    )
+    _check(
+        "openai deltas arrive in chunk order",
+        deltas == ["Looking ", "this up..."],
+        repr(deltas),
+    )
+    _check(
+        "openai concat deltas == returned text",
+        "".join(deltas) == out["text"] == "Looking this up...",
+        repr(out["text"]),
+    )
+    _check(
+        "openai accumulates tool_call args across chunks",
+        len(out["tool_calls"]) == 1
+        and out["tool_calls"][0]["id"] == "call_42"
+        and out["tool_calls"][0]["name"] == "lookup"
+        and out["tool_calls"][0]["args"] == {"q": "x"},
+        repr(out["tool_calls"]),
+    )
+    _check(
+        "openai usage parsed including cache_read",
+        out["usage"]["input"] == 8
+        and out["usage"]["output"] == 15
+        and out["usage"]["cache_read"] == 2,
+        repr(out["usage"]),
+    )
+
+    # No callback → no stream kwarg, returns from a non-iterator response.
+    non_stream_response = _Attr(
+        choices=[
+            _Attr(
+                message=_Attr(
+                    content="non-stream",
+                    tool_calls=None,
+                )
+            )
+        ],
+        usage=_Attr(
+            prompt_tokens=1,
+            completion_tokens=2,
+            prompt_tokens_details=None,
+        ),
+    )
+    captured.clear()
+
+    def fake_create_one_shot(**kwargs):
+        captured["kwargs"] = kwargs
+        return non_stream_response
+
+    fresh = OpenAIClient(model="gpt-4o", api_key="dummy")
+    with mock.patch.object(
+        fresh._client.chat.completions, "create", side_effect=fake_create_one_shot
+    ):
+        out2 = fresh.respond(conversation=[{"role": "user", "content": "x"}])
+    _check(
+        "openai no-callback omits stream from kwargs",
+        "stream" not in captured["kwargs"],
+        repr(captured["kwargs"]),
+    )
+    _check(
+        "openai no-callback returns full text",
+        out2["text"] == "non-stream",
+        repr(out2),
+    )
 
 
 def main() -> None:
@@ -282,6 +435,7 @@ def main() -> None:
     _check_provider_signatures_accept_kwarg()
     _check_agent_forwards_delta_callback()
     _check_anthropic_streaming_mocked()
+    _check_openai_streaming_mocked()
     print("smoke_streaming: all checks passed")
 
 


### PR DESCRIPTION
## Summary

Phase 2 of streaming. Adds an optional `on_text_delta` callback to `LLMClient.respond()`; **all five providers now stream**: pyagent stubs, ollama, Anthropic, OpenAI, Gemini. CLI renders chunks live.

### Wire shape

`respond()` gains `on_text_delta: Callable[[str], None] | None`. When set, the provider streams text chunks through the callback while the call is in flight; the returned dict still carries the fully-accumulated text. Tool calls stay batched at end-of-turn — the agent loop dispatches them as a set, so streaming them piecemeal would just be noise.

### Provider state

- **pyagent stubs** (`EchoClient` / `LoremClient`): real streaming. Echo splits by spaces; Lorem splits by sentence-ending punctuation. Synchronous, no sleeps, useful as a deterministic test bed.
- **ollama**: real streaming via `/api/chat` with `stream=true`. New `_consume_stream` drains NDJSON, fires deltas, folds accumulated text + tool_calls + usage back into `_build_response`. The no-tools-auto-retry path is preserved across both branches via `_post_chat`.
- **Anthropic**: real streaming via `messages.stream()` context manager. `text_stream` yields incremental chunks; `get_final_message()` provides the assembled content blocks (text + tool_use) and usage. Cache-control logic on system + tools blocks is preserved.
- **OpenAI**: real streaming via `chat.completions.create(stream=True, stream_options={"include_usage": True})`. Tool-call args accumulate by `index` since OpenAI splits them character-by-character across chunks. `max_completion_tokens` keeps o-series compatibility.
- **Gemini**: real streaming via `generate_content_stream()`. Each chunk's `candidates[0].content.parts` carries text + function_call parts; usage on the final chunk's `usage_metadata`. Uses the existing `_to_plain` for protobuf normalization.

### Plumbing

- `Agent.run` and `_call_llm` thread the callback through to the client.
- `agent_proc` emits a new `assistant_text_delta` event per chunk. The closing `assistant_text` event still carries the full text so non-streaming consumers (audit, bench, future renderers) keep working uniformly.
- CLI prints chunks inline (dim, soft-wrapped, no markdown). On the closing `assistant_text` it checks whether deltas streamed and either closes out the line (streamed → keep plain text) or falls back to the full markdown render (non-streaming consumer).

### CLI tradeoff

Streamed text loses markdown emphasis (bold, headers, lists, code blocks render as raw `**bold**`). The price for getting characters on screen as they arrive. A re-render pass at end-of-turn could win back markdown — left as a follow-up if the flicker tradeoff is acceptable.

## Test plan

- [ ] `python -m tests.smoke_streaming` passes — protocol surface, pyagent stubs, agent loop forwarding, **all four real providers (Anthropic / OpenAI / Gemini / Ollama) with mocked SDKs**
- [ ] `python -m tests.smoke_ollama_plugin` passes — including NDJSON streaming + tool-call accumulation
- [ ] `python -m tests.smoke_list_models` passes
- [ ] `python -m tests.smoke_plugin_provider` passes
- [ ] `python -m tests.smoke_plugins` passes
- [ ] Manual: `pyagent --model ollama/llama3.2` produces visible token-by-token output
- [ ] Manual: `pyagent --model anthropic` / `--model openai` / `--model gemini` produces visible token-by-token output (with API keys set)

## Phase 2 follow-ups (separate PRs)

- Optional: end-of-turn markdown re-render to recover formatting on streamed replies
- Per-model context-window awareness (separate effort, cross-provider)