### PR TITLE
streaming: re-render markdown after stream completes

### DIFF
--- a/pyagent/cli.py
+++ b/pyagent/cli.py
@@ -82,35 +82,85 @@ def _on_text(text: str, agent_id: str | None = None) -> None:
 
 
 # Per-agent streaming state. Keys are agent_id strings (or "root" for
-# the main agent); values are True from the first `assistant_text_delta`
-# of a text segment until the closing `assistant_text` arrives. Used
-# by the renderer to (a) emit a leading blank line + label exactly
-# once per streamed segment, and (b) decide whether the closing
-# `assistant_text` should re-render as markdown (provider didn't
-# stream) or just close out the line (provider did stream).
-_streaming_open: dict[str, bool] = {}
+# the main agent); each value is a dict tracking what we've streamed
+# so the closing `assistant_text` event can erase it cleanly and
+# re-render the same text as markdown (recovering bold/headers/code-
+# blocks the streamed plain text loses).
+#
+# Fields per state entry:
+#   - "buffer":   plain text streamed so far (no ANSI). Used to count
+#                 visual rows the cursor has advanced.
+#   - "width":    terminal width snapshot at the start of streaming.
+#                 We don't react to mid-turn resize; the cursor math
+#                 would lie if we did.
+#   - "header_advances": how many rows the cursor moved down BEFORE the
+#                 first chunk (leading blank line + optional agent
+#                 label). Tracked separately because it's plain
+#                 newlines with no soft-wrap component.
+_streaming_state: dict[str, dict[str, Any]] = {}
+
+# Strip ANSI control sequences when measuring visible character count.
+# Models occasionally emit `\033[...m` color codes inline; without this
+# strip, our per-row width math would treat them as visible chars and
+# the cursor-up math would over-count.
+_ANSI_RE = re.compile(r"\x1b\[[\d;]*[a-zA-Z]")
+
+
+def _count_cursor_advance(buffer: str, width: int) -> int:
+    """Count how many rows the cursor advanced from where streaming
+    started, given the streamed buffer and the terminal width.
+
+    Each `\\n` counts as one row. Each over-width segment between
+    newlines contributes ``(visible_len - 1) // width`` extra rows
+    from soft-wrapping. ANSI escape sequences are stripped before
+    measuring because they don't occupy visual columns.
+
+    Returns 0 for an empty buffer or non-positive width — both mean
+    "nothing to clear / nowhere safe to compute," and the caller
+    short-circuits the ANSI move.
+    """
+    if not buffer or width <= 0:
+        return 0
+    advance = 0
+    visible = _ANSI_RE.sub("", buffer)
+    segments = visible.split("\n")
+    for i, seg in enumerate(segments):
+        if i > 0:
+            advance += 1  # the newline itself
+        if seg:
+            advance += (len(seg) - 1) // width
+    return advance
 
 
 def _on_text_delta(chunk: str, agent_id: str | None = None) -> None:
     """Print one streaming text chunk inline, no markdown formatting.
 
-    Markdown rendering happens at end-of-turn via the closing
-    `assistant_text` event in the non-streaming case. While streaming
-    we lose markdown emphasis (bold, headers, lists) — the tradeoff
-    for getting characters on screen as the model produces them.
-    Worth it: the user can react to the response shape immediately,
-    and the raw text is still readable for any well-formed reply.
+    Markdown rendering happens at end-of-turn — the closing
+    `assistant_text` event clears the streamed plain text and
+    re-renders the same buffer through `_on_text`, recovering
+    bold/headers/code blocks the streamed dim text loses. The brief
+    reflow on completion is acceptable for the UX win of seeing
+    tokens land in real time AND keeping markdown formatting.
 
     Each text segment in a turn (one per LLM call before/between/
     after tool batches) gets its own leading blank line + agent
     label exactly once, on the first delta.
     """
     key = agent_id or "root"
-    if not _streaming_open.get(key):
+    state = _streaming_state.get(key)
+    if state is None:
         console.print()
+        header_advances = 1
         if agent_id:
             console.print(_agent_label(agent_id))
-        _streaming_open[key] = True
+            header_advances += 1
+        state = {
+            "buffer": "",
+            "width": console.width or 0,
+            "header_advances": header_advances,
+        }
+        _streaming_state[key] = state
+    state["buffer"] += chunk
     # `style="dim"` matches the non-streaming render so the streamed
     # text doesn't visually pop while the user's prompt is still the
     # most-prominent thing on screen.
@@ -1055,17 +1105,28 @@ def _print_event(event: dict) -> None:
         return
     if kind == "assistant_text":
         key = agent_id or "root"
-        if _streaming_open.get(key):
-            # Provider streamed — the buffer already shows the full
-            # text in plain form. Close out with the trailing blank
-            # line and clear the streaming flag; do NOT re-render
-            # as markdown over the top (would force a flicker /
-            # scroll-back that's worse UX than losing markdown).
-            console.print()
-            console.print()
-            _streaming_open.pop(key, None)
-        else:
+        state = _streaming_state.pop(key, None)
+        if state is None:
             # Non-streaming provider — full markdown render as before.
+            _on_text(event["text"], agent_id=agent_id)
+        else:
+            # Provider streamed — wipe the dim plain text we just
+            # printed, then call _on_text so the same text re-renders
+            # with full markdown formatting (bold, headers, lists,
+            # code blocks). Cursor-prev-line + clear-to-end works on
+            # any ANSI-aware terminal; we only emit it when the
+            # console is a real terminal so piped output (test
+            # captures, log redirects) doesn't get garbled by
+            # control sequences.
+            advance = _count_cursor_advance(
+                state["buffer"], state["width"]
+            ) + state["header_advances"]
+            if advance > 0 and console.is_terminal:
+                import sys
+                # `\x1b[<n>F` = Cursor Previous Line: up n lines, col 1.
+                # `\x1b[J`   = Erase from cursor to end of screen.
+                sys.stdout.write(f"\x1b[{advance}F\x1b[J")
+                sys.stdout.flush()
             _on_text(event["text"], agent_id=agent_id)
     elif kind == "tool_call_started":
         _on_tool_call(event["name"], event["args"], agent_id=agent_id)

--- a/tests/smoke_streamed_rerender.py
+++ b/tests/smoke_streamed_rerender.py
@@ -1,0 +1,150 @@
+"""Smoke for the streamed-text cursor-advance counter that drives
+the end-of-turn markdown re-render in `pyagent.cli`.
+
+The CLI streams plain dim text as deltas arrive, then on the closing
+``assistant_text`` event clears the streamed region and re-renders
+the same buffer as markdown so bold/headers/code blocks formatting
+survives. Clearing relies on knowing how many rows the cursor moved
+during streaming — a function of the buffer's hard newlines plus the
+soft wraps each segment incurs against the terminal width. This file
+exercises that pure function across the cases the live render path
+depends on.
+
+CLI integration is harder to test without a real TTY (the rest of
+the streaming surface is covered by ``smoke_streaming.py``); the
+visual reflow is verified manually with ``pyagent --model
+ollama/<model>``.
+
+Run with:
+
+    .venv/bin/python -m tests.smoke_streamed_rerender
+"""
+
+from __future__ import annotations
+
+from pyagent.cli import _count_cursor_advance
+
+
+def _check(label: str, cond: bool, detail: str = "") -> None:
+    sym = "✓" if cond else "✗"
+    extra = f" — {detail}" if detail else ""
+    print(f"{sym} {label}{extra}")
+    if not cond:
+        raise SystemExit(1)
+
+
+def _check_empty_and_degenerate() -> None:
+    _check("empty buffer → 0 advance", _count_cursor_advance("", 80) == 0)
+    _check(
+        "non-positive width → 0 advance (defensive)",
+        _count_cursor_advance("abc", 0) == 0,
+    )
+    _check(
+        "negative width → 0 advance",
+        _count_cursor_advance("abc", -5) == 0,
+    )
+
+
+def _check_short_text_no_wrap() -> None:
+    """Cursor stays on the same row for short text without newlines."""
+    _check(
+        "short non-wrapping text → 0 advance",
+        _count_cursor_advance("abc", 80) == 0,
+    )
+
+
+def _check_hard_newlines() -> None:
+    _check(
+        "trailing newline → 1 advance",
+        _count_cursor_advance("abc\n", 80) == 1,
+    )
+    _check(
+        "two segments separated by one newline → 1 advance",
+        _count_cursor_advance("abc\ndef", 80) == 1,
+    )
+    _check(
+        "three segments → 2 advances",
+        _count_cursor_advance("a\nb\nc", 80) == 2,
+    )
+    _check(
+        "purely-whitespace newlines preserved",
+        _count_cursor_advance("\n\n\n", 80) == 3,
+    )
+
+
+def _check_soft_wrap_boundary() -> None:
+    """Soft-wrap boundary cases — the formula is `(L-1) // W` so
+    exactly W chars do NOT wrap (cursor sits at end of row), but
+    W+1 wraps to a second row."""
+    _check(
+        "exactly width-many chars → no soft wrap",
+        _count_cursor_advance("x" * 80, 80) == 0,
+    )
+    _check(
+        "width+1 chars → 1 soft wrap",
+        _count_cursor_advance("x" * 81, 80) == 1,
+    )
+    _check(
+        "2*width chars → 1 soft wrap",
+        _count_cursor_advance("x" * 160, 80) == 1,
+    )
+    _check(
+        "2*width+1 chars → 2 soft wraps",
+        _count_cursor_advance("x" * 161, 80) == 2,
+    )
+
+
+def _check_mixed_hard_and_soft() -> None:
+    """A long line followed by a hard newline followed by another
+    long line: each long line contributes its soft-wrap count, plus
+    the hard newline contributes 1."""
+    width = 40
+    buf = ("x" * 100) + "\n" + ("y" * 50)
+    # First segment: 100 chars on width 40 → (100-1)//40 = 2 soft wraps
+    # Hard newline: +1
+    # Second segment: 50 chars → (50-1)//40 = 1 soft wrap
+    # Total: 2 + 1 + 1 = 4
+    _check(
+        f"mixed soft-and-hard wrap → 4 advance (got {_count_cursor_advance(buf, width)})",
+        _count_cursor_advance(buf, width) == 4,
+    )
+
+
+def _check_ansi_codes_stripped() -> None:
+    """Models occasionally emit ANSI escape sequences inline. Without
+    stripping, those bytes inflate the visible-length count and we'd
+    over-count cursor advance."""
+    # 80 'x' chars wrapped in dim/reset SGR codes — visible length
+    # is still 80, so no soft wrap.
+    buf = "\x1b[2m" + ("x" * 80) + "\x1b[0m"
+    _check(
+        "ANSI-wrapped text counted by visible length",
+        _count_cursor_advance(buf, 80) == 0,
+        f"buffer-len={len(buf)} visible-len=80 → got {_count_cursor_advance(buf, 80)}",
+    )
+
+    # Width=10, two ANSI codes around 30 visible chars + a newline.
+    buf2 = "\x1b[2m" + "x" * 30 + "\x1b[0m" + "\n" + "y" * 5
+    # First seg visible 30 → (30-1)//10 = 2 soft wraps
+    # Hard \n: +1
+    # Second seg visible 5 → 0 soft wraps
+    # Total: 3
+    _check(
+        "ANSI in mid-buffer doesn't bias count",
+        _count_cursor_advance(buf2, 10) == 3,
+        f"got {_count_cursor_advance(buf2, 10)}",
+    )
+
+
+def main() -> None:
+    _check_empty_and_degenerate()
+    _check_short_text_no_wrap()
+    _check_hard_newlines()
+    _check_soft_wrap_boundary()
+    _check_mixed_hard_and_soft()
+    _check_ansi_codes_stripped()
+    print("smoke_streamed_rerender: all checks passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

End-of-turn markdown re-render for streamed replies. Streaming UX (tokens appear as the model produces them) and markdown UX (bold / headers / lists / code blocks render) were mutually exclusive in the previous PR; this fixes that.

## How it works

- `_streaming_state` (per-agent dict) replaces the previous `_streaming_open` boolean — tracks the streamed buffer, terminal width snapshot, and how many header rows the cursor advanced past (leading blank + optional agent label).
- New `_count_cursor_advance(buffer, width)` computes `hard_newlines + Σ soft_wraps_per_segment`. ANSI escapes in the buffer are stripped before measuring so a model emitting inline color codes doesn't inflate the visible-length math.
- On the closing `assistant_text`, the CLI emits `\x1b[<n>F` (Cursor Previous Line) + `\x1b[J` (Erase to End of Screen) to wipe the streamed region, then calls `_on_text` for the markdown render. Control sequences only fire when `stdout` is a TTY — piped output is left alone.

## Tradeoffs flagged in the commit

- Doesn't react to mid-turn terminal resize (the clear math gets stale)
- Doesn't account for wide-character columns (CJK / emoji over-clear; same flicker outcome, no data loss)
- Content that scrolled off can't be cleared (ANSI moves are bounded by the visible region) — the off-screen plain text stays, markdown renders below

All cosmetic, no data loss in any case.

## Test plan

- [ ] `python -m tests.smoke_streamed_rerender` passes — covers the cursor-advance math (empty / hard newlines / soft-wrap boundaries / mixed / ANSI-stripped)
- [ ] `python -m tests.smoke_streaming` passes — provider-side surface unchanged
- [ ] `python -m tests.smoke_ollama_plugin` passes
- [ ] **Manual**: `pyagent --model ollama/llama3.2 "explain in 3 sentences with markdown formatting"` — streamed dim plain text appears, then on completion clears and re-renders as proper markdown (bold/headers visible)
- [ ] **Manual**: long replies that wrap the terminal still re-render cleanly
- [ ] **Manual**: piped output (`pyagent --model ... < prompt 2>&1 | cat`) doesn't emit garbled ANSI control sequences