### PR TITLE
context window: per-client lookup, footer % gauge, threshold warnings

### DIFF
--- a/pyagent/agent_proc.py
+++ b/pyagent/agent_proc.py
@@ -116,6 +116,12 @@ class _ChildState:
     # mid-turn inbox (turn active) or be promoted to a fresh
     # `user_prompt` (idle window). Issue #68.
     turn_active: threading.Event = field(default_factory=threading.Event)
+    # Highest context-utilization tier we've already warned about
+    # this session. Drives "warn once per crossing" behavior so the
+    # 80% chat warning doesn't repeat on every turn that stays above
+    # the line. Reset to -1 (no tier yet) at construction; tiers are
+    # the integers 0/1/2 corresponding to the 60/80/95% thresholds.
+    _context_warn_tier: int = -1
 
     def send(self, event_type: str, **payload: Any) -> None:
         """Send a typed event upstream (CLI for root, parent agent for sub).
@@ -917,6 +923,75 @@ def _bootstrap(
     return agent, session, loaded_plugins
 
 
+# Context-utilization warning thresholds. List of (percent, label,
+# message_template). Tier index in this list IS the integer stored
+# in `_ChildState._context_warn_tier`; new entries should be added
+# in ascending percent order. Crossing a tier emits an `info` event
+# to the chat once; the per-turn `context_status` event still flows
+# unconditionally so the footer always reflects current state.
+_CONTEXT_WARN_TIERS = (
+    (60, "info", "context: {pct}% of {window:,} tokens used"),
+    (
+        80,
+        "warn",
+        "context: {pct}% of {window:,} tokens used — approaching the limit",
+    ),
+    (
+        95,
+        "warn",
+        "context: {pct}% of {window:,} tokens used — next turn likely to fail",
+    ),
+)
+
+
+def _emit_context_status(
+    state: _ChildState, agent: Agent
+) -> None:
+    """After each turn, compute context utilization vs the model's
+    window and emit one `context_status` event for the footer plus,
+    on a tier crossing, one `info` event for the chat.
+
+    Token counting strategy: we use the *previous turn's*
+    ``usage.input`` as a stand-in for "current context size."
+    That's what the provider just paid attention to; the next
+    turn's input will be roughly that plus output plus any new
+    user/tool messages. It under-counts the not-yet-sent next
+    prompt slightly, but over-warns rather than missing the limit.
+
+    Window=0 means the client doesn't know its own context size
+    (older Ollama, pyagent stubs); skip the emission entirely so the
+    footer hides the segment instead of showing a useless 0%.
+    """
+    client = getattr(agent, "client", None)
+    if client is None:
+        return
+    window = int(getattr(client, "context_window", 0) or 0)
+    if window <= 0:
+        return
+    used = int(agent.token_usage.get("input", 0) or 0)
+    if used <= 0:
+        return
+    pct = max(0, min(100, int(used * 100 / window)))
+    state.send("context_status", pct=pct, used=used, window=window)
+
+    # Emit a chat info on the highest tier we've crossed but not yet
+    # warned about. We track the highest tier reached, not just the
+    # immediate crossing, so a turn that jumps multiple tiers at once
+    # (e.g. 50% → 90%) still surfaces the most-severe warning.
+    new_tier = -1
+    for i, (threshold, _level, _msg) in enumerate(_CONTEXT_WARN_TIERS):
+        if pct >= threshold:
+            new_tier = i
+    if new_tier > state._context_warn_tier:
+        state._context_warn_tier = new_tier
+        threshold, level, template = _CONTEXT_WARN_TIERS[new_tier]
+        state.send(
+            "info",
+            level=level,
+            message=template.format(pct=pct, window=window),
+        )
+
+
 def _run_turn(
     state: _ChildState,
     agent: Agent,
@@ -943,12 +1018,21 @@ def _run_turn(
             on_tool_result=lambda n, c: state.send(
                 "tool_result", name=n, content=c
             ),
-            on_usage=lambda u: state.send(
-                "usage",
-                input=int(u.get("input", 0) or 0),
-                output=int(u.get("output", 0) or 0),
-                cache_creation=int(u.get("cache_creation", 0) or 0),
-                cache_read=int(u.get("cache_read", 0) or 0),
+            on_usage=lambda u: (
+                state.send(
+                    "usage",
+                    input=int(u.get("input", 0) or 0),
+                    output=int(u.get("output", 0) or 0),
+                    cache_creation=int(u.get("cache_creation", 0) or 0),
+                    cache_read=int(u.get("cache_read", 0) or 0),
+                ),
+                # Right after the per-LLM-call usage update is
+                # forwarded, recompute context utilization. Doing it
+                # here (rather than at turn_complete) means the
+                # footer gauge updates between tool batches in a
+                # multi-call turn, matching the rest of the gutter
+                # which is already mid-turn-aware.
+                _emit_context_status(state, agent),
             ),
             cancel_event=state.cancel_event,
         )

--- a/pyagent/cli.py
+++ b/pyagent/cli.py
@@ -607,6 +607,18 @@ def _update_agents_state(
         for k in ("input", "output", "cache_creation", "cache_read"):
             tokens[k] = tokens.get(k, 0) + int(event.get(k, 0) or 0)
         return
+    if kind == "context_status":
+        # Root-emitted (subagents could too in principle, but the
+        # warning that matters for footer real estate is the root's
+        # context). Stash the latest reading; `_context_segment`
+        # reads from here on every footer redraw.
+        slot = agents.setdefault(key, {"status": "thinking"})
+        slot["context"] = {
+            "pct": int(event.get("pct", 0) or 0),
+            "used": int(event.get("used", 0) or 0),
+            "window": int(event.get("window", 0) or 0),
+        }
+        return
 
 
 def _build_input_history(conversation: list[Any]) -> InMemoryHistory:
@@ -742,6 +754,39 @@ def _prompt_message(busy: bool) -> ANSI:
 
 
 _PERMS_HEAD_PREVIEW_MAX = 30
+
+
+_CTX_WARN_PCT = 80
+_CTX_DANGER_PCT = 95
+
+
+def _context_segment(agents: dict) -> str:
+    """Render the footer's context-utilization segment (' · ctx: NN%')
+    or empty.
+
+    Reads the most recent `context_status` reading stashed on the
+    root agent by `_update_agents_state`. Hidden when no reading
+    has arrived yet (first turn before usage flows) or when the
+    model's window is unknown (stub clients, older Ollama). Color
+    escalates yellow at 80%, red at 95% — matches the chat info
+    thresholds emitted by `agent_proc._emit_context_status` so the
+    footer signal and the chat warning are visually consistent.
+    """
+    slot = agents.get("root")
+    if not isinstance(slot, dict):
+        return ""
+    ctx = slot.get("context")
+    if not isinstance(ctx, dict):
+        return ""
+    window = int(ctx.get("window", 0) or 0)
+    if window <= 0:
+        return ""
+    pct = int(ctx.get("pct", 0) or 0)
+    if pct >= _CTX_DANGER_PCT:
+        return f" · [red]ctx: {pct}%[/red]"
+    if pct >= _CTX_WARN_PCT:
+        return f" · [yellow]ctx: {pct}%[/yellow]"
+    return f" · ctx: {pct}%"
 
 
 def _perms_segment(
@@ -957,6 +1002,12 @@ def _compose_footer(
         if not drop_msgs:
             msgs_text, _ = _msgs_segment(agents, drop_severity_tag=drop_msgs_severity)
             center += msgs_text
+        # Context utilization sits at the tail of the center zone:
+        # less load-bearing than checklist/perms/msgs (those are
+        # action items), but still worth a glance. No degradation
+        # path — it's a single short atom that drops itself when the
+        # window is unknown.
+        center += _context_segment(agents)
         return center
 
     # Degradation pipeline. Each step makes one targeted concession
@@ -1063,7 +1114,10 @@ def _compose_footer(
         else:
             msgs_text, sev = _msgs_segment(agents, drop_severity_tag=dms)
             msgs_markup = _style_msgs(msgs_text, sev) if msgs_text else ""
-        left_markup = f"{center_markup}{perms_markup}{msgs_markup}"
+        # Context segment carries its own (yellow / red) styling at
+        # threshold so we don't pipe it through `_style_left`.
+        ctx_markup = _context_segment(agents)
+        left_markup = f"{center_markup}{perms_markup}{msgs_markup}{ctx_markup}"
 
     left_ansi = _markup_to_ansi(left_markup, max(cols, 1))
     left_w = _visible_width(left_ansi)

--- a/pyagent/llms/anthropic.py
+++ b/pyagent/llms/anthropic.py
@@ -6,6 +6,20 @@ from typing import Any, Callable
 from anthropic import Anthropic
 
 
+# Hardcoded context windows per model family. Built-in providers ship
+# these inline because they don't change often and avoid an API round
+# trip just to know "how big is this model's context." Bumping a model
+# is a one-line edit. Default of 200_000 (the modern Claude family
+# baseline) covers any unknown model name conservatively — better to
+# under-warn than over-warn for a model we haven't catalogued yet.
+_CONTEXT_WINDOWS = {
+    "claude-opus-4-7": 200_000,
+    "claude-sonnet-4-6": 200_000,
+    "claude-haiku-4-5-20251001": 200_000,
+}
+_DEFAULT_CONTEXT_WINDOW = 200_000
+
+
 class AnthropicClient:
     """Wraps the Anthropic SDK in our standardized client interface.
 
@@ -32,6 +46,18 @@ class AnthropicClient:
         if not api_key:
             raise ValueError("ANTHROPIC_API_KEY is not set")
         self._client = Anthropic(api_key=api_key)
+
+    @property
+    def context_window(self) -> int:
+        """Maximum prompt-token capacity for this model.
+
+        Used by the agent_proc context-warning machinery to compute
+        utilization vs the window. The lookup falls back to the
+        family default for any model name not in the catalogue —
+        better to under-warn than over-warn on a model we haven't
+        catalogued yet.
+        """
+        return _CONTEXT_WINDOWS.get(self.model, _DEFAULT_CONTEXT_WINDOW)
 
     def respond(
         self,

--- a/pyagent/llms/gemini.py
+++ b/pyagent/llms/gemini.py
@@ -7,6 +7,18 @@ from google import genai
 from google.genai import types
 
 
+# Hardcoded context windows per model. Gemini 2.5 family ships with
+# 2M tokens; Gemini 2.0 has the older 1M ceiling. Default to the
+# more conservative 1M for any unknown model so we don't over-promise
+# on a name we haven't catalogued.
+_CONTEXT_WINDOWS = {
+    "gemini-2.5-flash": 2_000_000,
+    "gemini-2.5-pro": 2_000_000,
+    "gemini-2.0-flash": 1_000_000,
+}
+_DEFAULT_CONTEXT_WINDOW = 1_000_000
+
+
 def _to_plain(value: Any) -> Any:
     """Recursively coerce protobuf composite types (MapComposite,
     RepeatedComposite) into plain dict/list so json.dumps doesn't choke
@@ -46,6 +58,13 @@ class GeminiClient:
         if not key:
             raise ValueError("GEMINI_API_KEY (or GOOGLE_API_KEY) is not set")
         self._client = genai.Client(api_key=key)
+
+    @property
+    def context_window(self) -> int:
+        """Maximum prompt-token capacity for this model. See module
+        docstring for the mapping; falls back to the conservative
+        1M default for unknown model names."""
+        return _CONTEXT_WINDOWS.get(self.model, _DEFAULT_CONTEXT_WINDOW)
 
     def respond(
         self,

--- a/pyagent/llms/openai.py
+++ b/pyagent/llms/openai.py
@@ -7,6 +7,21 @@ from typing import Any, Callable
 from openai import OpenAI
 
 
+# Hardcoded context windows per model. OpenAI's lineup splits between
+# 128K-context flagship chat models and 200K-context o-series reasoning
+# models, so the table is real-data, not a uniform default. Default
+# of 128_000 catches gpt-4-turbo / gpt-4o variants that ship with that
+# size; o-series get an explicit override.
+_CONTEXT_WINDOWS = {
+    "gpt-4o": 128_000,
+    "gpt-4o-mini": 128_000,
+    "o1": 200_000,
+    "o1-mini": 128_000,
+    "o3-mini": 200_000,
+}
+_DEFAULT_CONTEXT_WINDOW = 128_000
+
+
 class OpenAIClient:
     """Wraps the OpenAI SDK in our standardized client interface.
 
@@ -30,6 +45,13 @@ class OpenAIClient:
         self.provider_model = f"openai/{model}"
         self.max_tokens = max_tokens
         self._client = OpenAI(api_key=api_key or os.environ.get("OPENAI_API_KEY"))
+
+    @property
+    def context_window(self) -> int:
+        """Maximum prompt-token capacity for this model. See module
+        docstring for the mapping; falls back to the chat-model
+        default for unknown names."""
+        return _CONTEXT_WINDOWS.get(self.model, _DEFAULT_CONTEXT_WINDOW)
 
     def respond(
         self,

--- a/pyagent/llms/pyagent.py
+++ b/pyagent/llms/pyagent.py
@@ -29,6 +29,12 @@ class EchoClient:
         self.model = model
         self.provider_model = f"pyagent/{model}"
 
+    # Stub clients have no real context budget; reporting 0 makes the
+    # CLI's context-warning machinery treat them as "window unknown"
+    # and skip the footer segment entirely. They're for harness/UX
+    # testing where the budget question doesn't apply.
+    context_window: int = 0
+
     def respond(
         self,
         conversation: list[dict[str, Any]],
@@ -101,6 +107,8 @@ class LoremClient:
     def __init__(self, model: str = "loremipsum") -> None:
         self.model = model
         self.provider_model = f"pyagent/{model}"
+
+    context_window: int = 0
 
     def respond(
         self,

--- a/pyagent/plugins/ollama/client.py
+++ b/pyagent/plugins/ollama/client.py
@@ -155,6 +155,42 @@ class OllamaClient:
         # contract holds — the cost is exactly one extra failed
         # request the first time a no-tools model is used.
         self._skip_tools = False
+        # Cached context-window lookup. None = not yet asked; 0 =
+        # asked-and-unknown (server pre-0.5 / model lacks the field).
+        # Populated by the `context_window` property on first read.
+        self._context_window: int | None = None
+
+    @property
+    def context_window(self) -> int:
+        """Maximum prompt-token capacity for this model, looked up
+        live from the server's `/api/show` payload.
+
+        Cached after first read so the agent loop's per-turn check
+        doesn't redo the HTTP call. Returns 0 when the lookup fails
+        (server unreachable / older Ollama without `model_info`) —
+        the CLI's context-warning machinery treats that as "window
+        unknown" and hides the footer segment, matching the built-in
+        stubs.
+        """
+        if self._context_window is not None:
+            return self._context_window
+        try:
+            info = show_model(self.model, host=self.host)
+        except Exception:
+            self._context_window = 0
+            return 0
+        # Ollama's /api/show puts the architecture's context length
+        # under model_info["<family>.context_length"]. The family
+        # name varies (llama, qwen2, mistral, ...), so scan all keys
+        # ending with `.context_length` and take the first hit.
+        model_info = info.get("model_info") or {}
+        if isinstance(model_info, dict):
+            for key, val in model_info.items():
+                if key.endswith(".context_length") and isinstance(val, int):
+                    self._context_window = val
+                    return val
+        self._context_window = 0
+        return 0
 
     def respond(
         self,

--- a/pyagent/protocol.py
+++ b/pyagent/protocol.py
@@ -78,6 +78,16 @@ agent → CLI
         accumulates these per-agent in its `agents_state` dict and
         renders the running total (and a USD cost estimate when
         the model is in the pricing table) in the status footer.
+  - context_status {pct: int, used: int, window: int}
+        Current context utilization, emitted after every LLM call
+        right after `usage`. `pct` is `used / window * 100` clamped
+        to [0, 100]; `used` is the most recent turn's `usage.input`;
+        `window` is the model's hardcoded or backend-reported
+        context size. Hidden by the CLI when `window` is 0 (stub
+        clients, older Ollama servers without `model_info`). On
+        crossing a 60/80/95% threshold for the first time this
+        session, the agent_proc also emits a corresponding `info`
+        event so the warning lands in the chat surface.
   - checklist {tasks: list[dict]}
         Snapshot of the agent's current task list. Emitted after
         every add_task / update_task call. `tasks` is a list of

--- a/tests/smoke_context_window.py
+++ b/tests/smoke_context_window.py
@@ -1,0 +1,346 @@
+"""End-to-end smoke for the per-model context-window awareness.
+
+Concerns:
+
+  1. **Per-client context_window lookup.** Each built-in client
+     reports a non-zero, model-specific window from a hardcoded
+     table. Stub clients (pyagent/echo, pyagent/loremipsum) report
+     0 so the CLI machinery hides the segment for them.
+  2. **Ollama lazy /api/show fetch + cache.** First read calls the
+     server; subsequent reads return the cached value without a
+     second HTTP call. Lookup failure (server down, model gone,
+     missing field) caches 0 — no retry storm.
+  3. **`agent_proc._emit_context_status` event shape.** With a real
+     usage figure and a known window, fires `context_status` with
+     `pct/used/window`. With window=0 (stub clients), emits
+     nothing. With used=0 (very first turn before any input
+     counted), also emits nothing — protects against a bogus 0%
+     reading on session start.
+  4. **Threshold-crossing info events.** Crossing the 60/80/95
+     boundary emits one `info` per crossing; staying above doesn't
+     re-emit; a single jump that vaults multiple tiers (e.g. 50% →
+     90%) emits the highest-tier info, not a chain of three.
+  5. **CLI footer segment.** `_context_segment` returns the right
+     string at 0/50/85/96%, with yellow/red colorization at
+     threshold and empty when window=0.
+
+Run with:
+
+    .venv/bin/python -m tests.smoke_context_window
+"""
+
+from __future__ import annotations
+
+import os
+from unittest import mock
+
+from pyagent.cli import _context_segment
+
+
+def _check(label: str, cond: bool, detail: str = "") -> None:
+    sym = "✓" if cond else "✗"
+    extra = f" — {detail}" if detail else ""
+    print(f"{sym} {label}{extra}")
+    if not cond:
+        raise SystemExit(1)
+
+
+def _check_builtin_context_windows() -> None:
+    """Each built-in client reports a positive, model-specific
+    window via the new `context_window` property. We don't
+    construct the SDK clients (no API keys); we exercise the
+    static table directly."""
+    from pyagent.llms import anthropic as anthropic_mod
+    from pyagent.llms import gemini as gemini_mod
+    from pyagent.llms import openai as openai_mod
+
+    _check(
+        "anthropic table contains the catalog model",
+        anthropic_mod._CONTEXT_WINDOWS["claude-sonnet-4-6"] == 200_000,
+        repr(anthropic_mod._CONTEXT_WINDOWS),
+    )
+    _check(
+        "anthropic default for unknown name is positive",
+        anthropic_mod._DEFAULT_CONTEXT_WINDOW > 0,
+    )
+
+    _check(
+        "openai distinguishes o-series from chat models",
+        openai_mod._CONTEXT_WINDOWS["o1"] > openai_mod._CONTEXT_WINDOWS["gpt-4o"],
+        repr(openai_mod._CONTEXT_WINDOWS),
+    )
+
+    _check(
+        "gemini 2.5 family is 2M",
+        gemini_mod._CONTEXT_WINDOWS["gemini-2.5-flash"] == 2_000_000,
+    )
+    _check(
+        "gemini 2.0 family is 1M (older ceiling)",
+        gemini_mod._CONTEXT_WINDOWS["gemini-2.0-flash"] == 1_000_000,
+    )
+
+
+def _check_pyagent_stub_context_window_is_zero() -> None:
+    """Stub clients have no real budget; reporting 0 hides the
+    footer segment."""
+    from pyagent.llms.pyagent import EchoClient, LoremClient
+
+    _check(
+        "EchoClient.context_window == 0",
+        EchoClient().context_window == 0,
+    )
+    _check(
+        "LoremClient.context_window == 0",
+        LoremClient().context_window == 0,
+    )
+
+
+def _check_ollama_lazy_show_fetch_and_cache() -> None:
+    """Ollama queries `/api/show` on first read of `context_window`,
+    caches the result, and returns 0 on lookup failure without
+    retrying."""
+    from pyagent.plugins.ollama import client as ollama_client_mod
+
+    class _OK:
+        ok = True
+        status_code = 200
+
+        def __init__(self, payload):
+            self._p = payload
+
+        def json(self):
+            return self._p
+
+        def raise_for_status(self):
+            pass
+
+    calls = []
+
+    def fake_post(url, json=None, timeout=None, stream=False):
+        calls.append(json)
+        return _OK(
+            {
+                "model_info": {
+                    # Architecture-prefixed key matches the live
+                    # Ollama `/api/show` response shape.
+                    "llama.context_length": 131072,
+                    "general.architecture": "llama",
+                }
+            }
+        )
+
+    c = ollama_client_mod.OllamaClient(model="llama3.2")
+    with mock.patch.object(
+        ollama_client_mod.requests, "post", side_effect=fake_post
+    ):
+        first = c.context_window
+        second = c.context_window
+        third = c.context_window
+
+    _check(
+        "first read parsed context_length from model_info",
+        first == 131072,
+        repr(first),
+    )
+    _check(
+        "subsequent reads hit the cache (no extra HTTP)",
+        len(calls) == 1,
+        f"calls={len(calls)}",
+    )
+    _check(
+        "cached value is stable across reads",
+        first == second == third,
+    )
+
+    # Failure path: connection error → caches 0, doesn't retry.
+    def boom(*a, **kw):
+        raise ConnectionError("server down")
+
+    c2 = ollama_client_mod.OllamaClient(model="x")
+    boom_calls: list = []
+
+    def fake_post_boom(*a, **kw):
+        boom_calls.append(1)
+        raise ConnectionError("server down")
+
+    with mock.patch.object(
+        ollama_client_mod.requests, "post", side_effect=fake_post_boom
+    ):
+        v1 = c2.context_window
+        v2 = c2.context_window
+    _check(
+        "lookup failure caches 0",
+        v1 == 0 and v2 == 0,
+        f"v1={v1} v2={v2}",
+    )
+    _check(
+        "lookup failure doesn't retry on subsequent reads",
+        len(boom_calls) == 1,
+        f"calls={len(boom_calls)}",
+    )
+
+    # No model_info at all → caches 0 cleanly.
+    def fake_post_empty(url, json=None, timeout=None, stream=False):
+        return _OK({"capabilities": ["completion"]})
+
+    c3 = ollama_client_mod.OllamaClient(model="z")
+    with mock.patch.object(
+        ollama_client_mod.requests, "post", side_effect=fake_post_empty
+    ):
+        _check(
+            "missing model_info → context_window=0",
+            c3.context_window == 0,
+        )
+
+
+def _check_emit_context_status_shape() -> None:
+    """`_emit_context_status` fires the right events for the right
+    inputs, and skips emission when there's nothing useful to say."""
+    from pyagent.agent_proc import _emit_context_status
+
+    class _Client:
+        def __init__(self, window):
+            self.context_window = window
+
+    class _Agent:
+        def __init__(self, client, used):
+            self.client = client
+            self.token_usage = {"input": used}
+
+    class _State:
+        def __init__(self):
+            self.events: list[tuple] = []
+            self._context_warn_tier = -1
+
+        def send(self, event_type, **payload):
+            self.events.append((event_type, payload))
+
+    # Healthy reading: 50% utilization → context_status only, no
+    # info (we're under the 60% tier).
+    state = _State()
+    _emit_context_status(state, _Agent(_Client(200_000), used=100_000))
+    _check(
+        "50% utilization emits context_status only",
+        state.events == [
+            ("context_status", {"pct": 50, "used": 100_000, "window": 200_000})
+        ],
+        repr(state.events),
+    )
+
+    # Crossing 60% from below → context_status + info(level=info).
+    state = _State()
+    _emit_context_status(state, _Agent(_Client(200_000), used=130_000))
+    types = [e[0] for e in state.events]
+    _check(
+        "65% emits context_status + info",
+        types == ["context_status", "info"],
+        repr(types),
+    )
+    _check(
+        "60% tier latched on _ChildState",
+        state._context_warn_tier == 0,
+    )
+
+    # Staying above 60% on next call → no fresh info.
+    _emit_context_status(state, _Agent(_Client(200_000), used=140_000))
+    types = [e[0] for e in state.events]
+    _check(
+        "stay-above tier doesn't re-emit info",
+        types == ["context_status", "info", "context_status"],
+        repr(types),
+    )
+
+    # Multi-tier jump in one call (50% → 90%): info fires once at
+    # the highest tier we crossed, not once per tier.
+    state = _State()
+    _emit_context_status(state, _Agent(_Client(200_000), used=180_000))
+    types = [e[0] for e in state.events]
+    _check(
+        "multi-tier jump emits one info at highest tier",
+        types == ["context_status", "info"],
+        repr(types),
+    )
+    _check(
+        "highest tier (80% bucket) latched, not 60%",
+        state._context_warn_tier == 1,
+        f"tier={state._context_warn_tier}",
+    )
+
+    # Window=0 (stub client): emit nothing.
+    state = _State()
+    _emit_context_status(state, _Agent(_Client(0), used=999))
+    _check(
+        "window=0 emits nothing (footer hides the segment)",
+        state.events == [],
+        repr(state.events),
+    )
+
+    # Used=0 (no LLM calls yet): emit nothing — avoids a bogus 0%
+    # before the first turn finishes.
+    state = _State()
+    _emit_context_status(state, _Agent(_Client(200_000), used=0))
+    _check(
+        "used=0 emits nothing",
+        state.events == [],
+        repr(state.events),
+    )
+
+
+def _check_context_segment_renders() -> None:
+    """`_context_segment` reads from agents['root']['context'] and
+    formats it with threshold colors."""
+    # No state → empty.
+    _check(
+        "no agents → empty",
+        _context_segment({}) == "",
+    )
+    _check(
+        "no context key → empty",
+        _context_segment({"root": {"status": "thinking"}}) == "",
+    )
+
+    # window=0 → empty (stub clients).
+    agents = {"root": {"context": {"pct": 0, "used": 0, "window": 0}}}
+    _check(
+        "window=0 → empty",
+        _context_segment(agents) == "",
+    )
+
+    # Healthy 50% → plain ` · ctx: 50%`.
+    agents = {"root": {"context": {"pct": 50, "used": 100_000, "window": 200_000}}}
+    _check(
+        "50% → plain segment, no color",
+        _context_segment(agents) == " · ctx: 50%",
+        repr(_context_segment(agents)),
+    )
+
+    # 85% → yellow.
+    agents["root"]["context"]["pct"] = 85
+    seg = _context_segment(agents)
+    _check(
+        "85% → yellow markup",
+        "yellow" in seg and "85%" in seg,
+        seg,
+    )
+
+    # 96% → red.
+    agents["root"]["context"]["pct"] = 96
+    seg = _context_segment(agents)
+    _check(
+        "96% → red markup",
+        "red" in seg and "96%" in seg,
+        seg,
+    )
+
+
+def main() -> None:
+    _check_builtin_context_windows()
+    _check_pyagent_stub_context_window_is_zero()
+    _check_ollama_lazy_show_fetch_and_cache()
+    _check_emit_context_status_shape()
+    _check_context_segment_renders()
+    print("smoke_context_window: all checks passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Per-model context-window awareness across every provider. Phase 1 of context budgeting: **warn loudly, let the provider's overflow error surface naturally if the user ignores**. No automatic dropping or summarizing — those need their own design conversation and are easy to get wrong silently.

Surfaces both signals the user agreed to:
- **Status footer**: ` · ctx: NN%` at the tail of the center zone, yellow at 80%, red at 95%
- **Chat message**: an `info` event lands at every threshold crossing (60% / 80% / 95%) so the warning is in the conversation transcript, not just the peripheral footer

## Per-client context_window

- **Anthropic / OpenAI / Gemini**: hardcoded per-model lookup tables, with sensible defaults for uncatalogued names. One-line edits to bump.
- **Ollama**: lazy `/api/show` fetch, cached on the client instance. The architecture-prefixed `<family>.context_length` field is scanned out of `model_info`. Failure (server down, missing field) caches 0 — no retry storm.
- **pyagent stubs** (echo, loremipsum): return 0 ("unknown / unbounded"). Footer machinery treats 0 as "hide the segment."

Live verified: ollama llama3.2:latest → 131072 (matches what the server reports).

## Threshold logic

- Per-turn `context_status {pct, used, window}` event for the footer (mid-turn-aware: fires between tool batches alongside `usage`)
- Emission skipped when `window=0` or `used=0` so we never show a bogus 0% on a stub client or the very first turn
- 60 / 80 / 95% tiers. Crossing fires one `info` event per crossing
- A multi-tier jump (50% → 90%) emits one info at the highest tier, not a chain of three
- Tier latch on `_ChildState` — staying above a threshold doesn't re-warn on every turn

## Token-counting strategy (worth flagging)

Used = the most recent turn's `usage.input`. That's what the provider just paid attention to. The next turn will be roughly that plus output plus any new user/tool messages — so this under-counts the not-yet-sent next prompt slightly, which means we **over-warn rather than miss the limit**. Trade-off chosen deliberately: no extra dependency on per-provider tokenizers (`tiktoken`, `anthropic.count_tokens`, etc.), no extra API calls, no tokenizer-version drift to maintain.

## Test plan

- [ ] `python -m tests.smoke_context_window` passes — built-in tables, Ollama lazy fetch + cache + failure, threshold state machine (single / repeated / multi-tier), footer segment at each tier
- [ ] All other smokes still pass (regression sweep: `smoke_streaming`, `smoke_ollama_plugin`, `smoke_list_models`, `smoke_plugin_provider`, `smoke_plugins`, `smoke_status_footer`, `smoke_streamed_rerender`, `smoke_submit_handler`, `smoke_token_meter`, `smoke_permission_handler`)
- [ ] Manual: long conversation against `--model ollama/llama3.2` (131K window) — footer gauge climbs as the conversation grows; chat info messages land at 60/80/95
- [ ] Manual: same against `--model anthropic` (200K window) — verify the warnings still trigger before the provider returns its own overflow error

## Phase 2 follow-ups (separate PRs)

- Auto-trim oldest non-system messages when overflow is imminent
- Auto-summarize older history via a sub-LLM-call (the "compact" pattern)
- Per-provider tokenizers for accurate counting (replaces the projection-from-last-turn approximation)