### PR TITLE
doc-tools: bundled plugin for sub-LLM extract / summarize

### DIFF
--- a/pyagent/plugins/doc_tools/__init__.py
+++ b/pyagent/plugins/doc_tools/__init__.py
@@ -1,0 +1,289 @@
+"""doc-tools — bundled plugin: sub-LLM document extract / summarize.
+
+Two stateless tools, both single-shot sub-LLM calls over one document:
+
+  - ``extract(path, query, schema=None, model=None)`` — pull structured
+    fields / lists / tables out of a document. Use when the agent wants
+    specific information from a doc larger than ~4KB; for smaller docs,
+    ``read_file`` is strictly cheaper.
+  - ``summarize(path, focus=None, max_chars=1500, model=None)`` —
+    compress a document to prose. Same scale guidance.
+
+The motivation: the main agent reasoning over a 40KB markdown file via
+``read_file`` slices burns turns paginating through previews. Delegating
+to a focused sub-LLM that returns just the answer keeps those bytes off
+the main conversation.
+
+Configuration (all optional, all read at call time):
+
+  ``[plugins.doc-tools]`` table in pyagent's config TOML
+    ``model`` — provider/model string the tools call. Defaults to
+        ``anthropic/claude-haiku-4-5-20251001``: cheap, fast,
+        tool-capable. Per-call ``model=`` overrides.
+    ``min_size_chars`` — files smaller than this trigger a "just
+        read it directly" response instead of spinning up a sub-LLM.
+        Defaults to 4000 — below that the round-trip cost beats
+        ``read_file`` + reasoning.
+
+A model fallback chain (``model = ["ollama/...", "anthropic/..."]``)
+is intentionally not implemented in v0.1. See the doc_tools follow-up
+issue for the design.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from pyagent import permissions
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_MODEL = "anthropic/claude-haiku-4-5-20251001"
+_DEFAULT_MIN_SIZE_CHARS = 4000
+
+# Cap how much of the document we send to the sub-LLM in one call.
+# Most modern small models handle ~200K context, but the cost scales
+# with input length and the user is paying per call. 200K chars is
+# generous for almost any single document; if a user really needs to
+# extract from a megabyte of text, that's a different shape (chunk +
+# map-reduce) we can build later.
+_MAX_DOC_CHARS = 200_000
+
+
+_EXTRACT_SYSTEM = (
+    "You are an extraction worker. Given a document and an extraction "
+    "request, return ONLY the requested information — no preamble, no "
+    "commentary, no apology. If the request implies structured data "
+    "(a list, a table, fields), output JSON. Otherwise output terse "
+    "plain text. If the document does not contain what was asked, "
+    "return the literal token <not found> and nothing else."
+)
+
+_SUMMARIZE_SYSTEM = (
+    "You are a summarization worker. Produce a concise summary of the "
+    "document. No preamble, no meta-commentary. If a focus is given, "
+    "lead with that aspect. Stay under the requested character budget."
+)
+
+
+def _read_doc(path: str) -> tuple[str, str | None]:
+    """Read `path` for sub-LLM consumption.
+
+    Returns (text, error). On success error is None. On any failure,
+    text is empty and error is a `<...>` marker the tool can return
+    to the agent verbatim.
+    """
+    p = Path(path)
+    if not permissions.require_access(p):
+        return "", f"<access denied: {path}>"
+    try:
+        text = p.read_text()
+    except FileNotFoundError:
+        return "", f"<file not found: {path}>"
+    except IsADirectoryError:
+        return "", f"<is a directory, not a file: {path}>"
+    except PermissionError:
+        return "", f"<permission denied: {path}>"
+    except UnicodeDecodeError:
+        return "", f"<binary file (not text): {path}>"
+    except OSError as e:
+        return "", f"<could not read {path}: {e}>"
+    return text, None
+
+
+def _resolve_model(plugin_cfg: dict, override: str | None) -> str:
+    if override:
+        return str(override)
+    cfg_model = plugin_cfg.get("model")
+    if isinstance(cfg_model, str) and cfg_model.strip():
+        return cfg_model.strip()
+    return _DEFAULT_MODEL
+
+
+def _resolve_min_size(plugin_cfg: dict) -> int:
+    raw = plugin_cfg.get("min_size_chars")
+    if isinstance(raw, int) and raw >= 0:
+        return raw
+    return _DEFAULT_MIN_SIZE_CHARS
+
+
+def _call_subllm(model: str, system: str, user: str) -> tuple[str, str]:
+    """Run one sub-LLM turn. Returns (text, error).
+
+    Error is empty on success. On any failure, text is empty and
+    error is a short reason the tool wraps in its own marker.
+    """
+    # Deferred import: keeps pyagent.llms out of plugin-load critical
+    # path for users who never invoke doc-tools.
+    from pyagent import llms
+
+    try:
+        client = llms.get_client(model)
+    except Exception as e:
+        return "", f"could not load model {model!r}: {e}"
+    try:
+        result = client.respond(
+            conversation=[{"role": "user", "content": user}],
+            system=system,
+        )
+    except Exception as e:
+        return "", f"sub-LLM call failed ({model!r}): {e}"
+    text = result.get("text") if isinstance(result, dict) else None
+    if not isinstance(text, str) or not text.strip():
+        return "", f"sub-LLM returned no text ({model!r})"
+    return text, ""
+
+
+def register(api):
+    plugin_cfg_getter = lambda: api.plugin_config
+
+    def extract(
+        path: str,
+        query: str,
+        schema: str | None = None,
+        model: str | None = None,
+    ) -> str:
+        """Extract structured info from a document via a sub-LLM.
+
+        Use this for documents larger than a few KB when you want
+        specific fields, lists, or tables. The sub-LLM reads the whole
+        document and returns just the answer — far fewer turns than
+        slicing through previews with ``read_file``. For small files
+        (<4KB by default), this tool refuses and tells you to read
+        directly.
+
+        Args:
+            path: File to extract from. Subject to the standard
+                permission gate.
+            query: What to extract. Be specific. "List each horse with
+                name, odds, jockey, trainer as JSON" beats "tell me
+                about the horses". Vague queries produce vague results.
+            schema: Optional JSON schema string. When provided, the
+                extractor is told to return strict JSON conforming
+                to the schema.
+            model: Optional ``provider/model`` override. Defaults to
+                the configured model
+                (``[plugins.doc-tools] model`` in config.toml).
+
+        Returns:
+            The extracted text or JSON, prefixed with the model that
+            produced it. Errors return as ``<extract error: ...>``.
+        """
+        if not isinstance(path, str) or not path.strip():
+            return "<error: path is required>"
+        if not isinstance(query, str) or not query.strip():
+            return "<error: query is required — describe what to extract>"
+
+        plugin_cfg = plugin_cfg_getter() or {}
+        min_size = _resolve_min_size(plugin_cfg)
+        text, err = _read_doc(path)
+        if err is not None:
+            return err
+        if len(text) < min_size:
+            return (
+                f"<file is {len(text)} chars (under {min_size}-char "
+                f"threshold); read_file directly with start/end is "
+                f"strictly cheaper than spinning up a sub-LLM>"
+            )
+        if len(text) > _MAX_DOC_CHARS:
+            return (
+                f"<file is {len(text)} chars (over {_MAX_DOC_CHARS}-char "
+                f"limit); slice with read_file or grep first, then "
+                f"call extract on a narrower range>"
+            )
+
+        resolved_model = _resolve_model(plugin_cfg, model)
+        user_parts = [f"Document path: {path}", "Document content:", text, ""]
+        if schema:
+            user_parts.append(
+                f"Return JSON matching this schema:\n{schema}"
+            )
+        user_parts.append(f"Extraction request: {query}")
+        user = "\n".join(user_parts)
+
+        out, err_str = _call_subllm(resolved_model, _EXTRACT_SYSTEM, user)
+        if err_str:
+            return f"<extract error: {err_str}>"
+        return f"[extracted via {resolved_model}]\n{out}"
+
+    def summarize(
+        path: str,
+        focus: str | None = None,
+        max_chars: int = 1500,
+        model: str | None = None,
+    ) -> str:
+        """Summarize a document via a sub-LLM.
+
+        Use this when you want the gist of a doc larger than a few
+        KB without dragging the whole text through your context.
+        For small files, ``read_file`` directly is cheaper.
+
+        Args:
+            path: File to summarize. Subject to the standard
+                permission gate.
+            focus: Optional aspect to emphasize (e.g., "financial
+                figures", "deadlines", "API surface"). The summary
+                will lead with this if specified.
+            max_chars: Target length for the summary, in characters.
+                Default 1500. The sub-LLM is asked to stay under this;
+                it may slightly overshoot.
+            model: Optional ``provider/model`` override. Defaults to
+                the configured model
+                (``[plugins.doc-tools] model`` in config.toml).
+
+        Returns:
+            The summary text, prefixed with the model that produced
+            it. Errors return as ``<summarize error: ...>``.
+        """
+        if not isinstance(path, str) or not path.strip():
+            return "<error: path is required>"
+        try:
+            max_chars_int = int(max_chars)
+        except (TypeError, ValueError):
+            return f"<error: max_chars must be an integer, got {max_chars!r}>"
+        if max_chars_int < 100:
+            return (
+                f"<error: max_chars={max_chars_int} too small; "
+                f"minimum 100>"
+            )
+
+        plugin_cfg = plugin_cfg_getter() or {}
+        min_size = _resolve_min_size(plugin_cfg)
+        text, err = _read_doc(path)
+        if err is not None:
+            return err
+        if len(text) < min_size:
+            return (
+                f"<file is {len(text)} chars (under {min_size}-char "
+                f"threshold); read_file directly is cheaper than "
+                f"spinning up a sub-LLM>"
+            )
+        if len(text) > _MAX_DOC_CHARS:
+            return (
+                f"<file is {len(text)} chars (over {_MAX_DOC_CHARS}-char "
+                f"limit); slice with read_file first>"
+            )
+
+        resolved_model = _resolve_model(plugin_cfg, model)
+        user_parts = [
+            f"Document path: {path}",
+            "Document content:",
+            text,
+            "",
+            f"Summary budget: under {max_chars_int} characters.",
+        ]
+        if focus:
+            user_parts.append(f"Focus on: {focus}")
+        user_parts.append("Produce the summary now.")
+        user = "\n".join(user_parts)
+
+        out, err_str = _call_subllm(resolved_model, _SUMMARIZE_SYSTEM, user)
+        if err_str:
+            return f"<summarize error: {err_str}>"
+        return f"[summarized via {resolved_model}]\n{out}"
+
+    api.register_tool("extract", extract)
+    api.register_tool("summarize", summarize)

--- a/pyagent/plugins/doc_tools/__init__.py
+++ b/pyagent/plugins/doc_tools/__init__.py
@@ -18,17 +18,26 @@ Configuration (all optional, all read at call time):
 
   ``[plugins.doc-tools]`` table in pyagent's config TOML
     ``model`` — provider/model string the tools call. Defaults to
-        ``ollama/llama3.2:latest`` — chosen from a head-to-head over
-        local ollama models on representative fixtures: 5s extract,
-        sub-1s summarize, perfect schema match, 2GB on disk. Requires
-        the ollama daemon running and the model pulled; users without
-        ollama should set this to a hosted model
-        (e.g. ``anthropic/claude-haiku-4-5-20251001``). Per-call
-        ``model=`` overrides.
-    ``min_size_chars`` — files smaller than this trigger a "just
-        read it directly" response instead of spinning up a sub-LLM.
-        Defaults to 4000 — below that the round-trip cost beats
-        ``read_file`` + reasoning.
+        ``anthropic/claude-haiku-4-5-20251001``: cheap, fast,
+        tool-capable. Local users can switch to ollama with e.g.
+        ``model = "ollama/llama3.2:latest"`` (the empirical winner
+        of an 8-model eval; see PR #84 for the table).
+
+  ``PYAGENT_DOC_TOOLS_MODEL`` env var
+    Same shape as the config ``model`` value. Useful for
+    per-shell overrides without touching config.toml — testing,
+    CI, ad-hoc invocation.
+
+  ``min_size_chars`` (config only)
+    Files smaller than this trigger a "just read it directly"
+    response instead of spinning up a sub-LLM. Defaults to 4000 —
+    below that the round-trip cost beats ``read_file`` + reasoning.
+
+Resolution order, highest priority first:
+  1. Per-call ``model=`` argument.
+  2. ``PYAGENT_DOC_TOOLS_MODEL`` env var.
+  3. ``[plugins.doc-tools] model`` in config.toml.
+  4. Hardcoded default (haiku).
 
 A model fallback chain (``model = ["ollama/...", "anthropic/..."]``)
 is intentionally not implemented in v0.1. See the doc_tools follow-up
@@ -38,6 +47,7 @@ issue for the design.
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 from typing import Any
 
@@ -46,8 +56,9 @@ from pyagent import permissions
 logger = logging.getLogger(__name__)
 
 
-_DEFAULT_MODEL = "ollama/llama3.2:latest"
+_DEFAULT_MODEL = "anthropic/claude-haiku-4-5-20251001"
 _DEFAULT_MIN_SIZE_CHARS = 4000
+_MODEL_ENV_VAR = "PYAGENT_DOC_TOOLS_MODEL"
 
 # Cap how much of the document we send to the sub-LLM in one call.
 # Most modern small models handle ~200K context, but the cost scales
@@ -100,8 +111,18 @@ def _read_doc(path: str) -> tuple[str, str | None]:
 
 
 def _resolve_model(plugin_cfg: dict, override: str | None) -> str:
+    """Pick the model string for this call.
+
+    Order: per-call override → env var → plugin config → hardcoded default.
+    Env beats config so a user can switch models per-shell without
+    editing config.toml — the typical "let me try this with X real
+    quick" workflow.
+    """
     if override:
         return str(override)
+    env_model = os.environ.get(_MODEL_ENV_VAR, "").strip()
+    if env_model:
+        return env_model
     cfg_model = plugin_cfg.get("model")
     if isinstance(cfg_model, str) and cfg_model.strip():
         return cfg_model.strip()

--- a/pyagent/plugins/doc_tools/__init__.py
+++ b/pyagent/plugins/doc_tools/__init__.py
@@ -173,6 +173,111 @@ def _resolve_cache_size(plugin_cfg: dict) -> int:
     return _DEFAULT_CACHE_SIZE
 
 
+def _config_warnings(plugin_cfg: dict) -> list[str]:
+    """Sanity-check the ``[plugins.doc-tools]`` table at register time.
+
+    Returns a list of human-readable warning strings — the caller logs
+    them via ``api.log("warning", ...)``. None of these warnings block
+    registration: the silent-fallback resolvers (``_resolve_*``) still
+    promote bogus values to defaults at call time. The point is fast
+    feedback at startup so a typo in config.toml doesn't sit unnoticed
+    until the agent next invokes the tool.
+
+    Network probes (e.g. "is the configured ollama daemon reachable?")
+    are deliberately *not* done here — the configured model is one of
+    four resolution sources, so an unreachable default doesn't
+    necessarily mean the tool will fail. See the discussion in PR #84.
+    """
+    out: list[str] = []
+
+    # Model: must be a non-empty string. If it has a `/`, both halves
+    # must be non-empty. If it's a bare name (the "shorthand" form,
+    # e.g. ``--model anthropic`` → defaults applied), it must match a
+    # built-in provider — bare strings that look like model names
+    # without a provider prefix are the most common config typo.
+    raw_model = plugin_cfg.get("model")
+    if raw_model is not None:
+        if not isinstance(raw_model, str):
+            out.append(
+                f"model must be a string, got "
+                f"{type(raw_model).__name__}: {raw_model!r}"
+            )
+        else:
+            stripped = raw_model.strip()
+            if not stripped:
+                out.append("model is set but empty / whitespace-only")
+            elif "/" in stripped:
+                provider, _, name = stripped.partition("/")
+                if not provider.strip() or not name.strip():
+                    out.append(
+                        f"model {raw_model!r} has empty provider or "
+                        f"model name (expected 'provider/model')"
+                    )
+            else:
+                # Bare provider name. We can only verify against
+                # built-ins here because plugin-registered providers
+                # (e.g. ``ollama``) populate after every plugin's
+                # register() runs. Accept silently for shorthand the
+                # user may be using on purpose (rare in config), warn
+                # only when it's clearly off.
+                from pyagent import llms
+
+                builtins = {p.name for p in llms.PROVIDERS}
+                if stripped not in builtins and stripped != "ollama":
+                    out.append(
+                        f"model {raw_model!r} has no '/' separator and "
+                        f"doesn't match a known provider; expected "
+                        f"'provider/model' form"
+                    )
+
+    # timeout_s: positive integer.
+    if "timeout_s" in plugin_cfg:
+        raw = plugin_cfg["timeout_s"]
+        if not isinstance(raw, int) or isinstance(raw, bool):
+            out.append(
+                f"timeout_s must be a positive integer, got "
+                f"{type(raw).__name__}: {raw!r} — using default "
+                f"{_DEFAULT_TIMEOUT_S}"
+            )
+        elif raw <= 0:
+            out.append(
+                f"timeout_s must be > 0, got {raw} — using default "
+                f"{_DEFAULT_TIMEOUT_S}"
+            )
+
+    # cache_size: non-negative integer (0 disables).
+    if "cache_size" in plugin_cfg:
+        raw = plugin_cfg["cache_size"]
+        if not isinstance(raw, int) or isinstance(raw, bool):
+            out.append(
+                f"cache_size must be a non-negative integer, got "
+                f"{type(raw).__name__}: {raw!r} — using default "
+                f"{_DEFAULT_CACHE_SIZE}"
+            )
+        elif raw < 0:
+            out.append(
+                f"cache_size must be >= 0, got {raw} — using default "
+                f"{_DEFAULT_CACHE_SIZE}"
+            )
+
+    # min_size_chars: non-negative integer.
+    if "min_size_chars" in plugin_cfg:
+        raw = plugin_cfg["min_size_chars"]
+        if not isinstance(raw, int) or isinstance(raw, bool):
+            out.append(
+                f"min_size_chars must be a non-negative integer, got "
+                f"{type(raw).__name__}: {raw!r} — using default "
+                f"{_DEFAULT_MIN_SIZE_CHARS}"
+            )
+        elif raw < 0:
+            out.append(
+                f"min_size_chars must be >= 0, got {raw} — using "
+                f"default {_DEFAULT_MIN_SIZE_CHARS}"
+            )
+
+    return out
+
+
 def _validate_schema(schema: Any) -> tuple[str, str | None]:
     """Validate the optional schema arg. Returns (clean, error).
 
@@ -293,6 +398,13 @@ def _call_subllm(
 
 
 def register(api):
+    # Lightweight register-time validation of the [plugins.doc-tools]
+    # table. Bogus values still fall through to defaults at call time
+    # (via the _resolve_* helpers) — this is purely about surfacing
+    # config typos at startup instead of letting them sit silent.
+    for warning in _config_warnings(api.plugin_config or {}):
+        api.log("warning", warning)
+
     def extract_doc(
         path: str,
         query: str,

--- a/pyagent/plugins/doc_tools/__init__.py
+++ b/pyagent/plugins/doc_tools/__init__.py
@@ -18,8 +18,13 @@ Configuration (all optional, all read at call time):
 
   ``[plugins.doc-tools]`` table in pyagent's config TOML
     ``model`` — provider/model string the tools call. Defaults to
-        ``anthropic/claude-haiku-4-5-20251001``: cheap, fast,
-        tool-capable. Per-call ``model=`` overrides.
+        ``ollama/llama3.2:latest`` — chosen from a head-to-head over
+        local ollama models on representative fixtures: 5s extract,
+        sub-1s summarize, perfect schema match, 2GB on disk. Requires
+        the ollama daemon running and the model pulled; users without
+        ollama should set this to a hosted model
+        (e.g. ``anthropic/claude-haiku-4-5-20251001``). Per-call
+        ``model=`` overrides.
     ``min_size_chars`` — files smaller than this trigger a "just
         read it directly" response instead of spinning up a sub-LLM.
         Defaults to 4000 — below that the round-trip cost beats
@@ -41,7 +46,7 @@ from pyagent import permissions
 logger = logging.getLogger(__name__)
 
 
-_DEFAULT_MODEL = "anthropic/claude-haiku-4-5-20251001"
+_DEFAULT_MODEL = "ollama/llama3.2:latest"
 _DEFAULT_MIN_SIZE_CHARS = 4000
 
 # Cap how much of the document we send to the sub-LLM in one call.

--- a/pyagent/plugins/doc_tools/__init__.py
+++ b/pyagent/plugins/doc_tools/__init__.py
@@ -2,11 +2,11 @@
 
 Two stateless tools, both single-shot sub-LLM calls over one document:
 
-  - ``extract(path, query, schema=None, model=None)`` — pull structured
-    fields / lists / tables out of a document. Use when the agent wants
-    specific information from a doc larger than ~4KB; for smaller docs,
-    ``read_file`` is strictly cheaper.
-  - ``summarize(path, focus=None, max_chars=1500, model=None)`` —
+  - ``extract_doc(path, query, schema=None, model=None)`` — pull
+    structured fields / lists / tables out of a document. Use when
+    the agent wants specific information from a doc larger than ~4KB;
+    for smaller docs, ``read_file`` is strictly cheaper.
+  - ``summarize_doc(path, focus=None, max_chars=1500, model=None)`` —
     compress a document to prose. Same scale guidance.
 
 The motivation: the main agent reasoning over a 40KB markdown file via
@@ -22,16 +22,20 @@ Configuration (all optional, all read at call time):
         tool-capable. Local users can switch to ollama with e.g.
         ``model = "ollama/llama3.2:latest"`` (the empirical winner
         of an 8-model eval; see PR #84 for the table).
+    ``min_size_chars`` — files smaller than this trigger a "just
+        read it directly" response instead of spinning up a sub-LLM.
+        Defaults to 4000.
+    ``timeout_s`` — wall-clock cap on a single sub-LLM call.
+        Defaults to 300 (5 minutes). Hung daemons / wedged remote
+        providers surface as ``<… error: sub-LLM call timed out …>``
+        instead of blocking the agent loop indefinitely.
+    ``cache_size`` — number of cached results to retain
+        (process-local, LRU). Defaults to 64. Set to 0 to disable.
 
   ``PYAGENT_DOC_TOOLS_MODEL`` env var
     Same shape as the config ``model`` value. Useful for
     per-shell overrides without touching config.toml — testing,
     CI, ad-hoc invocation.
-
-  ``min_size_chars`` (config only)
-    Files smaller than this trigger a "just read it directly"
-    response instead of spinning up a sub-LLM. Defaults to 4000 —
-    below that the round-trip cost beats ``read_file`` + reasoning.
 
 Resolution order, highest priority first:
   1. Per-call ``model=`` argument.
@@ -46,8 +50,11 @@ issue for the design.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
+import threading
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any
 
@@ -58,6 +65,8 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_MODEL = "anthropic/claude-haiku-4-5-20251001"
 _DEFAULT_MIN_SIZE_CHARS = 4000
+_DEFAULT_TIMEOUT_S = 300
+_DEFAULT_CACHE_SIZE = 64
 _MODEL_ENV_VAR = "PYAGENT_DOC_TOOLS_MODEL"
 
 # Cap how much of the document we send to the sub-LLM in one call.
@@ -67,6 +76,11 @@ _MODEL_ENV_VAR = "PYAGENT_DOC_TOOLS_MODEL"
 # extract from a megabyte of text, that's a different shape (chunk +
 # map-reduce) we can build later.
 _MAX_DOC_CHARS = 200_000
+
+# Schema strings get embedded in the user prompt verbatim. Cap so a
+# pathological caller can't blow up the context window from this
+# argument alone. Real JSON Schemas are rarely larger than a few KB.
+_MAX_SCHEMA_CHARS = 16_000
 
 
 _EXTRACT_SYSTEM = (
@@ -83,6 +97,13 @@ _SUMMARIZE_SYSTEM = (
     "document. No preamble, no meta-commentary. If a focus is given, "
     "lead with that aspect. Stay under the requested character budget."
 )
+
+
+# Process-local LRU cache. Keys are tuples that include path
+# + mtime_ns + size, so a touched/edited file naturally invalidates.
+# Errors are *not* cached — a flaky network shouldn't poison repeats.
+_cache: "OrderedDict[tuple, str]" = OrderedDict()
+_cache_lock = threading.Lock()
 
 
 def _read_doc(path: str) -> tuple[str, str | None]:
@@ -104,7 +125,9 @@ def _read_doc(path: str) -> tuple[str, str | None]:
     except PermissionError:
         return "", f"<permission denied: {path}>"
     except UnicodeDecodeError:
-        return "", f"<binary file (not text): {path}>"
+        # Could be Latin-1, UTF-16, or genuinely binary. We can't
+        # tell from one decode failure, so don't claim "binary."
+        return "", f"<could not decode as text (not utf-8): {path}>"
     except OSError as e:
         return "", f"<could not read {path}: {e}>"
     return text, None
@@ -136,11 +159,97 @@ def _resolve_min_size(plugin_cfg: dict) -> int:
     return _DEFAULT_MIN_SIZE_CHARS
 
 
-def _call_subllm(model: str, system: str, user: str) -> tuple[str, str]:
+def _resolve_timeout(plugin_cfg: dict) -> int:
+    raw = plugin_cfg.get("timeout_s")
+    if isinstance(raw, int) and raw > 0:
+        return raw
+    return _DEFAULT_TIMEOUT_S
+
+
+def _resolve_cache_size(plugin_cfg: dict) -> int:
+    raw = plugin_cfg.get("cache_size")
+    if isinstance(raw, int) and raw >= 0:
+        return raw
+    return _DEFAULT_CACHE_SIZE
+
+
+def _validate_schema(schema: Any) -> tuple[str, str | None]:
+    """Validate the optional schema arg. Returns (clean, error).
+
+    Bad inputs return (empty, marker). A None / empty / whitespace
+    schema is treated as "no schema" and returns ("", None) — caller
+    skips the schema block entirely.
+    """
+    if schema is None:
+        return "", None
+    if not isinstance(schema, str):
+        return (
+            "",
+            f"<error: schema must be a string, got {type(schema).__name__}>",
+        )
+    s = schema.strip()
+    if not s:
+        return "", None
+    if len(s) > _MAX_SCHEMA_CHARS:
+        return (
+            "",
+            f"<error: schema is {len(s)} chars (max {_MAX_SCHEMA_CHARS})>",
+        )
+    try:
+        json.loads(s)
+    except json.JSONDecodeError as e:
+        return "", f"<error: schema is not valid JSON: {e}>"
+    return s, None
+
+
+def _file_signature(path: str) -> tuple[str, int, int] | None:
+    """Return (resolved_path, mtime_ns, size) or None if the file
+    can't be stat'd. Used as the file-content slice of the cache key
+    — touch / edit invalidates naturally because mtime changes."""
+    try:
+        p = Path(path).resolve()
+        st = p.stat()
+    except OSError:
+        return None
+    return str(p), st.st_mtime_ns, st.st_size
+
+
+def _cache_get(key: tuple) -> str | None:
+    with _cache_lock:
+        if key in _cache:
+            _cache.move_to_end(key)
+            return _cache[key]
+    return None
+
+
+def _cache_put(key: tuple, value: str, max_size: int) -> None:
+    if max_size <= 0:
+        return
+    with _cache_lock:
+        _cache[key] = value
+        _cache.move_to_end(key)
+        while len(_cache) > max_size:
+            _cache.popitem(last=False)
+
+
+def _cache_clear() -> None:
+    """Drop all cached entries. Test hook; not exposed as a tool."""
+    with _cache_lock:
+        _cache.clear()
+
+
+def _call_subllm(
+    model: str, system: str, user: str, timeout_s: int
+) -> tuple[str, str]:
     """Run one sub-LLM turn. Returns (text, error).
 
     Error is empty on success. On any failure, text is empty and
     error is a short reason the tool wraps in its own marker.
+
+    Timeout is enforced via a daemon thread we join with a deadline.
+    This is not concurrency — it's a kill-able wrapper around one
+    blocking I/O call. Daemon=True so a stalled call doesn't block
+    Python's exit handlers when the user Ctrl-C's the agent.
     """
     # Deferred import: keeps pyagent.llms out of plugin-load critical
     # path for users who never invoke doc-tools.
@@ -150,13 +259,33 @@ def _call_subllm(model: str, system: str, user: str) -> tuple[str, str]:
         client = llms.get_client(model)
     except Exception as e:
         return "", f"could not load model {model!r}: {e}"
-    try:
-        result = client.respond(
-            conversation=[{"role": "user", "content": user}],
-            system=system,
-        )
-    except Exception as e:
-        return "", f"sub-LLM call failed ({model!r}): {e}"
+
+    box: dict[str, Any] = {}
+
+    def _do_call() -> None:
+        try:
+            box["result"] = client.respond(
+                conversation=[{"role": "user", "content": user}],
+                system=system,
+            )
+        except Exception as e:  # noqa: BLE001 — surface to the tool result
+            box["error"] = e
+
+    t = threading.Thread(target=_do_call, daemon=True)
+    t.start()
+    t.join(timeout=timeout_s)
+
+    if t.is_alive():
+        # The daemon thread is still running. We can't cancel it —
+        # Python doesn't have safe thread-kill — but daemon=True means
+        # the orphaned worker won't block process exit. The user's
+        # call gets a clean timeout marker; the LLM client's own HTTP
+        # connection will time out on its own schedule.
+        return "", f"sub-LLM call timed out after {timeout_s}s ({model!r})"
+    if "error" in box:
+        return "", f"sub-LLM call failed ({model!r}): {box['error']}"
+
+    result = box.get("result")
     text = result.get("text") if isinstance(result, dict) else None
     if not isinstance(text, str) or not text.strip():
         return "", f"sub-LLM returned no text ({model!r})"
@@ -164,9 +293,7 @@ def _call_subllm(model: str, system: str, user: str) -> tuple[str, str]:
 
 
 def register(api):
-    plugin_cfg_getter = lambda: api.plugin_config
-
-    def extract(
+    def extract_doc(
         path: str,
         query: str,
         schema: str | None = None,
@@ -181,6 +308,11 @@ def register(api):
         (<4KB by default), this tool refuses and tells you to read
         directly.
 
+        Results are cached process-locally by (path + mtime + size,
+        query, schema, resolved-model), so identical re-queries of an
+        unchanged document return instantly without re-spending a
+        sub-LLM call. Touching or editing the file invalidates.
+
         Args:
             path: File to extract from. Subject to the standard
                 permission gate.
@@ -189,7 +321,8 @@ def register(api):
                 about the horses". Vague queries produce vague results.
             schema: Optional JSON schema string. When provided, the
                 extractor is told to return strict JSON conforming
-                to the schema.
+                to the schema. Validated as parseable JSON (rejected
+                on parse error) and capped at 16K chars.
             model: Optional ``provider/model`` override. Defaults to
                 the configured model
                 (``[plugins.doc-tools] model`` in config.toml).
@@ -202,8 +335,11 @@ def register(api):
             return "<error: path is required>"
         if not isinstance(query, str) or not query.strip():
             return "<error: query is required — describe what to extract>"
+        clean_schema, schema_err = _validate_schema(schema)
+        if schema_err is not None:
+            return schema_err
 
-        plugin_cfg = plugin_cfg_getter() or {}
+        plugin_cfg = api.plugin_config or {}
         min_size = _resolve_min_size(plugin_cfg)
         text, err = _read_doc(path)
         if err is not None:
@@ -218,24 +354,39 @@ def register(api):
             return (
                 f"<file is {len(text)} chars (over {_MAX_DOC_CHARS}-char "
                 f"limit); slice with read_file or grep first, then "
-                f"call extract on a narrower range>"
+                f"call extract_doc on a narrower range>"
             )
 
         resolved_model = _resolve_model(plugin_cfg, model)
+        sig = _file_signature(path)
+        cache_size = _resolve_cache_size(plugin_cfg)
+        cache_key: tuple | None = None
+        if sig is not None and cache_size > 0:
+            cache_key = ("extract_doc", sig, query, clean_schema, resolved_model)
+            cached = _cache_get(cache_key)
+            if cached is not None:
+                return cached
+
         user_parts = [f"Document path: {path}", "Document content:", text, ""]
-        if schema:
+        if clean_schema:
             user_parts.append(
-                f"Return JSON matching this schema:\n{schema}"
+                f"Return JSON matching this schema:\n{clean_schema}"
             )
         user_parts.append(f"Extraction request: {query}")
         user = "\n".join(user_parts)
 
-        out, err_str = _call_subllm(resolved_model, _EXTRACT_SYSTEM, user)
+        timeout_s = _resolve_timeout(plugin_cfg)
+        out, err_str = _call_subllm(
+            resolved_model, _EXTRACT_SYSTEM, user, timeout_s
+        )
         if err_str:
             return f"<extract error: {err_str}>"
-        return f"[extracted via {resolved_model}]\n{out}"
+        result_str = f"[extracted via {resolved_model}]\n{out}"
+        if cache_key is not None:
+            _cache_put(cache_key, result_str, cache_size)
+        return result_str
 
-    def summarize(
+    def summarize_doc(
         path: str,
         focus: str | None = None,
         max_chars: int = 1500,
@@ -246,6 +397,11 @@ def register(api):
         Use this when you want the gist of a doc larger than a few
         KB without dragging the whole text through your context.
         For small files, ``read_file`` directly is cheaper.
+
+        Results are cached process-locally by (path + mtime + size,
+        focus, max_chars, resolved-model). Identical re-queries of an
+        unchanged document return instantly. Touching or editing the
+        file invalidates.
 
         Args:
             path: File to summarize. Subject to the standard
@@ -276,7 +432,7 @@ def register(api):
                 f"minimum 100>"
             )
 
-        plugin_cfg = plugin_cfg_getter() or {}
+        plugin_cfg = api.plugin_config or {}
         min_size = _resolve_min_size(plugin_cfg)
         text, err = _read_doc(path)
         if err is not None:
@@ -294,6 +450,18 @@ def register(api):
             )
 
         resolved_model = _resolve_model(plugin_cfg, model)
+        sig = _file_signature(path)
+        cache_size = _resolve_cache_size(plugin_cfg)
+        cache_key: tuple | None = None
+        focus_norm = (focus or "").strip()
+        if sig is not None and cache_size > 0:
+            cache_key = (
+                "summarize_doc", sig, focus_norm, max_chars_int, resolved_model,
+            )
+            cached = _cache_get(cache_key)
+            if cached is not None:
+                return cached
+
         user_parts = [
             f"Document path: {path}",
             "Document content:",
@@ -301,15 +469,21 @@ def register(api):
             "",
             f"Summary budget: under {max_chars_int} characters.",
         ]
-        if focus:
-            user_parts.append(f"Focus on: {focus}")
+        if focus_norm:
+            user_parts.append(f"Focus on: {focus_norm}")
         user_parts.append("Produce the summary now.")
         user = "\n".join(user_parts)
 
-        out, err_str = _call_subllm(resolved_model, _SUMMARIZE_SYSTEM, user)
+        timeout_s = _resolve_timeout(plugin_cfg)
+        out, err_str = _call_subllm(
+            resolved_model, _SUMMARIZE_SYSTEM, user, timeout_s
+        )
         if err_str:
             return f"<summarize error: {err_str}>"
-        return f"[summarized via {resolved_model}]\n{out}"
+        result_str = f"[summarized via {resolved_model}]\n{out}"
+        if cache_key is not None:
+            _cache_put(cache_key, result_str, cache_size)
+        return result_str
 
-    api.register_tool("extract", extract)
-    api.register_tool("summarize", summarize)
+    api.register_tool("extract_doc", extract_doc)
+    api.register_tool("summarize_doc", summarize_doc)

--- a/pyagent/plugins/doc_tools/manifest.toml
+++ b/pyagent/plugins/doc_tools/manifest.toml
@@ -1,0 +1,26 @@
+name = "doc-tools"
+version = "0.1.0"
+description = "Sub-LLM document tools: extract structured data, summarize prose."
+api_version = "1"
+
+# Two stateless tools that wrap a single sub-LLM call:
+#
+#   extract(path, query, schema=None, model=None)
+#       Pull structured fields / lists / tables from a document.
+#       Use when the agent wants specific information out of a doc
+#       larger than ~4KB, where read_file + reasoning would burn
+#       turns paginating through previews.
+#
+#   summarize(path, focus=None, max_chars=1500, model=None)
+#       Compress a document to prose. Same scale guidance.
+#
+# The configured model is a fixed default; per-call `model=` overrides
+# it. A fallback chain across providers is intentionally out of scope
+# for v0.1 — see the issue on doc_tools fallback for the design.
+
+[provides]
+tools = ["extract", "summarize"]
+
+# Stateless and read-only — fine to load in subagents.
+[load]
+in_subagents = true

--- a/pyagent/plugins/doc_tools/manifest.toml
+++ b/pyagent/plugins/doc_tools/manifest.toml
@@ -5,21 +5,23 @@ api_version = "1"
 
 # Two stateless tools that wrap a single sub-LLM call:
 #
-#   extract(path, query, schema=None, model=None)
+#   extract_doc(path, query, schema=None, model=None)
 #       Pull structured fields / lists / tables from a document.
 #       Use when the agent wants specific information out of a doc
 #       larger than ~4KB, where read_file + reasoning would burn
 #       turns paginating through previews.
 #
-#   summarize(path, focus=None, max_chars=1500, model=None)
+#   summarize_doc(path, focus=None, max_chars=1500, model=None)
 #       Compress a document to prose. Same scale guidance.
 #
-# The configured model is a fixed default; per-call `model=` overrides
+# Results are cached process-locally (LRU) by file mtime + args, so
+# identical re-queries of an unchanged doc return instantly. The
+# configured model is a fixed default; per-call `model=` overrides
 # it. A fallback chain across providers is intentionally out of scope
-# for v0.1 — see the issue on doc_tools fallback for the design.
+# for v0.1 — see the doc_tools fallback follow-up issue.
 
 [provides]
-tools = ["extract", "summarize"]
+tools = ["extract_doc", "summarize_doc"]
 
 # Stateless and read-only — fine to load in subagents.
 [load]

--- a/tests/smoke_doc_tools.py
+++ b/tests/smoke_doc_tools.py
@@ -1,0 +1,289 @@
+"""End-to-end smoke for the doc-tools plugin.
+
+Six concerns:
+
+  1. **Plugin discovers and registers both tools.** ``register()``
+     publishes ``extract`` and ``summarize`` through the plugin API
+     surface; callers can fetch them off the registered map.
+  2. **Size-floor guardrail fires for small files.** A doc under
+     ``min_size_chars`` returns a ``<file is N chars …>`` marker
+     pointing the caller back to ``read_file`` instead of spinning
+     up a sub-LLM.
+  3. **Bigger doc invokes the sub-LLM and returns prefixed output.**
+     Using the ``pyagent/echo`` stub (which returns the most-recent
+     user message verbatim), we verify the document content and
+     query made it into the LLM call and the prefix names the model.
+  4. **Per-call ``model=`` override beats the configured model.**
+  5. **Configured ``model`` value is honored when no override.**
+  6. **Validation paths return string markers, not raises** —
+     missing path, missing query, bogus ``max_chars``, nonexistent
+     file, and a sub-LLM that fails all surface as ``<… error: …>``.
+
+Run with:
+
+    .venv/bin/python -m tests.smoke_doc_tools
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+from pyagent import permissions
+from pyagent.plugins import doc_tools as dt_mod
+
+
+def _capture_tools() -> dict:
+    """Run ``register()`` against a fake API; return the captured tools.
+
+    The fake also lets us stub out ``plugin_config`` so individual
+    checks can drive config-driven behavior without touching the real
+    config.toml on disk.
+    """
+    captured: dict = {"tools": {}, "plugin_config": {}}
+
+    class _FakeAPI:
+        @property
+        def plugin_config(self):
+            return captured["plugin_config"]
+
+        def register_tool(self, name, fn):
+            captured["tools"][name] = fn
+
+    dt_mod.register(_FakeAPI())
+    return captured
+
+
+def _check_register_publishes_both_tools() -> None:
+    cap = _capture_tools()
+    assert set(cap["tools"].keys()) == {"extract", "summarize"}, cap["tools"]
+    print("✓ register() publishes extract + summarize")
+
+
+def _check_size_floor_extract() -> None:
+    """A small file gets the read_file pointer, not a sub-LLM call."""
+    cap = _capture_tools()
+    cap["plugin_config"] = {"min_size_chars": 1000}
+    extract = cap["tools"]["extract"]
+
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".txt", delete=False
+    ) as f:
+        f.write("tiny content " * 5)  # ~65 chars
+        path = f.name
+
+    permissions.pre_approve(path)
+    try:
+        out = extract(path, "extract anything")
+    finally:
+        Path(path).unlink()
+
+    assert isinstance(out, str), type(out)
+    assert out.startswith("<file is "), out
+    assert "under 1000-char threshold" in out, out
+    assert "read_file" in out, out
+    print("✓ extract: small file → read_file pointer (no sub-LLM call)")
+
+
+def _check_size_floor_summarize() -> None:
+    cap = _capture_tools()
+    cap["plugin_config"] = {"min_size_chars": 1000}
+    summarize = cap["tools"]["summarize"]
+
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".txt", delete=False
+    ) as f:
+        f.write("tiny" * 10)
+        path = f.name
+    permissions.pre_approve(path)
+    try:
+        out = summarize(path)
+    finally:
+        Path(path).unlink()
+
+    assert out.startswith("<file is "), out
+    assert "read_file" in out, out
+    print("✓ summarize: small file → read_file pointer")
+
+
+def _check_extract_invokes_subllm_via_echo_stub() -> None:
+    """Bigger doc + echo stub: confirm content + query reached the LLM
+    and the prefix names the model."""
+    cap = _capture_tools()
+    # Override-via-call so this check is independent of config.
+    extract = cap["tools"]["extract"]
+
+    body = "DOCSENTINEL " * 500  # well over the 4KB default floor
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".txt", delete=False
+    ) as f:
+        f.write(body)
+        path = f.name
+    permissions.pre_approve(path)
+    try:
+        out = extract(
+            path,
+            "QUERYSENTINEL: list every occurrence",
+            model="pyagent/echo",
+        )
+    finally:
+        Path(path).unlink()
+
+    assert isinstance(out, str), type(out)
+    assert out.startswith("[extracted via pyagent/echo]\n"), out
+    # Echo returns the user message verbatim; the doc, query, and path
+    # are all wrapped into that user message.
+    assert "DOCSENTINEL" in out, out
+    assert "QUERYSENTINEL" in out, out
+    assert path in out, out
+    print("✓ extract: big doc → sub-LLM call carries doc + query + path")
+
+
+def _check_summarize_invokes_subllm_via_echo_stub() -> None:
+    cap = _capture_tools()
+    summarize = cap["tools"]["summarize"]
+
+    body = "SUMMARY-SENTINEL " * 300
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".txt", delete=False
+    ) as f:
+        f.write(body)
+        path = f.name
+    permissions.pre_approve(path)
+    try:
+        out = summarize(
+            path,
+            focus="FOCUSSENTINEL on key terms",
+            max_chars=500,
+            model="pyagent/echo",
+        )
+    finally:
+        Path(path).unlink()
+
+    assert out.startswith("[summarized via pyagent/echo]\n"), out
+    assert "SUMMARY-SENTINEL" in out, out
+    assert "FOCUSSENTINEL" in out, out
+    assert "Summary budget: under 500 characters." in out, out
+    print("✓ summarize: prefix + body + focus + budget reach the LLM")
+
+
+def _check_per_call_model_overrides_config() -> None:
+    cap = _capture_tools()
+    cap["plugin_config"] = {"model": "pyagent/loremipsum"}
+    extract = cap["tools"]["extract"]
+
+    body = "X" * 8000
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".txt", delete=False
+    ) as f:
+        f.write(body)
+        path = f.name
+    permissions.pre_approve(path)
+    try:
+        # Per-call override should win, not the configured loremipsum.
+        out = extract(path, "anything", model="pyagent/echo")
+    finally:
+        Path(path).unlink()
+    assert out.startswith("[extracted via pyagent/echo]\n"), out
+    print("✓ per-call model= overrides plugin config")
+
+
+def _check_configured_model_is_honored() -> None:
+    cap = _capture_tools()
+    cap["plugin_config"] = {"model": "pyagent/echo"}
+    extract = cap["tools"]["extract"]
+
+    body = "Y" * 8000
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".txt", delete=False
+    ) as f:
+        f.write(body)
+        path = f.name
+    permissions.pre_approve(path)
+    try:
+        out = extract(path, "anything")  # no override
+    finally:
+        Path(path).unlink()
+    assert out.startswith("[extracted via pyagent/echo]\n"), out
+    print("✓ configured model is used when no per-call override")
+
+
+def _check_input_validation() -> None:
+    cap = _capture_tools()
+    extract = cap["tools"]["extract"]
+    summarize = cap["tools"]["summarize"]
+
+    # Missing path
+    assert extract("", "q") == "<error: path is required>"
+    assert summarize("") == "<error: path is required>"
+    # Missing query
+    assert extract("/tmp/anything.txt", "").startswith(
+        "<error: query is required"
+    )
+    # Bad max_chars
+    out = summarize("/tmp/whatever", max_chars="not-a-number")
+    assert out.startswith("<error: max_chars must be an integer"), out
+    out = summarize("/tmp/whatever", max_chars=10)
+    assert out.startswith("<error: max_chars="), out
+    print("✓ input validation: missing path/query, bogus max_chars")
+
+
+def _check_nonexistent_file_marker() -> None:
+    cap = _capture_tools()
+    cap["plugin_config"] = {"min_size_chars": 100}  # anything above zero
+    extract = cap["tools"]["extract"]
+
+    bogus = "/tmp/__doc_tools_smoke_does_not_exist__.txt"
+    permissions.pre_approve(bogus)
+    out = extract(bogus, "anything")
+    assert out == f"<file not found: {bogus}>", out
+    print("✓ nonexistent path → <file not found: ...> marker")
+
+
+def _check_subllm_failure_wrapped() -> None:
+    """A factory that raises (e.g. missing API key) becomes a tool-result
+    error string, not a raise out of the tool."""
+    cap = _capture_tools()
+    extract = cap["tools"]["extract"]
+
+    body = "Z" * 8000
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".txt", delete=False
+    ) as f:
+        f.write(body)
+        path = f.name
+    permissions.pre_approve(path)
+
+    from pyagent import llms
+
+    def _boom(model):
+        raise RuntimeError("simulated provider unavailable")
+
+    try:
+        with mock.patch.object(llms, "get_client", side_effect=_boom):
+            out = extract(path, "anything", model="pyagent/echo")
+    finally:
+        Path(path).unlink()
+
+    assert out.startswith("<extract error:"), out
+    assert "simulated provider unavailable" in out, out
+    print("✓ sub-LLM construction failure → <extract error: ...> marker")
+
+
+def main() -> None:
+    _check_register_publishes_both_tools()
+    _check_size_floor_extract()
+    _check_size_floor_summarize()
+    _check_extract_invokes_subllm_via_echo_stub()
+    _check_summarize_invokes_subllm_via_echo_stub()
+    _check_per_call_model_overrides_config()
+    _check_configured_model_is_honored()
+    _check_input_validation()
+    _check_nonexistent_file_marker()
+    _check_subllm_failure_wrapped()
+    print("smoke_doc_tools: all checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/smoke_doc_tools.py
+++ b/tests/smoke_doc_tools.py
@@ -18,6 +18,9 @@ Six concerns:
   6. **Validation paths return string markers, not raises** —
      missing path, missing query, bogus ``max_chars``, nonexistent
      file, and a sub-LLM that fails all surface as ``<… error: …>``.
+  7. **Env var overrides config but loses to per-call.**
+     ``PYAGENT_DOC_TOOLS_MODEL`` beats ``[plugins.doc-tools] model``
+     and is beaten by an explicit ``model=`` argument.
 
 Run with:
 
@@ -26,6 +29,7 @@ Run with:
 
 from __future__ import annotations
 
+import os
 import tempfile
 from pathlib import Path
 from unittest import mock
@@ -189,6 +193,43 @@ def _check_per_call_model_overrides_config() -> None:
     print("✓ per-call model= overrides plugin config")
 
 
+def _check_env_var_overrides_config() -> None:
+    """``PYAGENT_DOC_TOOLS_MODEL`` beats config; loses to per-call."""
+    cap = _capture_tools()
+    cap["plugin_config"] = {"model": "pyagent/loremipsum"}
+    extract = cap["tools"]["extract"]
+
+    body = "X" * 8000
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".txt", delete=False
+    ) as f:
+        f.write(body)
+        path = f.name
+    permissions.pre_approve(path)
+    try:
+        # Env beats config.
+        with mock.patch.dict(
+            os.environ, {"PYAGENT_DOC_TOOLS_MODEL": "pyagent/echo"}
+        ):
+            out = extract(path, "anything")
+        assert out.startswith("[extracted via pyagent/echo]\n"), out
+
+        # Per-call still beats env. Both are set; explicit wins.
+        with mock.patch.dict(
+            os.environ, {"PYAGENT_DOC_TOOLS_MODEL": "pyagent/loremipsum"}
+        ):
+            out = extract(path, "anything", model="pyagent/echo")
+        assert out.startswith("[extracted via pyagent/echo]\n"), out
+
+        # Empty / whitespace env var falls through to config.
+        with mock.patch.dict(os.environ, {"PYAGENT_DOC_TOOLS_MODEL": "   "}):
+            out = extract(path, "anything")
+        assert out.startswith("[extracted via pyagent/loremipsum]\n"), out
+    finally:
+        Path(path).unlink()
+    print("✓ env var: beats config, loses to per-call, empty falls through")
+
+
 def _check_configured_model_is_honored() -> None:
     cap = _capture_tools()
     cap["plugin_config"] = {"model": "pyagent/echo"}
@@ -272,12 +313,17 @@ def _check_subllm_failure_wrapped() -> None:
 
 
 def main() -> None:
+    # Ensure the env var isn't bleeding in from the runner's shell —
+    # several checks assume "no env override" as their baseline.
+    os.environ.pop("PYAGENT_DOC_TOOLS_MODEL", None)
+
     _check_register_publishes_both_tools()
     _check_size_floor_extract()
     _check_size_floor_summarize()
     _check_extract_invokes_subllm_via_echo_stub()
     _check_summarize_invokes_subllm_via_echo_stub()
     _check_per_call_model_overrides_config()
+    _check_env_var_overrides_config()
     _check_configured_model_is_honored()
     _check_input_validation()
     _check_nonexistent_file_marker()

--- a/tests/smoke_doc_tools.py
+++ b/tests/smoke_doc_tools.py
@@ -1,26 +1,37 @@
 """End-to-end smoke for the doc-tools plugin.
 
-Six concerns:
+Concerns covered:
 
   1. **Plugin discovers and registers both tools.** ``register()``
-     publishes ``extract`` and ``summarize`` through the plugin API
-     surface; callers can fetch them off the registered map.
+     publishes ``extract_doc`` and ``summarize_doc`` through the
+     plugin API surface; callers can fetch them off the registered map.
   2. **Size-floor guardrail fires for small files.** A doc under
      ``min_size_chars`` returns a ``<file is N chars …>`` marker
      pointing the caller back to ``read_file`` instead of spinning
      up a sub-LLM.
-  3. **Bigger doc invokes the sub-LLM and returns prefixed output.**
+  3. **Max-size guardrail fires for huge files.** Over the 200K
+     hard ceiling, the tool refuses with a "slice with read_file
+     first" pointer.
+  4. **Bigger doc invokes the sub-LLM and returns prefixed output.**
      Using the ``pyagent/echo`` stub (which returns the most-recent
      user message verbatim), we verify the document content and
      query made it into the LLM call and the prefix names the model.
-  4. **Per-call ``model=`` override beats the configured model.**
-  5. **Configured ``model`` value is honored when no override.**
-  6. **Validation paths return string markers, not raises** —
-     missing path, missing query, bogus ``max_chars``, nonexistent
-     file, and a sub-LLM that fails all surface as ``<… error: …>``.
+  5. **Per-call ``model=`` override beats the configured model.**
+  6. **Configured ``model`` value is honored when no override.**
   7. **Env var overrides config but loses to per-call.**
      ``PYAGENT_DOC_TOOLS_MODEL`` beats ``[plugins.doc-tools] model``
      and is beaten by an explicit ``model=`` argument.
+  8. **Validation paths return string markers, not raises** —
+     missing path, missing query, bogus ``max_chars``, nonexistent
+     file, unicode-decode failures, permission denial, and a
+     sub-LLM that fails all surface as ``<… error: …>``.
+  9. **Schema validation** — non-string types, oversized strings,
+     and non-JSON strings each return a typed error marker.
+ 10. **Sub-LLM timeout** — a hung sub-LLM call surfaces as a clean
+     timeout marker, not an indefinite hang of the agent loop.
+ 11. **LRU cache** — identical re-queries of an unchanged file
+     return without invoking the sub-LLM. Touching the file
+     invalidates. Disabled with ``cache_size = 0``.
 
 Run with:
 
@@ -31,6 +42,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+import time
 from pathlib import Path
 from unittest import mock
 
@@ -43,8 +55,10 @@ def _capture_tools() -> dict:
 
     The fake also lets us stub out ``plugin_config`` so individual
     checks can drive config-driven behavior without touching the real
-    config.toml on disk.
+    config.toml on disk. Each call to _capture_tools also clears the
+    module-level LRU cache so checks don't bleed into each other.
     """
+    dt_mod._cache_clear()
     captured: dict = {"tools": {}, "plugin_config": {}}
 
     class _FakeAPI:
@@ -61,15 +75,17 @@ def _capture_tools() -> dict:
 
 def _check_register_publishes_both_tools() -> None:
     cap = _capture_tools()
-    assert set(cap["tools"].keys()) == {"extract", "summarize"}, cap["tools"]
-    print("✓ register() publishes extract + summarize")
+    assert set(cap["tools"].keys()) == {"extract_doc", "summarize_doc"}, (
+        cap["tools"]
+    )
+    print("✓ register() publishes extract_doc + summarize_doc")
 
 
 def _check_size_floor_extract() -> None:
     """A small file gets the read_file pointer, not a sub-LLM call."""
     cap = _capture_tools()
     cap["plugin_config"] = {"min_size_chars": 1000}
-    extract = cap["tools"]["extract"]
+    extract = cap["tools"]["extract_doc"]
 
     with tempfile.NamedTemporaryFile(
         "w", suffix=".txt", delete=False
@@ -87,13 +103,13 @@ def _check_size_floor_extract() -> None:
     assert out.startswith("<file is "), out
     assert "under 1000-char threshold" in out, out
     assert "read_file" in out, out
-    print("✓ extract: small file → read_file pointer (no sub-LLM call)")
+    print("✓ extract_doc: small file → read_file pointer (no sub-LLM call)")
 
 
 def _check_size_floor_summarize() -> None:
     cap = _capture_tools()
     cap["plugin_config"] = {"min_size_chars": 1000}
-    summarize = cap["tools"]["summarize"]
+    summarize = cap["tools"]["summarize_doc"]
 
     with tempfile.NamedTemporaryFile(
         "w", suffix=".txt", delete=False
@@ -108,15 +124,36 @@ def _check_size_floor_summarize() -> None:
 
     assert out.startswith("<file is "), out
     assert "read_file" in out, out
-    print("✓ summarize: small file → read_file pointer")
+    print("✓ summarize_doc: small file → read_file pointer")
+
+
+def _check_max_size_guardrail() -> None:
+    """Files over the 200K hard ceiling refuse without a sub-LLM call."""
+    cap = _capture_tools()
+    extract = cap["tools"]["extract_doc"]
+
+    body = "X" * (dt_mod._MAX_DOC_CHARS + 1000)
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".txt", delete=False
+    ) as f:
+        f.write(body)
+        path = f.name
+    permissions.pre_approve(path)
+    try:
+        out = extract(path, "anything", model="pyagent/echo")
+    finally:
+        Path(path).unlink()
+    assert out.startswith("<file is "), out
+    assert "over 200000-char limit" in out, out
+    assert "slice with read_file" in out, out
+    print("✓ extract_doc: over-size file → slice-first pointer")
 
 
 def _check_extract_invokes_subllm_via_echo_stub() -> None:
     """Bigger doc + echo stub: confirm content + query reached the LLM
     and the prefix names the model."""
     cap = _capture_tools()
-    # Override-via-call so this check is independent of config.
-    extract = cap["tools"]["extract"]
+    extract = cap["tools"]["extract_doc"]
 
     body = "DOCSENTINEL " * 500  # well over the 4KB default floor
     with tempfile.NamedTemporaryFile(
@@ -136,17 +173,15 @@ def _check_extract_invokes_subllm_via_echo_stub() -> None:
 
     assert isinstance(out, str), type(out)
     assert out.startswith("[extracted via pyagent/echo]\n"), out
-    # Echo returns the user message verbatim; the doc, query, and path
-    # are all wrapped into that user message.
     assert "DOCSENTINEL" in out, out
     assert "QUERYSENTINEL" in out, out
     assert path in out, out
-    print("✓ extract: big doc → sub-LLM call carries doc + query + path")
+    print("✓ extract_doc: big doc → sub-LLM call carries doc + query + path")
 
 
 def _check_summarize_invokes_subllm_via_echo_stub() -> None:
     cap = _capture_tools()
-    summarize = cap["tools"]["summarize"]
+    summarize = cap["tools"]["summarize_doc"]
 
     body = "SUMMARY-SENTINEL " * 300
     with tempfile.NamedTemporaryFile(
@@ -169,13 +204,13 @@ def _check_summarize_invokes_subllm_via_echo_stub() -> None:
     assert "SUMMARY-SENTINEL" in out, out
     assert "FOCUSSENTINEL" in out, out
     assert "Summary budget: under 500 characters." in out, out
-    print("✓ summarize: prefix + body + focus + budget reach the LLM")
+    print("✓ summarize_doc: prefix + body + focus + budget reach the LLM")
 
 
 def _check_per_call_model_overrides_config() -> None:
     cap = _capture_tools()
     cap["plugin_config"] = {"model": "pyagent/loremipsum"}
-    extract = cap["tools"]["extract"]
+    extract = cap["tools"]["extract_doc"]
 
     body = "X" * 8000
     with tempfile.NamedTemporaryFile(
@@ -185,7 +220,6 @@ def _check_per_call_model_overrides_config() -> None:
         path = f.name
     permissions.pre_approve(path)
     try:
-        # Per-call override should win, not the configured loremipsum.
         out = extract(path, "anything", model="pyagent/echo")
     finally:
         Path(path).unlink()
@@ -197,7 +231,7 @@ def _check_env_var_overrides_config() -> None:
     """``PYAGENT_DOC_TOOLS_MODEL`` beats config; loses to per-call."""
     cap = _capture_tools()
     cap["plugin_config"] = {"model": "pyagent/loremipsum"}
-    extract = cap["tools"]["extract"]
+    extract = cap["tools"]["extract_doc"]
 
     body = "X" * 8000
     with tempfile.NamedTemporaryFile(
@@ -233,7 +267,7 @@ def _check_env_var_overrides_config() -> None:
 def _check_configured_model_is_honored() -> None:
     cap = _capture_tools()
     cap["plugin_config"] = {"model": "pyagent/echo"}
-    extract = cap["tools"]["extract"]
+    extract = cap["tools"]["extract_doc"]
 
     body = "Y" * 8000
     with tempfile.NamedTemporaryFile(
@@ -252,8 +286,8 @@ def _check_configured_model_is_honored() -> None:
 
 def _check_input_validation() -> None:
     cap = _capture_tools()
-    extract = cap["tools"]["extract"]
-    summarize = cap["tools"]["summarize"]
+    extract = cap["tools"]["extract_doc"]
+    summarize = cap["tools"]["summarize_doc"]
 
     # Missing path
     assert extract("", "q") == "<error: path is required>"
@@ -270,10 +304,88 @@ def _check_input_validation() -> None:
     print("✓ input validation: missing path/query, bogus max_chars")
 
 
+def _check_schema_validation() -> None:
+    """Bad schema args produce typed error markers, not raises."""
+    cap = _capture_tools()
+    extract = cap["tools"]["extract_doc"]
+
+    # Non-string schema (would f-string-coerce silently otherwise).
+    out = extract("/tmp/x.txt", "q", schema={"a": 1})
+    assert out.startswith("<error: schema must be a string"), out
+    assert "dict" in out, out
+
+    # Oversized schema.
+    huge = '{"x":"' + "y" * (dt_mod._MAX_SCHEMA_CHARS + 100) + '"}'
+    out = extract("/tmp/x.txt", "q", schema=huge)
+    assert out.startswith("<error: schema is "), out
+    assert "max 16000" in out, out
+
+    # Non-JSON schema string.
+    out = extract("/tmp/x.txt", "q", schema="not actually json {")
+    assert out.startswith("<error: schema is not valid JSON"), out
+
+    # Empty / whitespace schema is fine — treated as no schema. We
+    # need a real file to get past the path check; use a body that
+    # would actually invoke the LLM via the echo stub.
+    body = "Z" * 8000
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".txt", delete=False
+    ) as f:
+        f.write(body)
+        path = f.name
+    permissions.pre_approve(path)
+    try:
+        out = extract(path, "anything", schema="   ", model="pyagent/echo")
+    finally:
+        Path(path).unlink()
+    assert out.startswith("[extracted via pyagent/echo]\n"), out
+    # Whitespace schema must NOT inject the schema block.
+    assert "schema" not in out.lower().split("\n", 1)[1].split("extraction request:")[0], out
+    print("✓ schema validation: type/length/JSON-parse + empty falls through")
+
+
+def _check_decode_error_marker() -> None:
+    """A non-UTF-8 file surfaces as 'could not decode as text', not
+    the misleading 'binary file' wording."""
+    cap = _capture_tools()
+    cap["plugin_config"] = {"min_size_chars": 100}
+    extract = cap["tools"]["extract_doc"]
+
+    with tempfile.NamedTemporaryFile(
+        "wb", suffix=".bin", delete=False
+    ) as f:
+        # Latin-1-only bytes that fail UTF-8 decode.
+        f.write(b"\xff\xfe\xfd this is not utf-8 \xc3\x28")
+        path = f.name
+    permissions.pre_approve(path)
+    try:
+        out = extract(path, "anything")
+    finally:
+        Path(path).unlink()
+    assert out.startswith("<could not decode as text"), out
+    assert "not utf-8" in out, out
+    print("✓ decode error: <could not decode as text (not utf-8): ...>")
+
+
+def _check_permission_denied_marker() -> None:
+    """A path the permission gate rejects returns the access-denied
+    marker without trying to read the file."""
+    cap = _capture_tools()
+    extract = cap["tools"]["extract_doc"]
+
+    bogus = "/tmp/__doc_tools_smoke_perm_denied__.txt"
+    with mock.patch.object(
+        permissions, "require_access", return_value=False
+    ):
+        out = extract(bogus, "anything")
+    assert out == f"<access denied: {bogus}>", out
+    print("✓ permission denied → <access denied: ...> marker")
+
+
 def _check_nonexistent_file_marker() -> None:
     cap = _capture_tools()
-    cap["plugin_config"] = {"min_size_chars": 100}  # anything above zero
-    extract = cap["tools"]["extract"]
+    cap["plugin_config"] = {"min_size_chars": 100}
+    extract = cap["tools"]["extract_doc"]
 
     bogus = "/tmp/__doc_tools_smoke_does_not_exist__.txt"
     permissions.pre_approve(bogus)
@@ -286,7 +398,7 @@ def _check_subllm_failure_wrapped() -> None:
     """A factory that raises (e.g. missing API key) becomes a tool-result
     error string, not a raise out of the tool."""
     cap = _capture_tools()
-    extract = cap["tools"]["extract"]
+    extract = cap["tools"]["extract_doc"]
 
     body = "Z" * 8000
     with tempfile.NamedTemporaryFile(
@@ -312,6 +424,204 @@ def _check_subllm_failure_wrapped() -> None:
     print("✓ sub-LLM construction failure → <extract error: ...> marker")
 
 
+def _check_subllm_timeout_marker() -> None:
+    """A sub-LLM call that hangs longer than ``timeout_s`` surfaces a
+    timeout marker. Verified by stubbing ``get_client`` with a client
+    whose ``respond`` sleeps."""
+    cap = _capture_tools()
+    cap["plugin_config"] = {"timeout_s": 1}
+    extract = cap["tools"]["extract_doc"]
+
+    body = "T" * 8000
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".txt", delete=False
+    ) as f:
+        f.write(body)
+        path = f.name
+    permissions.pre_approve(path)
+
+    class _SlowClient:
+        def respond(self, **_kw):
+            # Block long enough to exceed the 1-second cap.
+            time.sleep(5)
+            return {"text": "would have been a real reply"}
+
+    from pyagent import llms
+
+    try:
+        with mock.patch.object(
+            llms, "get_client", return_value=_SlowClient()
+        ):
+            t0 = time.time()
+            out = extract(path, "anything", model="pyagent/echo")
+            elapsed = time.time() - t0
+    finally:
+        Path(path).unlink()
+
+    assert out.startswith("<extract error:"), out
+    assert "timed out after 1s" in out, out
+    # Tool returned within the deadline (allow 0.5s slack for
+    # thread join + setup); did not block until the 5s sleep finished.
+    assert elapsed < 2.5, f"timeout enforcement was slow: {elapsed:.2f}s"
+    print(f"✓ sub-LLM timeout: <extract error: ... timed out> in {elapsed:.2f}s")
+
+
+def _check_lru_cache_returns_cached_result() -> None:
+    """Identical re-query of an unchanged file returns the cached
+    result without re-invoking the sub-LLM."""
+    cap = _capture_tools()
+    extract = cap["tools"]["extract_doc"]
+
+    body = "CACHE-SENTINEL " * 500
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".txt", delete=False
+    ) as f:
+        f.write(body)
+        path = f.name
+    permissions.pre_approve(path)
+
+    from pyagent import llms
+
+    real_get_client = llms.get_client
+    call_count = {"n": 0}
+
+    def _counted(model):
+        call_count["n"] += 1
+        return real_get_client(model)
+
+    try:
+        with mock.patch.object(llms, "get_client", side_effect=_counted):
+            first = extract(path, "what's the sentinel?", model="pyagent/echo")
+            second = extract(path, "what's the sentinel?", model="pyagent/echo")
+    finally:
+        Path(path).unlink()
+
+    assert first == second, (first, second)
+    assert call_count["n"] == 1, (
+        f"expected 1 sub-LLM call (cache hit on second), got {call_count['n']}"
+    )
+    print("✓ cache: identical re-query hits cache (1 call instead of 2)")
+
+
+def _check_lru_cache_invalidates_on_file_change() -> None:
+    """Touching the file's mtime invalidates the cached entry."""
+    cap = _capture_tools()
+    extract = cap["tools"]["extract_doc"]
+
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".txt", delete=False
+    ) as f:
+        f.write("ORIGINAL " * 600)
+        path = f.name
+    permissions.pre_approve(path)
+
+    from pyagent import llms
+
+    real_get_client = llms.get_client
+    call_count = {"n": 0}
+
+    def _counted(model):
+        call_count["n"] += 1
+        return real_get_client(model)
+
+    try:
+        with mock.patch.object(llms, "get_client", side_effect=_counted):
+            extract(path, "q", model="pyagent/echo")
+            # Modify content + bump mtime so signature changes.
+            time.sleep(0.01)
+            Path(path).write_text("CHANGED " * 600)
+            extract(path, "q", model="pyagent/echo")
+    finally:
+        Path(path).unlink()
+
+    assert call_count["n"] == 2, (
+        f"expected 2 sub-LLM calls (file changed → cache miss), "
+        f"got {call_count['n']}"
+    )
+    print("✓ cache: file mtime change invalidates entry")
+
+
+def _check_lru_cache_disabled_at_size_zero() -> None:
+    cap = _capture_tools()
+    cap["plugin_config"] = {"cache_size": 0}
+    extract = cap["tools"]["extract_doc"]
+
+    body = "DISABLED " * 600
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".txt", delete=False
+    ) as f:
+        f.write(body)
+        path = f.name
+    permissions.pre_approve(path)
+
+    from pyagent import llms
+
+    real_get_client = llms.get_client
+    call_count = {"n": 0}
+
+    def _counted(model):
+        call_count["n"] += 1
+        return real_get_client(model)
+
+    try:
+        with mock.patch.object(llms, "get_client", side_effect=_counted):
+            extract(path, "q", model="pyagent/echo")
+            extract(path, "q", model="pyagent/echo")
+    finally:
+        Path(path).unlink()
+
+    assert call_count["n"] == 2, (
+        f"expected 2 sub-LLM calls (cache disabled), got {call_count['n']}"
+    )
+    print("✓ cache: cache_size=0 disables, both calls go to LLM")
+
+
+def _check_lru_cache_evicts_oldest() -> None:
+    """With cache_size=2, the third distinct entry evicts the first."""
+    cap = _capture_tools()
+    cap["plugin_config"] = {"cache_size": 2}
+    extract = cap["tools"]["extract_doc"]
+
+    paths: list[str] = []
+    body = "LRU " * 1500
+    for _ in range(3):
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".txt", delete=False
+        ) as f:
+            f.write(body)
+            paths.append(f.name)
+        permissions.pre_approve(paths[-1])
+
+    from pyagent import llms
+
+    real_get_client = llms.get_client
+    call_count = {"n": 0}
+
+    def _counted(model):
+        call_count["n"] += 1
+        return real_get_client(model)
+
+    try:
+        with mock.patch.object(llms, "get_client", side_effect=_counted):
+            extract(paths[0], "q", model="pyagent/echo")
+            extract(paths[1], "q", model="pyagent/echo")
+            extract(paths[2], "q", model="pyagent/echo")
+            # paths[0] was evicted; re-querying it must call again.
+            extract(paths[0], "q", model="pyagent/echo")
+            # paths[2] is still warm; re-query is a hit.
+            extract(paths[2], "q", model="pyagent/echo")
+    finally:
+        for p in paths:
+            Path(p).unlink()
+
+    # 3 distinct + 1 eviction-replay + 1 hit = 4 calls
+    assert call_count["n"] == 4, (
+        f"expected 4 sub-LLM calls (3 distinct, 1 evicted-replay, "
+        f"1 hit), got {call_count['n']}"
+    )
+    print("✓ cache: LRU evicts oldest at cap; warm entries still hit")
+
+
 def main() -> None:
     # Ensure the env var isn't bleeding in from the runner's shell —
     # several checks assume "no env override" as their baseline.
@@ -320,14 +630,23 @@ def main() -> None:
     _check_register_publishes_both_tools()
     _check_size_floor_extract()
     _check_size_floor_summarize()
+    _check_max_size_guardrail()
     _check_extract_invokes_subllm_via_echo_stub()
     _check_summarize_invokes_subllm_via_echo_stub()
     _check_per_call_model_overrides_config()
     _check_env_var_overrides_config()
     _check_configured_model_is_honored()
     _check_input_validation()
+    _check_schema_validation()
+    _check_decode_error_marker()
+    _check_permission_denied_marker()
     _check_nonexistent_file_marker()
     _check_subllm_failure_wrapped()
+    _check_subllm_timeout_marker()
+    _check_lru_cache_returns_cached_result()
+    _check_lru_cache_invalidates_on_file_change()
+    _check_lru_cache_disabled_at_size_zero()
+    _check_lru_cache_evicts_oldest()
     print("smoke_doc_tools: all checks passed")
 
 

--- a/tests/smoke_doc_tools.py
+++ b/tests/smoke_doc_tools.py
@@ -50,16 +50,26 @@ from pyagent import permissions
 from pyagent.plugins import doc_tools as dt_mod
 
 
-def _capture_tools() -> dict:
-    """Run ``register()`` against a fake API; return the captured tools.
+def _capture_tools(plugin_config: dict | None = None) -> dict:
+    """Run ``register()`` against a fake API; return captured state.
 
-    The fake also lets us stub out ``plugin_config`` so individual
-    checks can drive config-driven behavior without touching the real
-    config.toml on disk. Each call to _capture_tools also clears the
-    module-level LRU cache so checks don't bleed into each other.
+    The fake stubs out ``plugin_config`` (driven by the optional arg
+    or assigned to the returned dict before `register()` re-runs) and
+    captures any ``api.log()`` calls so register-time warnings can be
+    asserted. Each call also clears the module-level LRU cache so
+    checks don't bleed into each other.
+
+    Pass ``plugin_config`` for the single-call shape used by warning
+    checks. For multi-step tests that mutate config between calls,
+    omit the arg, mutate ``captured["plugin_config"]``, and re-run
+    ``dt_mod.register()`` if needed.
     """
     dt_mod._cache_clear()
-    captured: dict = {"tools": {}, "plugin_config": {}}
+    captured: dict = {
+        "tools": {},
+        "plugin_config": plugin_config if plugin_config is not None else {},
+        "logs": [],
+    }
 
     class _FakeAPI:
         @property
@@ -68,6 +78,9 @@ def _capture_tools() -> dict:
 
         def register_tool(self, name, fn):
             captured["tools"][name] = fn
+
+        def log(self, level, message):
+            captured["logs"].append((level, message))
 
     dt_mod.register(_FakeAPI())
     return captured
@@ -466,6 +479,85 @@ def _check_subllm_timeout_marker() -> None:
     print(f"✓ sub-LLM timeout: <extract error: ... timed out> in {elapsed:.2f}s")
 
 
+def _check_register_warns_on_bogus_model() -> None:
+    """A malformed model string in config logs a warning at register
+    time and still publishes the tools."""
+    cap = _capture_tools(plugin_config={"model": "claude-haiku-no-slash"})
+    assert "extract_doc" in cap["tools"], cap["tools"]
+    assert "summarize_doc" in cap["tools"], cap["tools"]
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert any("'claude-haiku-no-slash'" in m for m in msgs), msgs
+    assert any("provider/model" in m for m in msgs), msgs
+
+    # Empty-half model: ``"anthropic/"`` shouldn't slip through.
+    cap = _capture_tools(plugin_config={"model": "anthropic/"})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert any("empty provider or model name" in m for m in msgs), msgs
+
+    # Non-string model.
+    cap = _capture_tools(plugin_config={"model": 42})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert any("model must be a string" in m for m in msgs), msgs
+    print("✓ register-time warning: bogus model values flagged, tools still register")
+
+
+def _check_register_warns_on_bogus_timeout() -> None:
+    cap = _capture_tools(plugin_config={"timeout_s": "not-an-int"})
+    assert "extract_doc" in cap["tools"], cap["tools"]
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert any("timeout_s must be a positive integer" in m for m in msgs), msgs
+
+    cap = _capture_tools(plugin_config={"timeout_s": 0})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert any("timeout_s must be > 0" in m for m in msgs), msgs
+
+    cap = _capture_tools(plugin_config={"timeout_s": -5})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert any("timeout_s must be > 0, got -5" in m for m in msgs), msgs
+    print("✓ register-time warning: bogus timeout_s values flagged")
+
+
+def _check_register_warns_on_bogus_cache_size() -> None:
+    cap = _capture_tools(plugin_config={"cache_size": "huge"})
+    assert "extract_doc" in cap["tools"], cap["tools"]
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert any("cache_size must be a non-negative integer" in m for m in msgs), msgs
+
+    cap = _capture_tools(plugin_config={"cache_size": -1})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert any("cache_size must be >= 0, got -1" in m for m in msgs), msgs
+    print("✓ register-time warning: bogus cache_size values flagged")
+
+
+def _check_register_silent_on_valid_config() -> None:
+    """A clean config produces zero warnings."""
+    cap = _capture_tools(plugin_config={
+        "model": "anthropic/claude-haiku-4-5-20251001",
+        "timeout_s": 60,
+        "cache_size": 32,
+        "min_size_chars": 4000,
+    })
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert msgs == [], f"expected no warnings on clean config, got: {msgs}"
+
+    # Empty config also produces zero warnings (every key is optional).
+    cap = _capture_tools(plugin_config={})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert msgs == [], f"expected no warnings on empty config, got: {msgs}"
+
+    # Plugin-provider shorthand (``ollama``) is accepted silently —
+    # we can't verify plugin providers at register time, so we don't
+    # warn on them.
+    cap = _capture_tools(plugin_config={"model": "ollama"})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert msgs == [], f"ollama shorthand should not warn, got: {msgs}"
+
+    cap = _capture_tools(plugin_config={"model": "ollama/llama3.2:latest"})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert msgs == [], f"ollama/<model> should not warn, got: {msgs}"
+    print("✓ register-time silent on valid config and plugin-provider shorthand")
+
+
 def _check_lru_cache_returns_cached_result() -> None:
     """Identical re-query of an unchanged file returns the cached
     result without re-invoking the sub-LLM."""
@@ -643,6 +735,10 @@ def main() -> None:
     _check_nonexistent_file_marker()
     _check_subllm_failure_wrapped()
     _check_subllm_timeout_marker()
+    _check_register_warns_on_bogus_model()
+    _check_register_warns_on_bogus_timeout()
+    _check_register_warns_on_bogus_cache_size()
+    _check_register_silent_on_valid_config()
     _check_lru_cache_returns_cached_result()
     _check_lru_cache_invalidates_on_file_change()
     _check_lru_cache_disabled_at_size_zero()


### PR DESCRIPTION
## Summary

Two stateless tools that delegate "give me the answer from this document" to a focused sub-LLM call:

- **`extract(path, query, schema=None, model=None)`** — pull structured fields / lists / tables out of one document. Returns JSON when the query implies structure.
- **`summarize(path, focus=None, max_chars=1500, model=None)`** — compress one document to prose, optionally with an emphasis.

Both refuse files under `min_size_chars` (default 4000) with a "read_file is cheaper" pointer instead of spinning up a sub-LLM.

## Motivation

Session `2026-05-02-grown-parrot` showed the agent burning **11 turns** walking a 38KB markdown file with `read_file` to extract a 20-row horse table — paginating through 1000-char previews because each slice tripped the 8000-char offload threshold. An `extract(horses.md, "list each horse with name, odds, jockey, trainer as JSON")` call would have done this in one round trip and never put the bytes on the main conversation.

This plugin is the narrow-tool half of the design discussed earlier: stateless, read-only, single sub-LLM call. The vector-search half stays in `memory-vector` (different lifecycle, different shape).

## Configuration & resolution order

Resolution, highest priority first:

1. Per-call `model=` argument.
2. `PYAGENT_DOC_TOOLS_MODEL` env var (per-shell override; useful for testing / CI / ad-hoc invocation).
3. `[plugins.doc-tools] model` in config.toml.
4. Hardcoded default: `anthropic/claude-haiku-4-5-20251001` (cheap, fast, tool-capable, works as long as `ANTHROPIC_API_KEY` is set).

```toml
[plugins.doc-tools]
model = "ollama/llama3.2:latest"   # optional — local-only setups
min_size_chars = 4000              # below this, refuse + suggest read_file
```

Per-shell override:
```bash
PYAGENT_DOC_TOOLS_MODEL=ollama/llama3.2:latest pyagent ...
```

The plugin is **not** added to `built_in_plugins_enabled` defaults — users opt in once they've picked a model.

## Empirical eval over local ollama models

Two real fixtures (~12KB horse list for extract, ~6KB SRE incident report for summarize), 8 ollama models. Useful as guidance for users picking a local model via config or the env var. Raw outputs and runner kept in `/tmp/doc_tools_eval/` (not committed — eval artifacts).

### Extract (strict 20-row JSON, schema-typed)

| Model | Size | Wall | Valid JSON | n | Schema OK |
|---|---|---|---|---|---|
| llama3.2:latest | 3B | 5.0s | ✓ | 20 | 20/20 |
| llama3.1:latest | 8B | 6.7s | ✓ | 20 | 20/20 |
| qwen2.5:7b-instruct | 7B | 7.8s | ✓ | 20 | 20/20 |
| qwen2.5:14b-instruct | 14B | 16.0s | ✓ | 20 | 20/20 |
| qwen2.5-coder:14b | 14B | 17.5s | ✓ | 20 | 20/20 |
| deepseek-r1:14b | 14B | 25.2s | ✓ | 20 | 20/20 |
| **phi3:mini** | 3.8B | 5.1s | ✗ | 0 | **0/20** |
| gemma2:2b | 2B | 4.2s | ✓ | 20 | 20/20 |

7/8 nailed it first try. **phi3:mini** failed three independent ways: wrong order (started at #20 going backwards), wrong types (string `"#20 Yellow Rose"` instead of int `20`), and trailing hallucinated garbage that broke JSON parsing.

### Summarize (≤800 char budget, root-cause + actions focus)

All 8 models hit full coverage on the three keyword probes (pool / actions / root cause). Length discipline differed: phi3:mini overshot at **1884 chars** (2.4× budget); the others sat 487–790 chars.

### Recommendations for users picking a local model

- **Speed + correctness on local hardware:** `ollama/llama3.2:latest` (3B, 5s extract, sub-1s summarize, perfect output, 2GB on disk).
- **Don't pick:** `ollama/phi3:mini` for this plugin — only model that broke the structured-extract contract.
- **14B family:** same outputs as 7B/8B variants, 2-5× the latency. Skip until needed.

## Out of scope (follow-ups discussed in thread)

- **Model fallback chain** (`model = ["ollama/...", "anthropic/..."]`) — initially in scope, deferred at user request to ship v0.1 simpler. Worth a separate issue if revived.
- **Tool can call another tool** (filed as #85) — the cleaner way to leverage the existing `claude_code_cli` plugin from inside `extract` / `summarize` rather than registering a separate provider.
- **Cache by `(path mtime+size, query, model)`** — skipped for v0.1; would prevent re-spending tokens on identical re-queries of the same doc.
- **Reject summaries that overshoot `max_chars` by N%** — phi3:mini is the one data point that would have benefited.

## Test plan

- [x] `tests/smoke_doc_tools.py` — 11 checks: register, size-floor (extract + summarize), sub-LLM invocation via `pyagent/echo` stub, per-call `model=` override, **env var beats config / per-call beats env / empty env falls through**, configured model honored, input validation, nonexistent-file handling, sub-LLM construction failure wrapped to a tool-result marker.
- [x] `plugins.load()` registers `extract` + `summarize` when `doc-tools` is in `built_in_plugins_enabled`.
- [x] End-to-end exercise across 8 local ollama models on real fixtures (see eval section above).
- [ ] Maintainer review of the system prompts for `extract` and `summarize` — these shape what every call returns; worth a sanity pass.
- [ ] Decide whether to add to `built_in_plugins_enabled` defaults or keep opt-in.