### PR TITLE
web_search: retry with backoff, classified failure markers (closes #81)

### DIFF
--- a/pyagent/plugins/web_search/__init__.py
+++ b/pyagent/plugins/web_search/__init__.py
@@ -14,6 +14,22 @@ than search-as-default — most queries the model thinks "I should
 search" can be answered from training data, and a network round trip
 costs the user real time and money.
 
+Configuration (all optional, all read at call time):
+
+  ``[plugins.web-search]`` table in pyagent's config TOML
+    ``retry_attempts`` — total attempts including the initial.
+        Defaults to 3 (initial + 2 retries). Set to 1 to disable
+        retry. The metasearch backend reshuffles engine order each
+        call, so a retry samples a different engine subset.
+    ``retry_backoff_s`` — list of per-retry sleep durations.
+        Defaults to ``[1.0, 3.0]`` for the standard 3-attempt run.
+        Length is expected to match ``retry_attempts - 1``; if
+        shorter, the last value is reused.
+    ``backend`` — comma-delimited engine names or ``"auto"`` for
+        the full set. Defaults to ``"auto"``. Use to pin to a known
+        subset (e.g. ``"duckduckgo,brave,yahoo,mojeek"``) if a
+        particular engine stays flaky.
+
 Lifted from the user-scope `web-search` skill at
 ~/.config/pyagent/skills/web-search/. The skill is left in place so
 older installs still work; the plugin shadows it in the catalog
@@ -22,6 +38,8 @@ because plugin tools call directly while skill scripts go through
 """
 
 from __future__ import annotations
+
+from typing import Sequence
 
 from pyagent.plugins.web_search import search as _search
 
@@ -32,7 +50,99 @@ from pyagent.plugins.web_search import search as _search
 _MAX_RESULTS = 25
 
 
+def _resolve_attempts(plugin_cfg: dict) -> int:
+    raw = plugin_cfg.get("retry_attempts")
+    if isinstance(raw, int) and not isinstance(raw, bool) and raw >= 1:
+        return raw
+    return _search._DEFAULT_ATTEMPTS
+
+
+def _resolve_backoff_s(plugin_cfg: dict) -> Sequence[float]:
+    raw = plugin_cfg.get("retry_backoff_s")
+    if isinstance(raw, list) and raw:
+        clean: list[float] = []
+        for v in raw:
+            if isinstance(v, (int, float)) and not isinstance(v, bool) and v >= 0:
+                clean.append(float(v))
+        if clean:
+            return clean
+    return _search._DEFAULT_BACKOFF_S
+
+
+def _resolve_backend(plugin_cfg: dict) -> str:
+    raw = plugin_cfg.get("backend")
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    return _search._DEFAULT_BACKEND
+
+
+def _config_warnings(plugin_cfg: dict) -> list[str]:
+    """Sanity-check the [plugins.web-search] table at register time.
+
+    Bogus values still fall through to defaults via the resolvers — this
+    surfaces typos at startup so they don't sit silent. No network
+    probes; the default backend "auto" is intentionally not validated
+    against the live engine list since the ddgs library handles
+    unknown-backend fallback internally.
+    """
+    out: list[str] = []
+
+    if "retry_attempts" in plugin_cfg:
+        raw = plugin_cfg["retry_attempts"]
+        if not isinstance(raw, int) or isinstance(raw, bool):
+            out.append(
+                f"retry_attempts must be a positive integer, got "
+                f"{type(raw).__name__}: {raw!r} — using default "
+                f"{_search._DEFAULT_ATTEMPTS}"
+            )
+        elif raw < 1:
+            out.append(
+                f"retry_attempts must be >= 1, got {raw} — using "
+                f"default {_search._DEFAULT_ATTEMPTS}"
+            )
+
+    if "retry_backoff_s" in plugin_cfg:
+        raw = plugin_cfg["retry_backoff_s"]
+        if not isinstance(raw, list):
+            out.append(
+                f"retry_backoff_s must be a list of numbers, got "
+                f"{type(raw).__name__}: {raw!r} — using default "
+                f"{list(_search._DEFAULT_BACKOFF_S)}"
+            )
+        else:
+            bad = [
+                v for v in raw
+                if not isinstance(v, (int, float))
+                or isinstance(v, bool)
+                or v < 0
+            ]
+            if bad:
+                out.append(
+                    f"retry_backoff_s contains invalid entries "
+                    f"(must be non-negative numbers): {bad!r}"
+                )
+
+    if "backend" in plugin_cfg:
+        raw = plugin_cfg["backend"]
+        if not isinstance(raw, str):
+            out.append(
+                f"backend must be a string, got {type(raw).__name__}: "
+                f"{raw!r} — using default {_search._DEFAULT_BACKEND!r}"
+            )
+        elif not raw.strip():
+            out.append("backend is set but empty — using default 'auto'")
+
+    return out
+
+
 def register(api):
+    # Lightweight register-time validation of the [plugins.web-search]
+    # table. Bogus values still fall through to defaults at call time
+    # via the _resolve_* helpers — this is purely about surfacing
+    # config typos at startup instead of letting them sit silent.
+    for warning in _config_warnings(api.plugin_config or {}):
+        api.log("warning", warning)
+
     def web_search(query: str, n: int = 10) -> str:
         """Search the web via DuckDuckGo; return up to `n` results.
 
@@ -44,6 +154,14 @@ def register(api):
         `fetch_url` on the most promising URL rather than reading every
         snippet.
 
+        Transient backend failures are retried with backoff
+        automatically (default 3 attempts, 1s+3s backoff). Persistent
+        failures return distinct markers so you can branch on what
+        happened: ``rate limited`` (back off), ``backend unavailable``
+        (try a different query or fall back to ``fetch_url`` with a
+        known URL), or a generic ``<search error: ...>`` for
+        programmer/parser issues.
+
         Args:
             query: Search query. Plain text; DDG handles quoting and
                 operators.
@@ -52,9 +170,12 @@ def register(api):
 
         Returns:
             A markdown numbered list of `title — url` lines with
-            snippets. `<no results ...>` if DDG returned nothing;
-            `<search error: ...>` on network/parser failure. Large
-            outputs auto-offload via the standard tool-result path.
+            snippets. ``<no results ...>`` if every backend returned
+            empty; ``<search error: rate limited; ...>`` if the upstream
+            is explicitly throttling; ``<search error: backend
+            unavailable after N attempts; ...>`` if all retries failed
+            with transient errors; ``<search error: ...>`` for other
+            failures.
         """
         if not query or not query.strip():
             return "<query is empty>"
@@ -66,12 +187,34 @@ def register(api):
             return "<error: n must be >= 1>"
         if n_int > _MAX_RESULTS:
             n_int = _MAX_RESULTS
+
+        cfg = api.plugin_config or {}
+        attempts = _resolve_attempts(cfg)
+        backoff_s = _resolve_backoff_s(cfg)
+        backend = _resolve_backend(cfg)
+
         try:
-            results = _search.ddg_text_search(query, n=n_int)
+            results = _search.ddg_text_search(
+                query,
+                n=n_int,
+                attempts=attempts,
+                backoff_s=backoff_s,
+                backend=backend,
+            )
         except ImportError:
             return (
                 "<search error: ddgs package not installed — "
                 "run: pip install ddgs>"
+            )
+        except _search.SearchRateLimited as e:
+            return (
+                f"<search error: rate limited; pause and try again "
+                f"later ({e})>"
+            )
+        except _search.SearchBackoffExhausted as e:
+            return (
+                f"<search error: backend unavailable {e}; try a "
+                f"different query or use fetch_url with a known URL>"
             )
         except Exception as e:
             return f"<search error: {e}>"

--- a/pyagent/plugins/web_search/search.py
+++ b/pyagent/plugins/web_search/search.py
@@ -20,14 +20,38 @@ topic toggle, etc.) lives in __init__.py.
 from __future__ import annotations
 
 import json
+import logging
+import time
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field
+from typing import Sequence
+
+logger = logging.getLogger(__name__)
 
 
 _INSTANT_ANSWER_URL = "https://api.duckduckgo.com/"
 _USER_AGENT = "Mozilla/5.0 (compatible; pyagent-web-search)"
 _INSTANT_TIMEOUT = 10
+
+
+# Retry policy defaults. These are overridable via [plugins.web-search]
+# in config.toml — see web_search/__init__.py for the resolver.
+_DEFAULT_ATTEMPTS = 3
+_DEFAULT_BACKOFF_S: tuple[float, ...] = (1.0, 3.0)
+_DEFAULT_BACKEND = "auto"
+
+
+class SearchRateLimited(Exception):
+    """Raised when the upstream signals rate-limiting. Don't retry —
+    the agent should pause and / or change strategy."""
+
+
+class SearchBackoffExhausted(Exception):
+    """Raised when every retry attempt failed with retryable errors.
+    Distinct from a generic ``<search error: ...>`` so the agent can
+    reason about the failure mode (transient backend trouble vs.
+    programmer error)."""
 
 
 @dataclass(frozen=True)
@@ -61,29 +85,103 @@ class InstantAnswer:
     related: tuple[tuple[str, str], ...] = field(default_factory=tuple)
 
 
-def ddg_text_search(query: str, n: int = 10) -> list[SearchResult]:
-    """Run a DDG text search and return up to `n` results.
+def ddg_text_search(
+    query: str,
+    n: int = 10,
+    *,
+    attempts: int = _DEFAULT_ATTEMPTS,
+    backoff_s: Sequence[float] = _DEFAULT_BACKOFF_S,
+    backend: str = _DEFAULT_BACKEND,
+) -> list[SearchResult]:
+    """Run a DDG text search with retry/backoff; return up to `n` results.
 
-    Uses the `ddgs` library (DuckDuckGo HTML endpoint scraper). May
-    raise on network failure or parser breakage — callers translate
-    those into a tool-result error string rather than letting them
-    bubble to the agent loop.
+    Uses the `ddgs` library, which fans out across ~10 backend engines
+    (DuckDuckGo, Bing, Brave, Google, Yandex, Yahoo, Mojeek,
+    Wikipedia, Grokipedia) in a parallel ThreadPoolExecutor and
+    aggregates results. The library only raises when *every* engine
+    failed or returned empty. Each attempt re-shuffles the engine
+    order, so a retry effectively samples a different subset of
+    engines.
+
+    Retry behavior:
+      - ``RatelimitException`` → no retry. Raises ``SearchRateLimited``
+        immediately so the caller can surface a distinct marker.
+      - ``TimeoutException`` / generic ``DDGSException`` → retry with
+        backoff. After ``attempts-1`` failures, raises
+        ``SearchBackoffExhausted`` carrying the last error.
+      - Any other exception (programmer error, ImportError, etc.)
+        propagates as today — caller's catch-all handles them.
+
+    Args:
+        query: Search query.
+        n: Number of results (max applied upstream by caller).
+        attempts: Total attempts including the initial. ``1`` disables
+            retry. Defaults to 3 (initial + 2 retries).
+        backoff_s: Per-retry sleep durations. ``backoff_s[i]`` is the
+            sleep before attempt ``i+1`` (the (i+1)-th retry). Length
+            is expected to be ``attempts-1``; if shorter, the last
+            value is reused for any subsequent retries.
+        backend: Comma-delimited engine names or ``"auto"`` for the
+            full set. Defaults to ``"auto"``.
+
+    Returns:
+        A list of SearchResult dataclasses. Empty list means the
+        engines all returned no results (a successful empty result;
+        not a retried failure).
     """
     # Local import so an environment missing `ddgs` still loads the
     # plugin module (the tool will return a clean error when called).
     from ddgs import DDGS
+    from ddgs.exceptions import (
+        DDGSException,
+        RatelimitException,
+        TimeoutException,
+    )
 
-    results = DDGS().text(query, max_results=n)
-    out: list[SearchResult] = []
-    for r in results or []:
-        out.append(
-            SearchResult(
-                title=str(r.get("title") or "").strip(),
-                url=str(r.get("href") or "").strip(),
-                snippet=str(r.get("body") or "").strip(),
+    if attempts < 1:
+        attempts = 1
+
+    last_err: Exception | None = None
+    for i in range(attempts):
+        try:
+            results = DDGS().text(query, max_results=n, backend=backend)
+        except RatelimitException as e:
+            # Don't retry — the upstream is explicitly throttling.
+            # The caller surfaces a distinct marker so the agent can
+            # back off rather than re-fire the same query.
+            raise SearchRateLimited(str(e)) from e
+        except (TimeoutException, DDGSException) as e:
+            last_err = e
+            logger.info(
+                "web_search attempt %d/%d failed: %s", i + 1, attempts, e
             )
-        )
-    return out
+            if i < attempts - 1:
+                # Sleep before the next attempt. backoff_s shorter
+                # than attempts-1 reuses the last value.
+                if backoff_s:
+                    delay = backoff_s[min(i, len(backoff_s) - 1)]
+                else:
+                    delay = 0.0
+                if delay > 0:
+                    time.sleep(delay)
+            continue
+        else:
+            out: list[SearchResult] = []
+            for r in results or []:
+                out.append(
+                    SearchResult(
+                        title=str(r.get("title") or "").strip(),
+                        url=str(r.get("href") or "").strip(),
+                        snippet=str(r.get("body") or "").strip(),
+                    )
+                )
+            return out
+
+    # All attempts exhausted. last_err is set because we only land
+    # here if the loop body raised on every iteration.
+    raise SearchBackoffExhausted(
+        f"after {attempts} attempt(s): {last_err}"
+    )
 
 
 def _parse_instant_payload(data: dict) -> InstantAnswer:

--- a/tests/smoke_web_search.py
+++ b/tests/smoke_web_search.py
@@ -1,6 +1,6 @@
 """End-to-end smoke for the web-search plugin.
 
-Four concerns:
+Concerns covered:
 
   1. **Plugin loads under the default config.** With "web-search" in
      `built_in_plugins_enabled`, `discover()` and `load()` produce
@@ -14,10 +14,20 @@ Four concerns:
      `<no instant answer ...>` marker; `related=True` appends
      related-topic links.
   4. **Tool wrappers translate exceptions and return string shape.**
-     The agent's auto-offload path expects strings; both tools must
-     return `str` on success and on every error path. A `web_search`
-     network failure becomes `<search error: ...>` rather than
-     bubbling out of the tool.
+     Both tools must return `str` on success and on every error path,
+     never raise into the agent loop.
+  5. **Retry / backoff classifies failures.** Transient
+     `DDGSException` / `TimeoutException` get retried with the
+     configured backoff (default ``[1.0, 3.0]``); `RatelimitException`
+     short-circuits with no retry; non-network exceptions skip the
+     retry loop entirely and hit the existing catch-all marker.
+  6. **Distinct error markers** — `<search error: rate limited; ...>`
+     vs. `<search error: backend unavailable after N attempts; ...>`
+     vs. the generic `<search error: ...>` so the agent can branch.
+  7. **Configuration flows through.** ``retry_attempts``,
+     ``retry_backoff_s``, and ``backend`` reach the DDGS call site;
+     bogus values produce register-time warnings but tools still
+     register and fall back to defaults.
 
 Run with:
 
@@ -32,7 +42,36 @@ from pathlib import Path
 from unittest import mock
 
 from pyagent import config as config_mod, paths as paths_mod, plugins
+from pyagent.plugins.web_search import register as web_search_register
 from pyagent.plugins.web_search import search as web_search_mod
+
+
+def _make_fake_api(plugin_config: dict | None = None) -> dict:
+    """Build a fake plugin API and register the web-search plugin
+    against it. Returns ``{"tools": {...}, "logs": [...], "plugin_config": ...}``.
+
+    The captured ``logs`` list lets register-time-warning checks
+    assert what the plugin emitted.
+    """
+    captured: dict = {
+        "tools": {},
+        "logs": [],
+        "plugin_config": plugin_config if plugin_config is not None else {},
+    }
+
+    class _FakeAPI:
+        @property
+        def plugin_config(self):
+            return captured["plugin_config"]
+
+        def register_tool(self, name, fn):
+            captured["tools"][name] = fn
+
+        def log(self, level, message):
+            captured["logs"].append((level, message))
+
+    web_search_register(_FakeAPI())
+    return captured
 
 
 _FIXTURE_RESULTS_RAW = [
@@ -186,19 +225,9 @@ def _check_plugin_loads_under_default_config() -> None:
 def _check_tool_wrapper_returns_string() -> None:
     """`web_search` returns str on success — no Attachment construction
     in the plugin (the auto-offload path handles large outputs)."""
-    # Re-register through a fake API so we can capture the tool fn.
-    captured: dict[str, callable] = {}
-
-    class _FakeAPI:
-        def register_tool(self, name, fn):
-            captured[name] = fn
-
-    from pyagent.plugins.web_search import register
-
-    register(_FakeAPI())
-    assert set(captured.keys()) == {"web_search", "web_search_instant"}, captured
-
-    web_search = captured["web_search"]
+    cap = _make_fake_api()
+    assert set(cap["tools"].keys()) == {"web_search", "web_search_instant"}, cap["tools"]
+    web_search = cap["tools"]["web_search"]
 
     fixture = [
         web_search_mod.SearchResult(
@@ -210,7 +239,13 @@ def _check_tool_wrapper_returns_string() -> None:
         web_search_mod, "ddg_text_search", return_value=fixture
     ) as m:
         out = web_search("python http", n=3)
-    m.assert_called_once_with("python http", n=3)
+    # The wrapper now passes retry/backoff/backend kwargs through —
+    # check the positional and the new kwargs ride together.
+    assert m.call_count == 1, m.call_args_list
+    args, kwargs = m.call_args
+    assert args == ("python http",), args
+    assert kwargs.get("n") == 3, kwargs
+    assert "attempts" in kwargs and "backoff_s" in kwargs and "backend" in kwargs, kwargs
     assert isinstance(out, str), type(out)
     assert "Best Python HTTP libraries 2025" in out, out
     print("✓ web_search tool returns str (auto-offload path)")
@@ -218,17 +253,9 @@ def _check_tool_wrapper_returns_string() -> None:
 
 def _check_tool_wrapper_translates_errors() -> None:
     """Network/parser failure → `<search error: ...>`, not a raise."""
-    captured: dict[str, callable] = {}
-
-    class _FakeAPI:
-        def register_tool(self, name, fn):
-            captured[name] = fn
-
-    from pyagent.plugins.web_search import register
-
-    register(_FakeAPI())
-    web_search = captured["web_search"]
-    web_search_instant = captured["web_search_instant"]
+    cap = _make_fake_api()
+    web_search = cap["tools"]["web_search"]
+    web_search_instant = cap["tools"]["web_search_instant"]
 
     def _boom(*a, **kw):
         raise RuntimeError("network down")
@@ -250,17 +277,9 @@ def _check_tool_wrapper_translates_errors() -> None:
 
 def _check_tool_wrapper_validates_inputs() -> None:
     """Empty query, bad `n` → tool-result error string, not a raise."""
-    captured: dict[str, callable] = {}
-
-    class _FakeAPI:
-        def register_tool(self, name, fn):
-            captured[name] = fn
-
-    from pyagent.plugins.web_search import register
-
-    register(_FakeAPI())
-    web_search = captured["web_search"]
-    web_search_instant = captured["web_search_instant"]
+    cap = _make_fake_api()
+    web_search = cap["tools"]["web_search"]
+    web_search_instant = cap["tools"]["web_search_instant"]
 
     assert web_search("") == "<query is empty>"
     assert web_search("   ") == "<query is empty>"
@@ -270,6 +289,244 @@ def _check_tool_wrapper_validates_inputs() -> None:
     bad_n2 = web_search("hi", n=0)
     assert bad_n2 == "<error: n must be >= 1>", bad_n2
     print("✓ tool wrappers reject empty query / bad n cleanly")
+
+
+# ---- Retry / backoff / classified-failure markers ----------------
+
+
+def _check_retry_succeeds_after_transient_failure() -> None:
+    """A single ``DDGSException`` then success: 2 calls, sleep once,
+    return the success markdown."""
+    from ddgs.exceptions import DDGSException
+
+    fixture_results = [
+        {"title": "ok", "href": "https://ok.example.com", "body": "ok body"}
+    ]
+
+    class _DDGS:
+        calls = 0
+
+        def text(self, query, max_results=10, backend="auto"):
+            type(self).calls += 1
+            if type(self).calls == 1:
+                raise DDGSException("transient: 502 from upstream")
+            return fixture_results
+
+    cap = _make_fake_api()
+    web_search = cap["tools"]["web_search"]
+
+    with mock.patch("ddgs.DDGS", _DDGS), mock.patch.object(
+        web_search_mod.time, "sleep"
+    ) as m_sleep:
+        out = web_search("anything")
+
+    assert _DDGS.calls == 2, f"expected 2 attempts, got {_DDGS.calls}"
+    assert m_sleep.call_count == 1, m_sleep.call_args_list
+    # Default backoff is (1.0, 3.0) — first retry sleeps 1.0s.
+    assert m_sleep.call_args == mock.call(1.0), m_sleep.call_args
+    assert "ok.example.com" in out, out
+    assert not out.startswith("<search error"), out
+    print("✓ retry: transient DDGSException → succeed on retry, slept 1.0s")
+
+
+def _check_retry_exhausted_marker() -> None:
+    """All attempts fail → distinct ``backend unavailable`` marker."""
+    from ddgs.exceptions import DDGSException
+
+    class _DDGS:
+        calls = 0
+
+        def text(self, query, max_results=10, backend="auto"):
+            type(self).calls += 1
+            raise DDGSException("upstream still flaking")
+
+    cap = _make_fake_api()
+    web_search = cap["tools"]["web_search"]
+
+    with mock.patch("ddgs.DDGS", _DDGS), mock.patch.object(
+        web_search_mod.time, "sleep"
+    ) as m_sleep:
+        out = web_search("anything")
+
+    assert _DDGS.calls == 3, f"expected 3 attempts (default), got {_DDGS.calls}"
+    assert m_sleep.call_count == 2, m_sleep.call_args_list
+    assert m_sleep.call_args_list == [mock.call(1.0), mock.call(3.0)]
+    assert out.startswith("<search error: backend unavailable"), out
+    assert "after 3 attempt(s)" in out, out
+    assert "upstream still flaking" in out, out
+    assert "fetch_url" in out, out
+    print("✓ retry: exhausted → <search error: backend unavailable after 3 attempt(s); ...>")
+
+
+def _check_rate_limited_marker_no_retry() -> None:
+    """``RatelimitException`` → distinct marker, NO retry."""
+    from ddgs.exceptions import RatelimitException
+
+    class _DDGS:
+        calls = 0
+
+        def text(self, query, max_results=10, backend="auto"):
+            type(self).calls += 1
+            raise RatelimitException("429 too many requests")
+
+    cap = _make_fake_api()
+    web_search = cap["tools"]["web_search"]
+
+    with mock.patch("ddgs.DDGS", _DDGS), mock.patch.object(
+        web_search_mod.time, "sleep"
+    ) as m_sleep:
+        out = web_search("anything")
+
+    assert _DDGS.calls == 1, f"rate-limit must not retry, got {_DDGS.calls} calls"
+    assert m_sleep.call_count == 0, m_sleep.call_args_list
+    assert out.startswith("<search error: rate limited"), out
+    assert "429" in out, out
+    print("✓ rate-limit: <search error: rate limited; ...>, no retry, no sleep")
+
+
+def _check_timeout_is_retried() -> None:
+    """``TimeoutException`` is retryable like ``DDGSException``."""
+    from ddgs.exceptions import TimeoutException
+
+    fixture = [{"title": "t", "href": "https://t.example.com", "body": ""}]
+
+    class _DDGS:
+        calls = 0
+
+        def text(self, query, max_results=10, backend="auto"):
+            type(self).calls += 1
+            if type(self).calls == 1:
+                raise TimeoutException("timed out fetching upstream")
+            return fixture
+
+    cap = _make_fake_api()
+    web_search = cap["tools"]["web_search"]
+
+    with mock.patch("ddgs.DDGS", _DDGS), mock.patch.object(
+        web_search_mod.time, "sleep"
+    ):
+        out = web_search("anything")
+    assert _DDGS.calls == 2, _DDGS.calls
+    assert "t.example.com" in out, out
+    print("✓ retry: TimeoutException retried like DDGSException")
+
+
+def _check_attempts_1_disables_retry() -> None:
+    """``retry_attempts = 1`` config → exactly one attempt, no sleep."""
+    from ddgs.exceptions import DDGSException
+
+    class _DDGS:
+        calls = 0
+
+        def text(self, query, max_results=10, backend="auto"):
+            type(self).calls += 1
+            raise DDGSException("flake")
+
+    cap = _make_fake_api(plugin_config={"retry_attempts": 1})
+    web_search = cap["tools"]["web_search"]
+
+    with mock.patch("ddgs.DDGS", _DDGS), mock.patch.object(
+        web_search_mod.time, "sleep"
+    ) as m_sleep:
+        out = web_search("anything")
+    assert _DDGS.calls == 1, _DDGS.calls
+    assert m_sleep.call_count == 0, m_sleep.call_args_list
+    assert out.startswith("<search error: backend unavailable"), out
+    print("✓ retry_attempts=1 disables retry entirely")
+
+
+def _check_backend_config_passes_through() -> None:
+    """``backend = "duckduckgo,brave"`` config reaches DDGS().text(...)."""
+    fixture = [{"title": "t", "href": "https://t.example.com", "body": ""}]
+
+    class _DDGS:
+        captured_backend: str | None = None
+
+        def text(self, query, max_results=10, backend="auto"):
+            type(self).captured_backend = backend
+            return fixture
+
+    cap = _make_fake_api(plugin_config={"backend": "duckduckgo,brave"})
+    web_search = cap["tools"]["web_search"]
+
+    with mock.patch("ddgs.DDGS", _DDGS):
+        web_search("anything")
+    assert _DDGS.captured_backend == "duckduckgo,brave", _DDGS.captured_backend
+    print("✓ backend config flows through to DDGS().text(backend=...)")
+
+
+def _check_non_network_exception_not_retried() -> None:
+    """A programmer error (TypeError) bypasses the retry loop and
+    surfaces via the existing catch-all ``<search error: ...>`` path."""
+    class _DDGS:
+        calls = 0
+
+        def text(self, query, max_results=10, backend="auto"):
+            type(self).calls += 1
+            raise TypeError("oops, programmer bug")
+
+    cap = _make_fake_api()
+    web_search = cap["tools"]["web_search"]
+
+    with mock.patch("ddgs.DDGS", _DDGS), mock.patch.object(
+        web_search_mod.time, "sleep"
+    ) as m_sleep:
+        out = web_search("anything")
+    assert _DDGS.calls == 1, f"non-network error must not retry, got {_DDGS.calls}"
+    assert m_sleep.call_count == 0, m_sleep.call_args_list
+    assert out.startswith("<search error:"), out
+    assert "programmer bug" in out, out
+    # NOT the typed markers — just the catch-all.
+    assert "rate limited" not in out, out
+    assert "backend unavailable" not in out, out
+    print("✓ non-network exceptions skip retry, hit the catch-all marker")
+
+
+# ---- Register-time config validation ------------------------------
+
+
+def _check_register_warnings_on_bogus_config() -> None:
+    cap = _make_fake_api(plugin_config={"retry_attempts": "three"})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert any("retry_attempts must be a positive integer" in m for m in msgs), msgs
+
+    cap = _make_fake_api(plugin_config={"retry_attempts": 0})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert any("retry_attempts must be >= 1" in m for m in msgs), msgs
+
+    cap = _make_fake_api(plugin_config={"retry_backoff_s": "not-a-list"})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert any("retry_backoff_s must be a list" in m for m in msgs), msgs
+
+    cap = _make_fake_api(plugin_config={"retry_backoff_s": [1.0, -1.0, "bad"]})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert any("retry_backoff_s contains invalid entries" in m for m in msgs), msgs
+
+    cap = _make_fake_api(plugin_config={"backend": 42})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert any("backend must be a string" in m for m in msgs), msgs
+
+    cap = _make_fake_api(plugin_config={"backend": "   "})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert any("backend is set but empty" in m for m in msgs), msgs
+
+    print("✓ register-time warnings: bogus retry/backoff/backend config flagged")
+
+
+def _check_register_silent_on_clean_config() -> None:
+    cap = _make_fake_api(plugin_config={
+        "retry_attempts": 4,
+        "retry_backoff_s": [0.5, 1.0, 2.0],
+        "backend": "duckduckgo,brave,yahoo",
+    })
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert msgs == [], f"expected no warnings, got: {msgs}"
+
+    # Empty config too.
+    cap = _make_fake_api(plugin_config={})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert msgs == [], f"expected no warnings on empty config, got: {msgs}"
+    print("✓ register-time silent on clean and empty config")
 
 
 def _check_instant_answer_uses_fixture_http() -> None:
@@ -317,6 +574,15 @@ def main() -> None:
     _check_tool_wrapper_returns_string()
     _check_tool_wrapper_translates_errors()
     _check_tool_wrapper_validates_inputs()
+    _check_retry_succeeds_after_transient_failure()
+    _check_retry_exhausted_marker()
+    _check_rate_limited_marker_no_retry()
+    _check_timeout_is_retried()
+    _check_attempts_1_disables_retry()
+    _check_backend_config_passes_through()
+    _check_non_network_exception_not_retried()
+    _check_register_warnings_on_bogus_config()
+    _check_register_silent_on_clean_config()
     _check_instant_answer_uses_fixture_http()
     print("smoke_web_search: all checks passed")
 


### PR DESCRIPTION
Closes #81.

## Observed (from #81)

In session `2026-05-02-grown-parrot`, **8 of 65 `web_search` calls (~12%)** failed with raw upstream errors and no retry. Failures clustered (3 consecutive on Hartwell rentals, 2 on Hall County), each costing a turn while the agent reworded and re-fired the same query into the same hole.

## Diagnosis (refined)

The original issue framed the failure as "Yandex flaked." Reading `ddgs/ddgs.py:_search_sync()` more carefully: `DDGS().text()` already runs ~10 engines in parallel via a `ThreadPoolExecutor`, only raises when *every* engine returned an error or empty, and the Yandex URL we see in the marker is just the *last* exception captured in the loop's `err` variable. The 8 failures were brief windows where the whole metasearch fanout went bad — exactly the shape that retry-with-backoff fixes, because each `DDGS().text()` reshuffles engine order, so a retry effectively samples a different subset.

So **no need to add our own fan-out** — it's there. The fix is at the layer above: classify exceptions, retry transients, surface distinct markers.

## Behavior

| Exception | Action | Marker |
|---|---|---|
| `RatelimitException` | **No retry** — surface immediately | `<search error: rate limited; pause and try again later (...)>` |
| `TimeoutException` | Retry with backoff | (success or exhausted marker) |
| `DDGSException` | Retry with backoff | (success or exhausted marker) |
| Exhausted retries | Stop | `<search error: backend unavailable after N attempt(s); try a different query or use fetch_url with a known URL>` |
| Other exceptions | Fail fast | `<search error: ...>` (today's behavior) |

The exhausted-retry marker is **distinct** from today's so the agent can reason about it ("the backend is down, switch strategies") instead of just rewording and re-firing.

## Configuration

New `[plugins.web-search]` table, all optional:

```toml
[plugins.web-search]
retry_attempts = 3              # initial + (n-1) retries; 1 disables retry
retry_backoff_s = [1.0, 3.0]    # per-retry sleep durations; len ~= attempts-1
backend = "auto"                # comma-delimited engine names, or "auto"
```

`backend` lets the user pin to a known-good subset (e.g. `"duckduckgo,brave,yahoo,mojeek"` to skip Yandex if it stays flaky over time). Default `"auto"` keeps current behavior.

Register-time validation (warn-but-continue): malformed values log a warning via `api.log()` and the resolvers fall back to defaults at call time. Same pattern as doc-tools.

## Out of scope (intentionally)

- **`web_search_instant` retry.** Different code path (raw urllib), no observed failures, separate design if needed.
- **Cross-call backoff state.** Remembering rate-limit hits across consecutive calls so the agent doesn't immediately re-fire. Useful but bigger; defer.
- **Result caching.** Different shape of problem.
- **Side-saving structured `SearchResult[]` to attachments** so future tools can read the raw URL list. Discussed in the design thread; needs framework support (PluginAPI session-attachments + `Attachment.inline_text` decoupling) — will file as a follow-up.

## Test plan

- [x] `tests/smoke_web_search.py` — 21 checks total (12 existing + 9 new):
  - Transient failure → success on retry, asserts `time.sleep(1.0)` was called once.
  - Exhaustion across all 3 attempts → distinct "backend unavailable after 3 attempt(s)" marker; asserts `[1.0, 3.0]` sleep sequence.
  - `RatelimitException` → no retry, no sleep, distinct rate-limit marker.
  - `TimeoutException` → retried like `DDGSException`.
  - `retry_attempts=1` → exactly one attempt, no sleep.
  - `backend="duckduckgo,brave"` reaches `DDGS().text(backend=...)`.
  - `TypeError` (non-network) bypasses retry, hits the catch-all marker (no rate-limit / backend-unavailable strings).
  - Register-time warnings on bogus `retry_attempts` / `retry_backoff_s` / `backend`.
  - Silence on clean and empty config.
- [x] Existing tests adjusted to handle the new kwargs in the `DDGS().text()` call.
- [ ] Manual exercise on the live network — not done; the retry path is exercised by mocked failures and the happy-path call signature is verified.