### PR TITLE
agent: structured offload notice with size/range metadata

### DIFF
--- a/pyagent/agent.py
+++ b/pyagent/agent.py
@@ -203,7 +203,7 @@ class Agent:
                 declared_tool_provenance=provenance,
             )
         result = self.tools[name](**args)
-        return self._render_tool_result(name, result)
+        return self._render_tool_result(name, result, args=args)
 
     # Hard ceiling: any tool result above this size is offloaded
     # regardless of the tool's `auto_offload` setting. Prevents a
@@ -226,7 +226,12 @@ class Agent:
     # read of HTML / a wide log line / a binary mistakenly read as text.
     SOFT_THRESHOLD_FORCED_TOOLS: frozenset[str] = frozenset({"read_file"})
 
-    def _render_tool_result(self, name: str, result: Any) -> str:
+    def _render_tool_result(
+        self,
+        name: str,
+        result: Any,
+        args: dict[str, Any] | None = None,
+    ) -> str:
         if isinstance(result, Attachment):
             if not self.session:
                 if result.preview:
@@ -235,8 +240,13 @@ class Agent:
             path = self.session.write_attachment(
                 name, result.content, result.suffix
             )
+            cap = self.session.attachment_threshold
             return self._format_offload_ref(
-                path, len(result.content), result.preview
+                path,
+                len(result.content),
+                result.preview,
+                cap_chars=cap,
+                tool_name=name,
             )
 
         if isinstance(result, str):
@@ -260,7 +270,52 @@ class Agent:
             if (auto and over_threshold) or over_ceiling or forced_soft:
                 path = self.session.write_attachment(name, text)
                 preview = text[: self.session.preview_chars]
-                return self._format_offload_ref(path, len(text), preview)
+                # File-shape and read_file range hints are computed
+                # from the rendered text + the original tool args so
+                # the agent can size its next slice without having to
+                # bisect by feel (issue #82).
+                file_lines = text.count("\n") + 1 if text else 0
+                range_consumed: tuple[int, int] | None = None
+                next_call_hint: str | None = None
+                if name == "read_file" and isinstance(args, dict):
+                    rf_path = args.get("path")
+                    rf_start_raw = args.get("start", 1)
+                    rf_end_raw = args.get("end")
+                    try:
+                        rf_start = int(rf_start_raw)
+                    except (TypeError, ValueError):
+                        rf_start = 1
+                    rf_consumed_end = rf_start + file_lines - 1
+                    range_consumed = (rf_start, rf_consumed_end)
+                    # Was this slice the tail of the file? If `end`
+                    # is unset the agent asked for "to EOF" — but
+                    # `read_file` itself caps at 2000 lines and
+                    # appends a `... (truncated: ...)` marker when
+                    # it had to truncate, so check for that instead
+                    # of trusting the args. With explicit end, the
+                    # next start is one past what we just returned.
+                    end_is_eof = rf_end_raw is None
+                    truncated_marker = "... (truncated: file has "
+                    file_was_truncated = truncated_marker in text
+                    if end_is_eof and not file_was_truncated:
+                        next_call_hint = "[whole file consumed]"
+                    elif rf_path is not None:
+                        next_start = rf_consumed_end + 1
+                        next_call_hint = (
+                            f"[next: read_file({rf_path}, "
+                            f"start={next_start}) — you've read lines "
+                            f"{rf_start}-{rf_consumed_end}]"
+                        )
+                return self._format_offload_ref(
+                    path,
+                    len(text),
+                    preview,
+                    cap_chars=self.session.attachment_threshold,
+                    file_lines=file_lines,
+                    range_consumed=range_consumed,
+                    next_call_hint=next_call_hint,
+                    tool_name=name,
+                )
         return text
 
     def _scrub_large_tool_args(self, call: dict[str, Any]) -> None:
@@ -296,18 +351,85 @@ class Agent:
                     f"see the tool result for the outcome>"
                 )
 
+    # Per-tool next-step hints rendered into the offload header when no
+    # tool-specific guidance has already been computed (read_file gets
+    # its own range-aware hint via `next_call_hint`; grep already
+    # appends a "tighten the pattern" marker on truncation in
+    # tools.py). See issue #82.
+    _TOOL_HINTS: dict[str, str] = {
+        "execute": (
+            "stdout was huge — filter (`grep`/`head`) or redirect to a "
+            "file"
+        ),
+        "fetch_url": (
+            "use `html_to_md` on the saved path or `read_file` with a "
+            "smaller range"
+        ),
+        "html_to_md": (
+            "use `html_to_md` on the saved path or `read_file` with a "
+            "smaller range"
+        ),
+    }
+
     @staticmethod
-    def _format_offload_ref(path: Any, size: int, preview: str) -> str:
-        header = (
-            f"[output saved to {path} ({size} chars) — preview below. "
-            f"Do NOT read_file the whole attachment; that pulls every "
-            f"byte back into context permanently. If you need more, "
-            f"grep for what you want or read_file with start/end to "
-            f"slice a specific range.]"
-        )
+    def _format_offload_ref(
+        path: Any,
+        size: int,
+        preview: str,
+        *,
+        cap_chars: int | None = None,
+        file_lines: int | None = None,
+        range_consumed: tuple[int, int] | None = None,
+        next_call_hint: str | None = None,
+        tool_name: str | None = None,
+    ) -> str:
+        """Render the offload notice the agent sees in place of bytes.
+
+        The first line is a structured header keyed `produced` /
+        `cap` / `file` so the agent can size its next slice on the
+        first try instead of bisecting (issue #82). Older inline
+        prose has been dropped — for `read_file` the next-range
+        hint replaces the generic warning, for other tools the hint
+        comes from `_TOOL_HINTS` keyed off `tool_name`.
+
+        Note: `range_consumed` is currently included on the next-step
+        line for `read_file` rather than the header; kept as a
+        parameter so future callers can surface it independently
+        (e.g. tail/head-style readers) without refactoring.
+        """
+        # Header: structured tokens. Keep keys / order stable —
+        # `pyagent.sessions_audit._OFFLOAD_RE` parses this prefix to
+        # identify offloaded results vs inline ones.
+        parts = [f"[offload {path}", f"produced {size}c"]
+        if cap_chars is not None:
+            parts.append(f"cap {cap_chars}c")
+        if file_lines is not None and file_lines > 0:
+            avg = max(1, size // file_lines) if file_lines else 0
+            parts.append(f"file {file_lines} lines, ~{avg}c/line avg")
+        header = " | ".join(parts) + "]"
+
+        # Next-step line: read_file gets a range-aware hint computed
+        # by the caller; other tools fall back to the static hint
+        # table. Some tools (`grep`) emit their own truncation hint
+        # inside the result body — they get nothing extra here.
+        hint_line: str | None = None
+        if next_call_hint:
+            hint_line = next_call_hint
+        elif tool_name and tool_name in Agent._TOOL_HINTS:
+            hint_line = f"[hint: {Agent._TOOL_HINTS[tool_name]}]"
+        # `range_consumed` is not separately rendered today (the
+        # range info already lives in `next_call_hint`); reserved for
+        # future tool-shapes. Reference it so static analysis doesn't
+        # flag it.
+        _ = range_consumed
+
+        lines = [header]
+        if hint_line:
+            lines.append(hint_line)
         if preview:
-            return f"{header}\n\n--- preview ---\n{preview}"
-        return header
+            lines.append("--- preview ---")
+            lines.append(preview)
+        return "\n".join(lines)
 
     def _route_tool(
         self,

--- a/pyagent/sessions_audit.py
+++ b/pyagent/sessions_audit.py
@@ -27,12 +27,13 @@ from typing import Any
 from pyagent import pricing
 
 
-# Matches the prefix produced by `Agent._format_offload_ref(path, size, preview)`.
-# Captures the attachment path and its char count. Anchored to the start
-# of the tool-result content; unanchored matching would catch the
-# substring inside an inline tool result that happens to mention an
-# attachment, inflating the offload count.
-_OFFLOAD_RE = re.compile(r"^\[output saved to (\S+) \((\d+) chars\)")
+# Matches the prefix produced by `Agent._format_offload_ref` (issue #82
+# changed the header from prose to structured tokens). Captures the
+# attachment path and its char count. Anchored to the start of the
+# tool-result content; unanchored matching would catch the substring
+# inside an inline tool result that happens to mention an attachment,
+# inflating the offload count.
+_OFFLOAD_RE = re.compile(r"^\[offload (\S+) \| produced (\d+)c")
 
 
 @dataclass

--- a/tests/smoke_read_file_ceiling.py
+++ b/tests/smoke_read_file_ceiling.py
@@ -64,7 +64,7 @@ def _check_large_read_file_offloads() -> None:
         )
         text = "y" * size
         rendered = agent._render_tool_result("read_file", text)
-        assert "[output saved to" in rendered, rendered
+        assert rendered.startswith("[offload "), rendered
         assert text not in rendered, (
             "raw payload leaked through soft-threshold offload"
         )
@@ -94,7 +94,7 @@ def _check_hard_ceiling_still_fires() -> None:
         ceiling = agent.HARD_OFFLOAD_CEILING
         text = "q" * (ceiling + 5_000)
         rendered = agent._render_tool_result("read_skill", text)
-        assert "[output saved to" in rendered, rendered
+        assert rendered.startswith("[offload "), rendered
         assert text not in rendered
     print("✓ hard ceiling still offloads oversize read_skill output")
 

--- a/tests/smoke_session_audit.py
+++ b/tests/smoke_session_audit.py
@@ -43,6 +43,109 @@ def _check_offload_regex_matches_format_offload_ref() -> None:
     print(f"✓ _OFFLOAD_RE captures path={m.group(1)!r} size={m.group(2)!r}")
 
 
+def _check_offload_header_structured_tokens() -> None:
+    """The new structured header (issue #82) carries produced/cap/file
+    tokens so the agent can size its next slice without bisecting.
+
+    Locks the format the regex above relies on, plus the optional
+    fields a tool-aware caller may pass through (cap, file_lines).
+    """
+    fake_path = Path("/tmp/foo.txt")
+    stub = Agent._format_offload_ref(
+        fake_path,
+        10204,
+        "preview",
+        cap_chars=8000,
+        file_lines=561,
+    )
+    first_line = stub.splitlines()[0]
+    assert first_line.startswith(f"[offload {fake_path}"), first_line
+    assert "produced 10204c" in first_line, first_line
+    assert "cap 8000c" in first_line, first_line
+    assert "file 561 lines" in first_line, first_line
+    # Header should be MUCH cheaper than the old prose paragraph (~330c).
+    assert len(first_line) < 130, (
+        f"header bloated past target: {len(first_line)}c — {first_line!r}"
+    )
+    print(f"✓ structured header tokens present ({len(first_line)}c)")
+
+
+def _check_offload_read_file_next_range_hint() -> None:
+    """For `read_file` with a known consumed range, the hint line tells
+    the agent the next start so successive slices don't overlap."""
+    from pyagent.agent import Agent
+    from pyagent.session import Session
+    import tempfile as _tempfile
+
+    with _tempfile.TemporaryDirectory() as td:
+        session = Session(session_id="hint", root=Path(td))
+        session._ensure_dirs()
+        agent = Agent(client=None, session=session)
+        agent.add_tool("read_file", lambda: None, auto_offload=False)
+        # 240 lines of 80 chars each = ~19_440 chars > 8000 threshold.
+        text = "\n".join(["x" * 80 for _ in range(240)])
+        rendered = agent._render_tool_result(
+            "read_file", text, args={"path": "f.txt", "start": 200, "end": 700}
+        )
+        # Header line 1.
+        lines = rendered.splitlines()
+        assert lines[0].startswith("[offload "), lines[0]
+        # Hint line 2 — read_file gets the range-aware next-call line.
+        assert lines[1].startswith("[next: read_file(f.txt"), lines[1]
+        assert "start=440" in lines[1], lines[1]  # 200 + 240 lines
+        assert "lines 200-439" in lines[1], lines[1]
+        print(f"✓ read_file next-range hint: {lines[1]!r}")
+
+
+def _check_offload_read_file_whole_file_consumed() -> None:
+    """When the agent asked for to-EOF and the read_file tool didn't
+    truncate, the hint says `[whole file consumed]` instead of
+    pointing at a phantom next slice."""
+    from pyagent.agent import Agent
+    from pyagent.session import Session
+    import tempfile as _tempfile
+
+    with _tempfile.TemporaryDirectory() as td:
+        session = Session(session_id="whole", root=Path(td))
+        session._ensure_dirs()
+        agent = Agent(client=None, session=session)
+        agent.add_tool("read_file", lambda: None, auto_offload=False)
+        # No truncation marker, no end arg ⇒ "[whole file consumed]".
+        text = "\n".join(["y" * 80 for _ in range(150)])
+        rendered = agent._render_tool_result(
+            "read_file", text, args={"path": "g.txt", "start": 1}
+        )
+        lines = rendered.splitlines()
+        assert "[whole file consumed]" in lines[1], lines[1]
+        print(f"✓ whole-file-consumed hint: {lines[1]!r}")
+
+
+def _check_offload_tool_specific_hints() -> None:
+    """`execute` / `fetch_url` / `html_to_md` get their own hint lines.
+    `read_file` is exempt (it gets the range-aware variant)."""
+    fake_path = Path("/tmp/x.txt")
+    for tool, needle in [
+        ("execute", "stdout was huge"),
+        ("fetch_url", "html_to_md"),
+        ("html_to_md", "html_to_md"),
+    ]:
+        stub = Agent._format_offload_ref(
+            fake_path, 9000, "preview", cap_chars=8000, tool_name=tool
+        )
+        lines = stub.splitlines()
+        assert lines[1].startswith("[hint: "), (tool, lines[1])
+        assert needle in lines[1], (tool, lines[1])
+    # A tool with no entry in the table (e.g. `grep`) gets no hint
+    # line — grep emits its own truncation marker in the body.
+    stub = Agent._format_offload_ref(
+        fake_path, 9000, "preview", cap_chars=8000, tool_name="grep"
+    )
+    lines = stub.splitlines()
+    # First line is header, then "--- preview ---", then preview body.
+    assert lines[1] == "--- preview ---", lines
+    print("✓ tool-specific hints render for execute/fetch_url/html_to_md")
+
+
 def _write_synthetic_session(tmp: Path) -> Path:
     """Mint a session dir with a transcript containing both pre-#15 and
     post-#15 assistant turns, plus inline + offloaded tool results, and
@@ -420,6 +523,10 @@ def _check_path_traversal_refused() -> None:
 
 def main() -> None:
     _check_offload_regex_matches_format_offload_ref()
+    _check_offload_header_structured_tokens()
+    _check_offload_read_file_next_range_hint()
+    _check_offload_read_file_whole_file_consumed()
+    _check_offload_tool_specific_hints()
     _check_audit_synthetic_session()
     _check_render_text_smoke()
     _check_render_json_smoke()

--- a/tests/smoke_session_replay.py
+++ b/tests/smoke_session_replay.py
@@ -52,7 +52,7 @@ def _check_stub_not_content() -> None:
     # Mint a stub the same way Agent._render_tool_result does.
     preview = payload[: session.preview_chars]
     stub = Agent._format_offload_ref(attachment_path, len(payload), preview)
-    assert "[output saved to" in stub, stub
+    assert stub.startswith("[offload "), stub
 
     # Build a realistic tool-result conversation entry and persist it.
     entry = {
@@ -181,7 +181,7 @@ def _check_render_path_returns_stub() -> None:
     )
     assert isinstance(rendered, str), type(rendered)
     assert big not in rendered, "raw content leaked through _render_tool_result"
-    assert "[output saved to" in rendered, rendered
+    assert rendered.startswith("[offload "), rendered
     print(f"✓ _render_tool_result(Attachment) → stub: {len(rendered)} chars")
 
 


### PR DESCRIPTION
## Motivation

Closes #82. Session `2026-05-02-grown-parrot` showed the agent burning 11 turns paginating a 561-line markdown file because every `read_file` slice over 8000c got re-offloaded into a 1000c preview, and the offload notice didn't carry the numbers the agent needed to size its next slice. The offload mechanism is correct; the *feedback signal* was the bug.

## What changed

`Agent._format_offload_ref` now produces a structured one-line header keyed `produced` / `cap` / `file` instead of a 330c prose paragraph. `Agent._render_tool_result` computes the metadata from the rendered text + the original tool args and threads it through.

For `read_file`, a second line either reports `[whole file consumed]` (when the agent asked to-EOF and the tool didn't truncate) or hands the agent the exact `read_file(<path>, start=N)` to fire next, computed from the consumed range. For `execute` / `fetch_url` / `html_to_md` a short hint line is rendered from a small table. `grep` already emits its own truncation marker, so it's intentionally not in the table.

## Before / after

Before:
```
[output saved to /…/foo.txt (10204 chars) — preview below. Do NOT read_file
the whole attachment; that pulls every byte back into context permanently.
If you need more, grep for what you want or read_file with start/end to
slice a specific range.]
```

After:
```
[offload /…/foo.txt | produced 10204c | cap 8000c | file 561 lines, ~18c/line avg]
[next: read_file(/…/foo.txt, start=441) — you've read lines 200-440]
--- preview ---
…
```

Header is now ~60-130c (structured) vs the prior ~330c (prose), and the agent stops re-walking territory it has already seen.

## Tool-specific hints

- `read_file` — range-aware `[next: ...]` or `[whole file consumed]`.
- `execute` — `stdout was huge — filter (grep/head) or redirect to a file`.
- `fetch_url` / `html_to_md` — `use html_to_md on the saved path or read_file with a smaller range`.
- `grep` — emits its own `<truncated: ...; tighten the pattern>` marker in the body, so no extra hint here.

## Files touched

- `pyagent/agent.py` — `_render_tool_result` widened to take `args`; `_format_offload_ref` rewritten with structured kwargs; `_TOOL_HINTS` table added.
- `pyagent/sessions_audit.py` — `_OFFLOAD_RE` updated for the new prefix (`[offload <path> | produced Nc`).
- `tests/smoke_session_audit.py` — added 4 new checks (header tokens, read_file next-range, whole-file-consumed, tool-specific hints); existing regex-roundtrip check now asserts the new shape.
- `tests/smoke_session_replay.py`, `tests/smoke_read_file_ceiling.py` — updated old-prefix asserts.

## Test plan

- [x] `python -m tests.smoke_session_audit` — 16 of 16 pass (4 new + 12 existing).
- [x] `python -m tests.smoke_session_replay` — 4 of 4 pass.
- [x] `python -m tests.smoke_read_file_ceiling` — 5 of 5 pass.
- [x] `python -m tests.smoke_arg_scrubbing`, `smoke_skill_eviction` — pass (sanity for adjacent tool-execution paths).
- [ ] Manual: pull a fresh worktree, fire a `read_file` slice past the 8000c threshold, confirm the next-range hint is present and the agent can use it directly.

## Coordination note

Issue #88 is concurrently touching `_render_tool_result` (early-return for `Attachment.inline_text`). Edits here are scoped to the offload-header path — `Attachment` dataclass, eviction, scrubbing, and the rest of `_route_tool` are untouched, so the merge should be mechanical.