### PR TITLE
attachments: decouple inline_text from saved content

### DIFF
--- a/pyagent/agent.py
+++ b/pyagent/agent.py
@@ -234,12 +234,24 @@ class Agent:
     ) -> str:
         if isinstance(result, Attachment):
             if not self.session:
+                # No session → nothing to save. Prefer inline_text if
+                # the tool supplied one (it's the human answer); else
+                # fall back to today's preview-or-content behavior.
+                if result.inline_text is not None:
+                    return result.inline_text
                 if result.preview:
                     return result.preview
                 return result.content if isinstance(result.content, str) else ""
             path = self.session.write_attachment(
                 name, result.content, result.suffix
             )
+            if result.inline_text is not None:
+                # inline_text path: the saved file is *side data*
+                # (structured blob the agent might legitimately re-read
+                # via extract_doc / read_file), not an offloaded big
+                # result. Skip the offload header / "do not read" warn;
+                # just point at the file with a minimal footer.
+                return f"{result.inline_text}\n\n[also saved: {path}]"
             cap = self.session.attachment_threshold
             return self._format_offload_ref(
                 path,

--- a/pyagent/agent_proc.py
+++ b/pyagent/agent_proc.py
@@ -829,6 +829,12 @@ def _bootstrap(
             plugin_loader=loaded_plugins,
         )
 
+    # Now that the session exists, expose it to plugins so
+    # PluginAPI.write_session_attachment can resolve a real path.
+    # Bench / no-session contexts skip this step → plugins fall back
+    # to inline-only rendering.
+    loaded_plugins.bind_session(session)
+
     agent = Agent(
         client=client,
         system=system,

--- a/pyagent/plugins/__init__.py
+++ b/pyagent/plugins/__init__.py
@@ -271,8 +271,17 @@ class PluginAPI:
     contributes.
     """
 
-    def __init__(self, plugin_state: _PluginState) -> None:
+    def __init__(
+        self,
+        plugin_state: _PluginState,
+        loader: "LoadedPlugins | None" = None,
+    ) -> None:
         self._state = plugin_state
+        # Back-reference to the LoadedPlugins instance so
+        # `write_session_attachment` can find the active session that
+        # the agent binds via `LoadedPlugins.bind_session()` after
+        # session construction.
+        self._loader = loader
         self._frozen = False
 
     # ---- read-only attributes -----------------------------------
@@ -303,6 +312,37 @@ class PluginAPI:
     @property
     def plugin_name(self) -> str:
         return self._state.manifest.name
+
+    # ---- session-scoped writes ----------------------------------
+
+    def write_session_attachment(
+        self,
+        tool_name: str,
+        content: str | bytes,
+        suffix: str = "",
+    ) -> Path | None:
+        """Write to the current session's attachments dir.
+
+        Returns ``None`` if no session is active (e.g. the bench
+        harness or a no-session test run). Plugins should fall back
+        gracefully — render inline-only when the path is ``None``.
+
+        Most plugins should prefer returning
+        ``Attachment(content=..., inline_text=..., suffix=...)`` from
+        a tool — the agent's render path writes the file *and* glues
+        the inline rendering with the ``[also saved: <path>]`` footer
+        in one shot. Use this method directly when the plugin wants
+        explicit control over file layout (e.g. multiple files per
+        call) or wants to write before constructing the inline
+        rendering.
+        """
+        loader = self._loader
+        if loader is None:
+            return None
+        session = loader.session
+        if session is None:
+            return None
+        return session.write_attachment(tool_name, content, suffix)
 
     # ---- registration -------------------------------------------
 
@@ -865,6 +905,20 @@ class LoadedPlugins:
     _resolved_providers: dict[str, _RegisteredProvider] = field(
         default_factory=dict
     )
+    # Active session for plugin-side writes via
+    # `PluginAPI.write_session_attachment`. The agent's bootstrap
+    # constructs the session after `load()` returns, then calls
+    # `bind_session(session)` to populate this. Stays `None` in
+    # bench / no-session contexts; plugins fall back to inline-only.
+    session: Any | None = None
+
+    def bind_session(self, session: Any | None) -> None:
+        """Attach the active Session so `PluginAPI.write_session_attachment`
+        can resolve a path. Called once by the agent bootstrap after
+        load() returns and the session is constructed; stays unset in
+        contexts that don't have a session (the bench harness, certain
+        test fixtures)."""
+        self.session = session
 
     def tools(self) -> Mapping[str, tuple[str, Callable]]:
         """Effective tool name → (plugin_name, fn) after conflict
@@ -1164,7 +1218,7 @@ def load(*, is_subagent: bool = False) -> LoadedPlugins:
             )
             continue
         state = _PluginState(manifest=record.manifest)
-        api = PluginAPI(state)
+        api = PluginAPI(state, loader=loaded)
         try:
             register_fn(api)
         except Exception:

--- a/pyagent/session.py
+++ b/pyagent/session.py
@@ -29,11 +29,21 @@ class Attachment:
     truncating `content`. `suffix` is the filename extension to use
     when saving (e.g. `".png"`); defaults pick `.txt` for str, `.bin`
     for bytes.
+
+    `inline_text`, when set, decouples "what the agent sees inline"
+    from "what's saved on disk". The agent renders ``inline_text``
+    followed by a minimal ``[also saved: <path>]`` footer instead of
+    the offload header + preview. Use this when the saved file is
+    structured side data (e.g. a JSON blob a downstream tool will
+    read) and ``content`` is no longer a candidate for inline preview.
+    When ``None`` (default), behavior is unchanged: the saved bytes
+    drive the inline preview through the offload header path.
     """
 
     content: str | bytes
     preview: str = ""
     suffix: str = ""
+    inline_text: str | None = None
 
 
 class Session:

--- a/tests/smoke_plugins.py
+++ b/tests/smoke_plugins.py
@@ -956,6 +956,109 @@ def test_insert_index_bullet_unit() -> None:
     print("✓ _insert_index_bullet: placement edge cases")
 
 
+def test_write_session_attachment_no_session() -> None:
+    """`PluginAPI.write_session_attachment` returns None when no session
+    has been bound. Plugins fall back to inline-only rendering in this
+    branch (bench harness, certain test fixtures)."""
+    cfg, restore = _isolated_config_dir()
+    try:
+        plugin_py = (
+            "_state = {'path': 'unset'}\n"
+            "def get_state(): return _state\n"
+            "def register(api):\n"
+            "    def go() -> str:\n"
+            '        """Smoke: try to write."""\n'
+            '        path = api.write_session_attachment(\n'
+            '            "go", "side-data", suffix=".json"\n'
+            "        )\n"
+            "        _state['path'] = path\n"
+            "        return 'ok'\n"
+            '    api.register_tool("go", go)\n'
+        )
+        _write_plugin(
+            cfg / "plugins",
+            dirname="wsa-none",
+            name="wsa-none",
+            provides_tools=["go"],
+            plugin_py=plugin_py,
+        )
+        loaded = plugins_mod.load()
+        # No bind_session() call → loader.session is None.
+        _, fn = loaded.tools()["go"]
+        assert fn() == "ok"
+        import sys
+        plugin_module = next(
+            mod
+            for mod_name, mod in sys.modules.items()
+            if mod_name.startswith("pyagent_plugin_wsa_none")
+        )
+        assert plugin_module.get_state()["path"] is None, (
+            "expected None when no session is bound"
+        )
+        print("✓ write_session_attachment returns None with no bound session")
+    finally:
+        restore()
+
+
+def test_write_session_attachment_with_session() -> None:
+    """After `bind_session(session)`, `write_session_attachment` writes
+    bytes into the session's attachments dir and returns the Path."""
+    from pyagent.session import Session
+
+    cfg, restore = _isolated_config_dir()
+    try:
+        plugin_py = (
+            "_state = {'path': 'unset'}\n"
+            "def get_state(): return _state\n"
+            "def register(api):\n"
+            "    def go() -> str:\n"
+            '        """Smoke: write side-data."""\n'
+            '        p = api.write_session_attachment(\n'
+            '            "go", \'{"k": 1}\', suffix=".json"\n'
+            "        )\n"
+            "        _state['path'] = p\n"
+            "        return 'ok'\n"
+            '    api.register_tool("go", go)\n'
+        )
+        _write_plugin(
+            cfg / "plugins",
+            dirname="wsa-real",
+            name="wsa-real",
+            provides_tools=["go"],
+            plugin_py=plugin_py,
+        )
+        loaded = plugins_mod.load()
+        sess_root = Path(tempfile.mkdtemp(prefix="pyagent-wsa-"))
+        try:
+            session = Session(session_id="t", root=sess_root)
+            session._ensure_dirs()
+            loaded.bind_session(session)
+
+            _, fn = loaded.tools()["go"]
+            assert fn() == "ok"
+
+            import sys
+            plugin_module = next(
+                mod
+                for mod_name, mod in sys.modules.items()
+                if mod_name.startswith("pyagent_plugin_wsa_real")
+            )
+            saved = plugin_module.get_state()["path"]
+            assert saved is not None, "expected a Path"
+            assert saved.exists(), saved
+            assert saved.parent == session.attachments_dir, saved
+            assert saved.read_text() == '{"k": 1}'
+            assert saved.suffix == ".json"
+            print(
+                f"✓ write_session_attachment with session: "
+                f"wrote {saved.stat().st_size} bytes to {saved.name}"
+            )
+        finally:
+            shutil.rmtree(sess_root, ignore_errors=True)
+    finally:
+        restore()
+
+
 def test_graceful_degradation_when_memory_disabled() -> None:
     """With built_in_plugins_enabled=[], the agent has no ledger
     tools and no ledger prose, but its declared_tool_provenance
@@ -1010,6 +1113,8 @@ def main() -> None:
     test_memory_vector_recall()
     test_add_memory_tool()
     test_insert_index_bullet_unit()
+    test_write_session_attachment_no_session()
+    test_write_session_attachment_with_session()
     test_graceful_degradation_when_memory_disabled()
     print("\nALL CHECKS PASSED")
 

--- a/tests/smoke_session_replay.py
+++ b/tests/smoke_session_replay.py
@@ -185,11 +185,89 @@ def _check_render_path_returns_stub() -> None:
     print(f"✓ _render_tool_result(Attachment) → stub: {len(rendered)} chars")
 
 
+def _check_attachment_inline_text_unset_unchanged() -> None:
+    """Regression-guard: Attachment without inline_text uses the same
+    offload-header rendering as before #88. Locks "today's behavior is
+    unchanged when the new field is None"."""
+    tmp = Path(tempfile.mkdtemp(prefix="pyagent-smoke-replay-"))
+    session = Session(session_id="legacy", root=tmp)
+    agent = Agent(client=None, session=session)
+
+    payload = "Z" * 12_000
+    rendered = agent._render_tool_result(
+        "read_file",
+        Attachment(content=payload, preview=payload[:100]),
+    )
+    assert rendered.startswith("[offload "), rendered
+    assert "[also saved:" not in rendered, (
+        "side-data footer must NOT appear when inline_text is None"
+    )
+    assert payload not in rendered
+    print("✓ inline_text=None: legacy offload-header path unchanged")
+
+
+def _check_attachment_inline_text_set() -> None:
+    """When inline_text is set, the rendered output starts with the
+    inline_text and ends with `[also saved: <path>]`. The file lands
+    on disk with the expected `content`."""
+    tmp = Path(tempfile.mkdtemp(prefix="pyagent-smoke-replay-"))
+    session = Session(session_id="inline", root=tmp)
+    agent = Agent(client=None, session=session)
+
+    inline = "## Top hits\n\n- foo (https://a)\n- bar (https://b)\n"
+    structured = '[{"title": "foo", "url": "https://a"}]'
+    rendered = agent._render_tool_result(
+        "web_search",
+        Attachment(
+            content=structured,
+            inline_text=inline,
+            suffix=".json",
+        ),
+    )
+    assert isinstance(rendered, str), type(rendered)
+    assert rendered.startswith(inline), rendered
+    # Footer at the tail; minimal shape "[also saved: <path>]".
+    assert rendered.rstrip().endswith("]"), rendered
+    assert "[also saved: " in rendered, rendered
+    # No offload header: the file is *side data*, not an offloaded big
+    # result whose preview the agent must not re-read.
+    assert "[offload " not in rendered, rendered
+    assert "Do NOT read_file" not in rendered
+
+    # Recover the path from the footer and confirm the bytes landed.
+    footer = rendered.rsplit("[also saved: ", 1)[1].rstrip().rstrip("]")
+    saved_path = Path(footer)
+    assert saved_path.exists(), saved_path
+    assert saved_path.read_text() == structured
+    assert saved_path.suffix == ".json", saved_path
+    print(
+        f"✓ inline_text path: rendered starts with inline_text, "
+        f"ends with [also saved: ...], file on disk = "
+        f"{saved_path.stat().st_size} bytes"
+    )
+
+
+def _check_attachment_inline_text_no_session() -> None:
+    """No session → inline_text wins over preview/content. Plugins that
+    optimistically build both shapes still degrade to the human view."""
+    agent = Agent(client=None, session=None)
+    inline = "## summary\nfoo\n"
+    rendered = agent._render_tool_result(
+        "web_search",
+        Attachment(content="raw", inline_text=inline, preview="ignored"),
+    )
+    assert rendered == inline, rendered
+    print("✓ inline_text path with no session: returns inline_text only")
+
+
 def main() -> None:
     _check_stub_not_content()
     _check_round_trip()
     _check_attachment_construction_sites()
     _check_render_path_returns_stub()
+    _check_attachment_inline_text_unset_unchanged()
+    _check_attachment_inline_text_set()
+    _check_attachment_inline_text_no_session()
     print("\nALL CHECKS PASSED")
 
 


### PR DESCRIPTION
## Motivation

Closes #88.

The `Attachment` dataclass coupled "what to save on disk" with "what to render inline" — the saved bytes drove the inline preview through the offload header. Plugins like the upcoming `web_search` side-save need both views: a human-rendered markdown summary inline AND a structured JSON blob saved to attachments for downstream tools.

## API surface

### `Attachment.inline_text: str | None = None` (new field)

```python
@dataclass
class Attachment:
    content: str | bytes      # what to save on disk
    preview: str = ""         # used today; appears under the offload header
    suffix: str = ""
    inline_text: str | None = None   # NEW
```

When set, `Agent._render_tool_result` writes the file as before but returns:

```
<inline_text>

[also saved: <path>]
```

No offload header, no "do not read_file" warning — the saved file is structured side data the agent might legitimately re-read with `extract_doc` / `read_file`. `inline_text=None` preserves today's offload-stub behavior exactly (regression-guarded by `_check_attachment_inline_text_unset_unchanged`).

### `PluginAPI.write_session_attachment(tool_name, content, suffix="") -> Path | None` (new method)

For plugins that want explicit control over file layout (multiple files per call, etc.). Returns `None` when no session is active so plugins can degrade gracefully to inline-only.

Plumbing: `LoadedPlugins.bind_session(session)` is called from `agent_proc._bootstrap` immediately after session construction. `PluginAPI` keeps a back-reference to its `LoadedPlugins` so it can resolve the bound session lazily.

## Example: before / after

Before (web_search inline-only):

```python
def web_search(query: str) -> str:
    results = ddg(query)
    return render_markdown(results)
```

After (web_search side-saves the structured form):

```python
from pyagent.session import Attachment

def web_search(query: str) -> Attachment:
    results = ddg(query)
    return Attachment(
        content=json.dumps([asdict(r) for r in results]),
        inline_text=render_markdown(results),
        suffix=".json",
    )
```

The agent sees the markdown inline; downstream `extract_doc` / `read_file` can recover the URL list from the saved JSON.

## Test plan

- [x] `tests.smoke_session_replay` — 4 existing checks pass; 3 new checks added
  - [x] `inline_text=None` preserves the legacy offload-header path
  - [x] `inline_text` set: rendered starts with `inline_text`, ends with `[also saved: <path>]`, file exists on disk with the expected `content`
  - [x] `inline_text` set with no session: returns `inline_text` only
- [x] `tests.smoke_plugins` — all existing checks pass; 2 new checks added
  - [x] `write_session_attachment` returns `None` when no session bound
  - [x] `write_session_attachment` writes into the bound session's `attachments_dir` and returns the `Path`
- [x] `tests.smoke_session_audit` — passes (offload-regex stub format unchanged)
- [x] `tests.smoke_read_file_ceiling` — passes
- [x] `tests.smoke_html_tools` — passes
- [x] `tests.smoke_controlling_hooks` — passes
- [x] `tests.smoke_web_search` — passes

## Heads-up: parallel work on #82

#82 is concurrently editing the offloaded-large-result formatting in `_render_tool_result`. This PR only **adds a new branch** (the `inline_text is not None` path); the existing offload path and `_format_offload_ref` are untouched. Branches will need a small manual merge if they land in different orders.