### PR TITLE
web_search: side-save structured results; explicit inline_text footer

### DIFF
--- a/pyagent/agent.py
+++ b/pyagent/agent.py
@@ -250,8 +250,16 @@ class Agent:
                 # (structured blob the agent might legitimately re-read
                 # via extract_doc / read_file), not an offloaded big
                 # result. Skip the offload header / "do not read" warn;
-                # just point at the file with a minimal footer.
-                return f"{result.inline_text}\n\n[also saved: {path}]"
+                # use a footer that's explicit about both halves —
+                # "inline above is complete" so the agent doesn't
+                # reflexively re-read for missing content, and
+                # "for downstream tools" so the LLM knows when reading
+                # IS appropriate (chaining, structured-input consumers).
+                return (
+                    f"{result.inline_text}\n\n[also saved: {path} — "
+                    f"inline answer above is complete; attachment is "
+                    f"for downstream tools]"
+                )
             cap = self.session.attachment_threshold
             return self._format_offload_ref(
                 path,

--- a/pyagent/plugins/web_search/__init__.py
+++ b/pyagent/plugins/web_search/__init__.py
@@ -29,6 +29,13 @@ Configuration (all optional, all read at call time):
         the full set. Defaults to ``"auto"``. Use to pin to a known
         subset (e.g. ``"duckduckgo,brave,yahoo,mojeek"``) if a
         particular engine stays flaky.
+    ``save_structured`` — when true (default), web_search saves the
+        structured ``[{title, url, snippet}]`` list as a JSON
+        attachment alongside the inline markdown. The footer points
+        at the attachment so downstream tools (extract_doc, future
+        chained workflows) can consume the URL list without
+        re-running the search. Set to false to keep the legacy
+        markdown-only string return.
 
 Lifted from the user-scope `web-search` skill at
 ~/.config/pyagent/skills/web-search/. The skill is left in place so
@@ -39,15 +46,24 @@ because plugin tools call directly while skill scripts go through
 
 from __future__ import annotations
 
+import json
 from typing import Sequence
 
 from pyagent.plugins.web_search import search as _search
+from pyagent.session import Attachment
 
 
 # Maximum results the agent is allowed to ask for in one call. DDG
 # starts rate-limiting around the high 20s in practice; cap is a
 # safety belt rather than the everyday limit.
 _MAX_RESULTS = 25
+
+# Side-save the structured SearchResult list to attachments by
+# default. Cost is ~3KB per call; benefit is downstream tools can
+# consume the URL list without re-running the search, and the agent
+# has a recovery path if it forgets which URLs it saw. Configurable
+# via [plugins.web-search] save_structured.
+_DEFAULT_SAVE_STRUCTURED = True
 
 
 def _resolve_attempts(plugin_cfg: dict) -> int:
@@ -74,6 +90,13 @@ def _resolve_backend(plugin_cfg: dict) -> str:
     if isinstance(raw, str) and raw.strip():
         return raw.strip()
     return _search._DEFAULT_BACKEND
+
+
+def _resolve_save_structured(plugin_cfg: dict) -> bool:
+    raw = plugin_cfg.get("save_structured")
+    if isinstance(raw, bool):
+        return raw
+    return _DEFAULT_SAVE_STRUCTURED
 
 
 def _config_warnings(plugin_cfg: dict) -> list[str]:
@@ -132,6 +155,15 @@ def _config_warnings(plugin_cfg: dict) -> list[str]:
         elif not raw.strip():
             out.append("backend is set but empty — using default 'auto'")
 
+    if "save_structured" in plugin_cfg:
+        raw = plugin_cfg["save_structured"]
+        if not isinstance(raw, bool):
+            out.append(
+                f"save_structured must be a bool, got "
+                f"{type(raw).__name__}: {raw!r} — using default "
+                f"{_DEFAULT_SAVE_STRUCTURED}"
+            )
+
     return out
 
 
@@ -143,7 +175,7 @@ def register(api):
     for warning in _config_warnings(api.plugin_config or {}):
         api.log("warning", warning)
 
-    def web_search(query: str, n: int = 10) -> str:
+    def web_search(query: str, n: int = 10):
         """Search the web via DuckDuckGo; return up to `n` results.
 
         Reach for this when `fetch_url` alone isn't enough — i.e. you
@@ -162,6 +194,15 @@ def register(api):
         known URL), or a generic ``<search error: ...>`` for
         programmer/parser issues.
 
+        On a successful search the structured ``[{title, url,
+        snippet}]`` list is also saved as a JSON attachment. The
+        markdown above the ``[also saved: ...]`` footer is the
+        complete answer — no need to read the attachment unless
+        you're chaining (passing the structured form to
+        ``extract_doc`` or another tool that consumes it).
+        Disable via ``[plugins.web-search] save_structured = false``
+        for the legacy markdown-only string return.
+
         Args:
             query: Search query. Plain text; DDG handles quoting and
                 operators.
@@ -169,13 +210,18 @@ def register(api):
                 may auto-offload as an attachment.
 
         Returns:
-            A markdown numbered list of `title — url` lines with
-            snippets. ``<no results ...>`` if every backend returned
-            empty; ``<search error: rate limited; ...>`` if the upstream
-            is explicitly throttling; ``<search error: backend
-            unavailable after N attempts; ...>`` if all retries failed
-            with transient errors; ``<search error: ...>`` for other
-            failures.
+            On success: an Attachment whose inline_text is a markdown
+            numbered list of ``title — url`` lines with snippets, and
+            whose content is the same results as a JSON list. The
+            agent renders the markdown inline with an ``[also saved:
+            <path>]`` footer.
+
+            On miss / failure: a plain string marker. ``<no results
+            ...>`` if every backend returned empty; ``<search error:
+            rate limited; ...>`` if the upstream is explicitly
+            throttling; ``<search error: backend unavailable after N
+            attempts; ...>`` if all retries failed with transient
+            errors; ``<search error: ...>`` for other failures.
         """
         if not query or not query.strip():
             return "<query is empty>"
@@ -192,6 +238,7 @@ def register(api):
         attempts = _resolve_attempts(cfg)
         backoff_s = _resolve_backoff_s(cfg)
         backend = _resolve_backend(cfg)
+        save_structured = _resolve_save_structured(cfg)
 
         try:
             results = _search.ddg_text_search(
@@ -218,7 +265,28 @@ def register(api):
             )
         except Exception as e:
             return f"<search error: {e}>"
-        return _search.format_search_results(results, query)
+
+        markdown = _search.format_search_results(results, query)
+        # Empty-results path: format_search_results returned the
+        # `<no results ...>` marker. Nothing structurally useful to
+        # save; return the marker as a plain string so error/empty
+        # behavior stays consistent.
+        if not save_structured or not results:
+            return markdown
+
+        structured = json.dumps(
+            [
+                {"title": r.title, "url": r.url, "snippet": r.snippet}
+                for r in results
+            ],
+            indent=2,
+            ensure_ascii=False,
+        )
+        return Attachment(
+            content=structured,
+            inline_text=markdown,
+            suffix=".json",
+        )
 
     def web_search_instant(query: str, related: bool = False) -> str:
         """Hit DuckDuckGo's instant-answer API for a short factual reply.

--- a/tests/smoke_session_replay.py
+++ b/tests/smoke_session_replay.py
@@ -149,7 +149,18 @@ def _check_attachment_construction_sites() -> None:
             if name == "Attachment":
                 sites.append((py.relative_to(repo_root), node.lineno))
 
-    allowed = {Path("pyagent/tools.py")}
+    # Files whose Attachment(...) calls have been reviewed and confirmed
+    # to flow through Agent._render_tool_result (i.e. they're returned
+    # from a tool, not stuffed into the conversation directly).
+    #   - pyagent/tools.py: read_file binary branch.
+    #   - pyagent/plugins/web_search/__init__.py: side-saves the
+    #     structured SearchResult list as JSON via Attachment(
+    #     content=json, inline_text=markdown). The Agent layer
+    #     renders inline_text + [also saved: ...] footer.
+    allowed = {
+        Path("pyagent/tools.py"),
+        Path("pyagent/plugins/web_search/__init__.py"),
+    }
     unexpected = [(p, i) for (p, i) in sites if p not in allowed]
     assert not unexpected, (
         "Unexpected Attachment(...) construction site(s); each new site "
@@ -226,17 +237,24 @@ def _check_attachment_inline_text_set() -> None:
     )
     assert isinstance(rendered, str), type(rendered)
     assert rendered.startswith(inline), rendered
-    # Footer at the tail; minimal shape "[also saved: <path>]".
+    # Footer at the tail; explicit about "complete above" + "for chaining".
     assert rendered.rstrip().endswith("]"), rendered
     assert "[also saved: " in rendered, rendered
+    # The footer must signal that the inline view is COMPLETE so the
+    # agent doesn't reflexively re-read the attachment for "missing"
+    # content (a real risk given how the offload header trains
+    # similar-shaped attention).
+    assert "inline answer above is complete" in rendered, rendered
+    assert "for downstream tools" in rendered, rendered
     # No offload header: the file is *side data*, not an offloaded big
     # result whose preview the agent must not re-read.
     assert "[offload " not in rendered, rendered
     assert "Do NOT read_file" not in rendered
 
     # Recover the path from the footer and confirm the bytes landed.
-    footer = rendered.rsplit("[also saved: ", 1)[1].rstrip().rstrip("]")
-    saved_path = Path(footer)
+    # Footer shape: "[also saved: <path> — inline answer above is ...]"
+    footer_chunk = rendered.rsplit("[also saved: ", 1)[1]
+    saved_path = Path(footer_chunk.split(" — ", 1)[0])
     assert saved_path.exists(), saved_path
     assert saved_path.read_text() == structured
     assert saved_path.suffix == ".json", saved_path

--- a/tests/smoke_web_search.py
+++ b/tests/smoke_web_search.py
@@ -222,9 +222,13 @@ def _check_plugin_loads_under_default_config() -> None:
     print(f"✓ plugin loads by default; web-search tools present")
 
 
-def _check_tool_wrapper_returns_string() -> None:
-    """`web_search` returns str on success — no Attachment construction
-    in the plugin (the auto-offload path handles large outputs)."""
+def _check_tool_wrapper_returns_attachment() -> None:
+    """On a successful search, `web_search` returns an Attachment
+    whose inline_text is the markdown and whose content is the
+    structured JSON. The agent layer renders the markdown inline
+    with an [also saved: ...] footer."""
+    from pyagent.session import Attachment as _Attachment
+
     cap = _make_fake_api()
     assert set(cap["tools"].keys()) == {"web_search", "web_search_instant"}, cap["tools"]
     web_search = cap["tools"]["web_search"]
@@ -239,16 +243,134 @@ def _check_tool_wrapper_returns_string() -> None:
         web_search_mod, "ddg_text_search", return_value=fixture
     ) as m:
         out = web_search("python http", n=3)
-    # The wrapper now passes retry/backoff/backend kwargs through —
-    # check the positional and the new kwargs ride together.
+    # The wrapper passes retry/backoff/backend kwargs through —
+    # confirm the positional and new kwargs ride together.
     assert m.call_count == 1, m.call_args_list
     args, kwargs = m.call_args
     assert args == ("python http",), args
     assert kwargs.get("n") == 3, kwargs
     assert "attempts" in kwargs and "backoff_s" in kwargs and "backend" in kwargs, kwargs
+
+    # Returned shape is now an Attachment by default (save_structured
+    # is on). inline_text carries the human markdown; content is the
+    # structured JSON list.
+    assert isinstance(out, _Attachment), type(out)
+    assert out.suffix == ".json", out.suffix
+    assert isinstance(out.inline_text, str), type(out.inline_text)
+    assert "Best Python HTTP libraries 2025" in out.inline_text, out.inline_text
+
+    parsed = json.loads(out.content)
+    assert isinstance(parsed, list) and len(parsed) == 3, parsed
+    assert {"title", "url", "snippet"} <= set(parsed[0].keys()), parsed[0]
+    assert parsed[0]["title"] == "Best Python HTTP libraries 2025", parsed[0]
+    assert parsed[0]["url"] == "https://example.com/python-http", parsed[0]
+    print("✓ web_search returns Attachment(inline_text=md, content=json, suffix='.json')")
+
+
+def _check_save_structured_disabled_returns_string() -> None:
+    """With save_structured=false the legacy markdown-only string
+    return shape is preserved verbatim."""
+    cap = _make_fake_api(plugin_config={"save_structured": False})
+    web_search = cap["tools"]["web_search"]
+
+    fixture = [
+        web_search_mod.SearchResult(
+            title=r["title"], url=r["href"], snippet=r["body"]
+        )
+        for r in _FIXTURE_RESULTS_RAW
+    ]
+    with mock.patch.object(
+        web_search_mod, "ddg_text_search", return_value=fixture
+    ):
+        out = web_search("python http", n=3)
     assert isinstance(out, str), type(out)
     assert "Best Python HTTP libraries 2025" in out, out
-    print("✓ web_search tool returns str (auto-offload path)")
+    assert "[also saved:" not in out, out
+    print("✓ save_structured=false: legacy markdown-only string return")
+
+
+def _check_empty_results_returns_string_marker() -> None:
+    """An empty result list returns the <no results ...> string
+    marker — no point spinning up a JSON attachment for nothing."""
+    cap = _make_fake_api()
+    web_search = cap["tools"]["web_search"]
+    with mock.patch.object(
+        web_search_mod, "ddg_text_search", return_value=[]
+    ):
+        out = web_search("nonsense query no hits")
+    assert isinstance(out, str), type(out)
+    assert out.startswith("<no results "), out
+    print("✓ empty results: <no results ...> string marker, no attachment")
+
+
+def _check_full_agent_render_path() -> None:
+    """Wire the plugin through a real Agent + Session, run the tool,
+    and confirm the rendered output starts with the markdown and ends
+    with the explicit-wording [also saved: ...] footer. Also confirms
+    the JSON file landed on disk and round-trips."""
+    from pathlib import Path as _Path
+    import tempfile as _tempfile
+    from pyagent.agent import Agent as _Agent
+    from pyagent.session import Session as _Session
+
+    cap = _make_fake_api()
+    web_search = cap["tools"]["web_search"]
+
+    fixture = [
+        web_search_mod.SearchResult(
+            title=r["title"], url=r["href"], snippet=r["body"]
+        )
+        for r in _FIXTURE_RESULTS_RAW
+    ]
+    tmp = _Path(_tempfile.mkdtemp(prefix="pyagent-smoke-websearch-render-"))
+    session = _Session(session_id="render", root=tmp)
+    agent = _Agent(client=None, session=session)
+
+    with mock.patch.object(
+        web_search_mod, "ddg_text_search", return_value=fixture
+    ):
+        result = web_search("anything")
+    rendered = agent._render_tool_result("web_search", result)
+
+    assert isinstance(rendered, str), type(rendered)
+    assert "Best Python HTTP libraries 2025" in rendered, rendered
+    assert "[also saved: " in rendered, rendered
+    # Footer is explicit about both halves so the agent doesn't
+    # reflexively re-read the attachment for "missing" content.
+    assert "inline answer above is complete" in rendered, rendered
+    assert "for downstream tools" in rendered, rendered
+    # No offload header — this is side data, not an offloaded big result.
+    assert "[offload " not in rendered, rendered
+    assert "Do NOT read_file" not in rendered
+
+    # JSON file landed and round-trips.
+    footer_chunk = rendered.rsplit("[also saved: ", 1)[1]
+    saved_path = _Path(footer_chunk.split(" — ", 1)[0])
+    assert saved_path.exists(), saved_path
+    parsed = json.loads(saved_path.read_text())
+    assert len(parsed) == 3, parsed
+    assert parsed[0]["url"] == "https://example.com/python-http", parsed[0]
+    print(f"✓ full agent render: markdown inline + footer + JSON on disk ({saved_path.stat().st_size}B)")
+
+
+def _check_register_warnings_on_bogus_save_structured() -> None:
+    """save_structured must be a bool — strings, ints, etc. flagged."""
+    cap = _make_fake_api(plugin_config={"save_structured": "yes"})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert any("save_structured must be a bool" in m for m in msgs), msgs
+
+    cap = _make_fake_api(plugin_config={"save_structured": 1})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert any("save_structured must be a bool" in m for m in msgs), msgs
+
+    # True bool values silent.
+    cap = _make_fake_api(plugin_config={"save_structured": True})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert msgs == [], msgs
+    cap = _make_fake_api(plugin_config={"save_structured": False})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert msgs == [], msgs
+    print("✓ register-time warning: save_structured non-bool flagged, bools silent")
 
 
 def _check_tool_wrapper_translates_errors() -> None:
@@ -324,8 +446,10 @@ def _check_retry_succeeds_after_transient_failure() -> None:
     assert m_sleep.call_count == 1, m_sleep.call_args_list
     # Default backoff is (1.0, 3.0) — first retry sleeps 1.0s.
     assert m_sleep.call_args == mock.call(1.0), m_sleep.call_args
-    assert "ok.example.com" in out, out
-    assert not out.startswith("<search error"), out
+    # Successful searches now return an Attachment with markdown
+    # inline_text and structured JSON content.
+    inline = out.inline_text if hasattr(out, "inline_text") else out
+    assert "ok.example.com" in inline, inline
     print("✓ retry: transient DDGSException → succeed on retry, slept 1.0s")
 
 
@@ -407,7 +531,8 @@ def _check_timeout_is_retried() -> None:
     ):
         out = web_search("anything")
     assert _DDGS.calls == 2, _DDGS.calls
-    assert "t.example.com" in out, out
+    inline = out.inline_text if hasattr(out, "inline_text") else out
+    assert "t.example.com" in inline, inline
     print("✓ retry: TimeoutException retried like DDGSException")
 
 
@@ -571,7 +696,11 @@ def main() -> None:
     _check_instant_formatter_answer_beats_abstract()
     _check_instant_formatter_no_data()
     _check_plugin_loads_under_default_config()
-    _check_tool_wrapper_returns_string()
+    _check_tool_wrapper_returns_attachment()
+    _check_save_structured_disabled_returns_string()
+    _check_empty_results_returns_string_marker()
+    _check_full_agent_render_path()
+    _check_register_warnings_on_bogus_save_structured()
     _check_tool_wrapper_translates_errors()
     _check_tool_wrapper_validates_inputs()
     _check_retry_succeeds_after_transient_failure()


### PR DESCRIPTION
Bundles two changes — the framework wording fix (so every `inline_text` user benefits) and the web_search consumer that depends on it. They land together because the second uses the first.

## Why now

#88 introduced `Attachment.inline_text` so plugins can decouple "what's saved on disk" from "what's rendered inline." The minimal footer that landed (`[also saved: <path>]`) was terse but ambiguous: an LLM trained to recognize the offload header (`[offload ... | preview below]` — which DOES signal "read the file for the rest") could plausibly read this attachment reflexively, even though the markdown above is the complete answer.

This PR fixes the wording at the framework layer and ships the first concrete consumer.

## Changes

### Framework: footer wording

```diff
- [also saved: <path>]
+ [also saved: <path> — inline answer above is complete; attachment is for downstream tools]
```

The two phrases do specific work:
- **"complete"** — disambiguates side-save vs. partial-preview. The cue that says "don't reflexively re-read."
- **"for downstream tools"** — signals when reading IS appropriate (chaining via `extract_doc`, future tool composition #85). Prevents the over-correction "never read this file."

### Consumer: `web_search` side-save

On a non-empty successful search:

```python
return Attachment(
    content=json.dumps([{"title": ..., "url": ..., "snippet": ...} ...]),
    inline_text=<existing markdown rendering>,
    suffix=".json",
)
```

Empty results and error markers still return as plain strings — there's no structure worth preserving for an empty list, and error markers are already terse.

### Configuration

New `[plugins.web-search] save_structured = true` (default on). Disables the side-save and falls back to the legacy markdown-only string return. Validated at register time same as the other web-search config.

## Why this shape

- **Markdown stays inline** — today's UX unchanged.
- **Structured JSON on disk** — downstream tools (`extract_doc(<saved-search.json>, "extract URLs about X")`, future structured-input consumers) work without re-running the search.
- **Recovery path** — if the agent later forgets which URLs it saw, the JSON is one read away, no second search round-trip.
- **Inline cost unchanged** — the side-save is on disk, not in the conversation.

Cost: ~3KB JSON per call. Mitigated when #86's attachment LRU lands.

## Test plan

- [x] `tests/smoke_web_search.py` — 26 checks total (21 from prior + 5 new):
  - Returns `Attachment` with the right shape (suffix `.json`, parseable JSON content matching `{title, url, snippet}` schema, markdown in `inline_text`).
  - `save_structured = false` config preserves the legacy string return.
  - Empty results path still returns the `<no results ...>` string marker — no attachment for an empty list.
  - Full agent render-path exercise: real `Agent` + `Session`, asserts the rendered output starts with the markdown, ends with the explicit-wording footer, and the JSON file landed on disk + round-trips.
  - Register-time warning on bogus `save_structured` (non-bool); `True` / `False` silent.
  - Existing retry-success tests adjusted to read `.inline_text` on the success paths (the success return is now an `Attachment`).
- [x] `tests/smoke_session_replay.py` — `inline_text` assertions updated to require the explicit "complete / for downstream tools" wording. `Attachment(...)` construction-site allowlist gains `pyagent/plugins/web_search/__init__.py` with a justifying comment.
- [x] Cross-suite sanity: `smoke_plugins`, `smoke_session_audit`, `smoke_read_file_ceiling` all green.

## Out of scope (filed as follow-ups when this lands)

- **Reddit / Hacker News search tools.** Discussed in the design thread; both have free, no-auth APIs and would surface content metasearch under-covers (real-world Q&A, technical consensus). Each is its own ~50-100 LOC plugin riding the same `Attachment(inline_text=md, content=json)` shape this PR establishes.
- **Stack Overflow / GitHub code search / arXiv.** Marginal — covered by general web search or with worse trade-offs (rate limits, auth tokens).