### PR TITLE
session: per-session attachments LRU cap with eviction

### DIFF
--- a/pyagent/agent_proc.py
+++ b/pyagent/agent_proc.py
@@ -794,10 +794,18 @@ def _bootstrap(
     # spawn is misleading prose.
     catalog_for_roles = roles_mod.catalog if allow_meta else ""
 
+    # Sessions inherit the attachment cap from the parent's config dict
+    # (cli.py reads config.toml once at startup and threads the resolved
+    # value down through agent_config). Subagents inherit the same cap;
+    # they each have their own attachments dir under their own session
+    # subtree, so eviction is per-subagent-session.
+    cap_mb = int(config.get("attachment_dir_cap_mb", 25))
+
     if is_subagent:
         session = Session(
             session_id=config["session_id"],
             root=Path(config["session_root"]),
+            attachment_dir_cap_mb=cap_mb,
         )
         # Plant a small breadcrumb so the on-disk tree is self-describing.
         session.dir.mkdir(parents=True, exist_ok=True)
@@ -819,7 +827,10 @@ def _bootstrap(
             plugin_loader=loaded_plugins,
         )
     else:
-        session = Session(session_id=config["session_id"])
+        session = Session(
+            session_id=config["session_id"],
+            attachment_dir_cap_mb=cap_mb,
+        )
         system = SystemPromptBuilder(
             soul=Path(config["soul_path"]),
             tools=Path(config["tools_path"]),

--- a/pyagent/agent_proc.py
+++ b/pyagent/agent_proc.py
@@ -38,6 +38,7 @@ from multiprocessing.connection import Connection
 from pathlib import Path
 from typing import Any
 
+from pyagent import config as config_mod
 from pyagent import paths
 from pyagent import permissions
 from pyagent import plugins as plugins_mod
@@ -799,7 +800,9 @@ def _bootstrap(
     # value down through agent_config). Subagents inherit the same cap;
     # they each have their own attachments dir under their own session
     # subtree, so eviction is per-subagent-session.
-    cap_mb = int(config.get("attachment_dir_cap_mb", 25))
+    cap_mb = config_mod.resolve_attachment_dir_cap_mb(
+        config.get("attachment_dir_cap_mb")
+    )
 
     if is_subagent:
         session = Session(

--- a/pyagent/cli.py
+++ b/pyagent/cli.py
@@ -1763,7 +1763,9 @@ def main(
     model = _resolve_model(model)
 
     cfg = config.load()
-    cap_mb = int(cfg.get("session", {}).get("attachment_dir_cap_mb", 25))
+    cap_mb = config.resolve_attachment_dir_cap_mb(
+        cfg.get("session", {}).get("attachment_dir_cap_mb")
+    )
 
     if resume_id:
         session = Session(session_id=resume_id, attachment_dir_cap_mb=cap_mb)

--- a/pyagent/cli.py
+++ b/pyagent/cli.py
@@ -1762,12 +1762,15 @@ def main(
 
     model = _resolve_model(model)
 
+    cfg = config.load()
+    cap_mb = int(cfg.get("session", {}).get("attachment_dir_cap_mb", 25))
+
     if resume_id:
-        session = Session(session_id=resume_id)
+        session = Session(session_id=resume_id, attachment_dir_cap_mb=cap_mb)
         if not session.exists():
             raise click.UsageError(f"session {resume_id!r} not found at {session.dir}")
     else:
-        session = Session()
+        session = Session(attachment_dir_cap_mb=cap_mb)
 
     soul = paths.resolve("SOUL.md", override=soul, seed="SOUL.md")
     tools_md = paths.resolve("TOOLS.md", override=tools_md, seed="TOOLS.md")
@@ -1788,6 +1791,7 @@ def main(
         "tools_path": str(tools_md),
         "primer_path": str(primer),
         "approved_paths": [str(p) for p in permissions.approved_paths()],
+        "attachment_dir_cap_mb": cap_mb,
     }
 
     # spawn (not fork): pickles fresh, doesn't drag the parent's

--- a/pyagent/config.py
+++ b/pyagent/config.py
@@ -18,9 +18,18 @@ Schema (current):
     max_depth  = 3   # maximum spawn-tree height; root is depth 0
     max_fanout = 5   # max simultaneous children any single agent can hold
 
+    [session]
+    attachment_dir_cap_mb = 25   # soft cap; LRU evict over this. 0 = off.
+
 The subagent caps exist to mitigate fork-bomb behavior — a confused
 turn could spawn unboundedly otherwise, amplifying cost per process
 and outpacing the human's ability to hit Esc.
+
+`session.attachment_dir_cap_mb` is a soft cap on the per-session
+`attachments/` directory size. After each new attachment write,
+files are evicted in least-recently-accessed order (atime, mtime
+fallback) until the dir total is back under cap. The just-written
+file is never a candidate for eviction. Set to 0 to disable.
 
 `default_model` pins the provider/model used when `--model` is not
 passed. Empty string means auto-detect from API-key env vars.
@@ -65,6 +74,9 @@ DEFAULTS: dict[str, Any] = {
     "subagents": {
         "max_depth": 3,
         "max_fanout": 5,
+    },
+    "session": {
+        "attachment_dir_cap_mb": 25,
     },
 }
 

--- a/pyagent/config.py
+++ b/pyagent/config.py
@@ -122,6 +122,68 @@ def load() -> dict[str, Any]:
     return _deep_merge(_deep_merge(DEFAULTS, user), project)
 
 
+_DEFAULT_ATTACHMENT_CAP_MB = 25
+
+
+def resolve_attachment_dir_cap_mb(value: Any) -> int:
+    """Validate a `[session] attachment_dir_cap_mb` value into a
+    non-negative int, warning on type/range surprises.
+
+    Why this exists: the bare ``int(value)`` coercion that older call
+    sites used silently rounds floats (``25.0`` → 25 is fine, but
+    ``0.5`` → 0 silently disables eviction) and quietly accepts
+    negative ints as "off" without explanation. Both paths bit users
+    in the original LRU PR review (#93).
+
+    Resolution rules:
+      - Missing / None → default 25 MB, no warning.
+      - bool (TOML allows it; ``True`` is ``1``, ``False`` is ``0``)
+        → warn, fall back to default.
+      - float → warn, round to ``int`` (preserving the user's intent
+        — they typed a number, just wrong type).
+      - int >= 0 → return as-is.
+      - int < 0 → warn, clamp to 0 (eviction disabled — same effect
+        as the user's likely "off" intent, but explicit).
+      - any other type (str, list, dict, …) → warn, default.
+
+    All warnings go through the module logger so cli.py and
+    agent_proc.py share the same surface.
+    """
+    if value is None:
+        return _DEFAULT_ATTACHMENT_CAP_MB
+    # bool subclasses int — check before isinstance(int)
+    if isinstance(value, bool):
+        logger.warning(
+            "[session] attachment_dir_cap_mb must be an integer, "
+            "got bool: %r — using default %d MB",
+            value, _DEFAULT_ATTACHMENT_CAP_MB,
+        )
+        return _DEFAULT_ATTACHMENT_CAP_MB
+    if isinstance(value, float):
+        coerced = int(value)
+        logger.warning(
+            "[session] attachment_dir_cap_mb must be an integer "
+            "(got float %r); rounding to %d MB",
+            value, coerced,
+        )
+        return max(0, coerced)
+    if isinstance(value, int):
+        if value < 0:
+            logger.warning(
+                "[session] attachment_dir_cap_mb must be >= 0, "
+                "got %d — clamping to 0 (eviction disabled)",
+                value,
+            )
+            return 0
+        return value
+    logger.warning(
+        "[session] attachment_dir_cap_mb must be an integer, got "
+        "%s: %r — using default %d MB",
+        type(value).__name__, value, _DEFAULT_ATTACHMENT_CAP_MB,
+    )
+    return _DEFAULT_ATTACHMENT_CAP_MB
+
+
 def path() -> Path:
     """Where the user-tier config file lives (whether or not it exists).
 

--- a/pyagent/session.py
+++ b/pyagent/session.py
@@ -9,6 +9,7 @@ into offloading; the agent additionally applies a size-based fallback.
 """
 
 import json
+import logging
 import uuid
 from dataclasses import dataclass
 from datetime import date
@@ -16,6 +17,8 @@ from pathlib import Path
 from typing import Any
 
 import petname
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -50,13 +53,29 @@ class Session:
     DEFAULT_ROOT = Path(".pyagent/sessions")
     attachment_threshold = 8000
     preview_chars = 1000
+    # Soft cap on total attachments-dir size, in megabytes. After each
+    # write, if the dir exceeds this we evict least-recently-accessed
+    # files (atime, mtime fallback) until under the cap. The just-
+    # written file is always preserved. 0 disables eviction entirely.
+    attachment_dir_cap_mb: int = 25
 
-    def __init__(self, session_id: str | None = None, root: Path | None = None) -> None:
+    def __init__(
+        self,
+        session_id: str | None = None,
+        root: Path | None = None,
+        attachment_dir_cap_mb: int | None = None,
+    ) -> None:
         self.root = root if root is not None else self.DEFAULT_ROOT
         self.id = session_id or self._unique_id(self.root)
         self.dir = self.root / self.id
         self.attachments_dir = self.dir / "attachments"
         self.conversation_path = self.dir / "conversation.jsonl"
+        if attachment_dir_cap_mb is not None:
+            # Per-instance override of the class-level default. Keeps
+            # the class attribute as the single source of truth for the
+            # default while letting config wiring inject a different
+            # cap without subclassing.
+            self.attachment_dir_cap_mb = attachment_dir_cap_mb
 
     @classmethod
     def list_ids(cls, root: Path | None = None) -> list[str]:
@@ -114,7 +133,91 @@ class Session:
             path.write_bytes(content)
         else:
             path.write_text(content)
+        # After every write, run LRU eviction if the dir is over cap.
+        # The just-written `path` is always exempt — even a single
+        # write that exceeds the cap by itself stays put (we evict
+        # everything older first, then stop). cap=0 disables eviction.
+        if self.attachment_dir_cap_mb > 0:
+            self._evict_lru_until_under_cap(exclude=path)
         return path
+
+    def _evict_lru_until_under_cap(self, exclude: Path) -> int:
+        """Delete least-recently-accessed attachments until under cap.
+
+        Eviction policy:
+          - Sort files in `attachments_dir` by access time ascending
+            (oldest atime first). Some filesystems mount with
+            `noatime` and never update atime; on those, atime equals
+            ctime/mtime, so falling back to mtime is implicit when the
+            two agree. We still prefer atime explicitly because on a
+            filesystem that DOES track it, "haven't read this in a
+            while" is the policy we want.
+          - The file at `exclude` (the just-written attachment) is
+            never evicted, even if removing every other file still
+            leaves us over cap. A single huge write that exceeds the
+            cap on its own is allowed; the alternative (refusing the
+            write or deleting it) breaks forward progress mid-task,
+            which is exactly what the LRU design avoids per the issue.
+          - Path A re: conversation.jsonl: we do NOT rewrite the JSONL
+            when an evicted file was referenced. A future re-read
+            attempt by the agent will hit the standard "file not
+            found" marker, which is acceptable signal. Documenting
+            here so the contract is grep-able alongside the eviction
+            logic.
+
+        Returns the count of files evicted.
+        """
+        cap_bytes = self.attachment_dir_cap_mb * 1024 * 1024
+        if cap_bytes <= 0:
+            return 0
+        if not self.attachments_dir.exists():
+            return 0
+
+        # Collect (atime, size, path) for everything in the dir. We
+        # gather sizes up front so the running total is stable as we
+        # unlink — no re-stat per iteration.
+        entries: list[tuple[float, int, Path]] = []
+        total = 0
+        try:
+            exclude_resolved = exclude.resolve()
+        except OSError:
+            exclude_resolved = exclude
+        for child in self.attachments_dir.iterdir():
+            if not child.is_file():
+                continue
+            try:
+                st = child.stat()
+            except OSError:
+                continue
+            entries.append((st.st_atime, st.st_size, child))
+            total += st.st_size
+
+        if total <= cap_bytes:
+            return 0
+
+        # Sort oldest-atime first. Tie-break by size descending so a
+        # cluster of same-atime files (common on noatime fs) prefers
+        # to drop bigger ones first — fewer evictions to get under.
+        entries.sort(key=lambda e: (e[0], -e[1]))
+
+        evicted = 0
+        for _atime, size, child in entries:
+            if total <= cap_bytes:
+                break
+            try:
+                if child.resolve() == exclude_resolved:
+                    continue
+            except OSError:
+                if child == exclude:
+                    continue
+            try:
+                child.unlink()
+            except OSError as e:
+                logger.warning("attachment eviction skipped %s: %s", child, e)
+                continue
+            total -= size
+            evicted += 1
+        return evicted
 
     def find_orphan_attachments(self) -> list[Path]:
         """Return attachment files not referenced by conversation.jsonl.

--- a/tests/smoke_attachment_lru.py
+++ b/tests/smoke_attachment_lru.py
@@ -1,6 +1,6 @@
 """Smoke for the per-session attachments LRU cap (issue #86).
 
-Locks five behaviors:
+Locks these behaviors:
 
   1. **Under cap → no eviction.** Several small writes keep total
      under cap; every file remains.
@@ -17,6 +17,17 @@ Locks five behaviors:
      temp config flows through to a `Session(attachment_dir_cap_mb=5)`
      when constructed via the CLI startup pattern (mirrors
      `pyagent/cli.py` Session construction).
+  6. **Class default unchanged.** Sessions constructed without an
+     explicit cap inherit the class-level 25 MB.
+  7. **Config validation.** Bogus values (float, negative, bool,
+     non-numeric) emit warnings and resolve sanely — closes the
+     "TOML float silently disables eviction" hole flagged in #93
+     review.
+  8. **Path A contract.** When the LRU evicts a file that's still
+     referenced by the agent's prior conversation, a future
+     `read_file` against the saved path lands on the standard
+     `<file not found: ...>` marker. Locks the behavior the LRU
+     implementation explicitly relies on.
 
 No subprocess, no network. Run with:
     .venv/bin/python -m tests.smoke_attachment_lru
@@ -24,11 +35,14 @@ No subprocess, no network. Run with:
 
 from __future__ import annotations
 
+import logging
 import os
 import tempfile
 from pathlib import Path
 
 from pyagent import config as config_mod
+from pyagent import permissions
+from pyagent import tools as agent_tools
 from pyagent.session import Session
 
 
@@ -180,6 +194,97 @@ def _check_class_default_unchanged() -> None:
     print("✓ class default = 25 MB; instance without kwarg inherits it")
 
 
+def _check_validation_warns_and_falls_back() -> None:
+    """`resolve_attachment_dir_cap_mb` must warn-and-resolve for the
+    cases that bit users in the #93 review: TOML floats silently
+    disabling, negatives silently disabling, booleans, non-numerics."""
+
+    class _CaptureHandler(logging.Handler):
+        def __init__(self) -> None:
+            super().__init__()
+            self.records: list[logging.LogRecord] = []
+
+        def emit(self, record: logging.LogRecord) -> None:
+            self.records.append(record)
+
+    handler = _CaptureHandler()
+    cfg_logger = logging.getLogger("pyagent.config")
+    cfg_logger.addHandler(handler)
+    cfg_logger.setLevel(logging.WARNING)
+
+    try:
+        # Missing → silent default.
+        handler.records.clear()
+        assert config_mod.resolve_attachment_dir_cap_mb(None) == 25
+        assert handler.records == [], handler.records
+
+        # Plain int → silent passthrough.
+        handler.records.clear()
+        assert config_mod.resolve_attachment_dir_cap_mb(10) == 10
+        assert handler.records == [], handler.records
+
+        # Float 25.0 → warn, round to 25.
+        handler.records.clear()
+        assert config_mod.resolve_attachment_dir_cap_mb(25.0) == 25
+        assert any("float" in r.getMessage() for r in handler.records), handler.records
+
+        # Float 0.5 → warn, round to 0 (the surprise case from review).
+        handler.records.clear()
+        assert config_mod.resolve_attachment_dir_cap_mb(0.5) == 0
+        msgs = [r.getMessage() for r in handler.records]
+        assert any("float" in m for m in msgs), msgs
+
+        # Negative → warn, clamp to 0.
+        handler.records.clear()
+        assert config_mod.resolve_attachment_dir_cap_mb(-5) == 0
+        assert any(">= 0" in r.getMessage() for r in handler.records), handler.records
+
+        # Bool (TOML allows it; True is int(1) silently otherwise) → warn, default.
+        handler.records.clear()
+        assert config_mod.resolve_attachment_dir_cap_mb(True) == 25
+        assert any("bool" in r.getMessage() for r in handler.records), handler.records
+
+        # Non-numeric → warn, default.
+        handler.records.clear()
+        assert config_mod.resolve_attachment_dir_cap_mb("a lot") == 25
+        assert any("integer" in r.getMessage() for r in handler.records), handler.records
+    finally:
+        cfg_logger.removeHandler(handler)
+    print("✓ validation: float / negative / bool / non-numeric warn and resolve sanely")
+
+
+def _check_path_a_contract() -> None:
+    """When the LRU evicts a file, the saved path is gone — a future
+    `read_file` against it returns the standard
+    `<file not found: ...>` marker. The agent has no special "evicted"
+    semantics; the existing not-found contract is the signal."""
+    with tempfile.TemporaryDirectory(prefix="pyagent-lru-") as t:
+        # 1 MB cap, 700 KB writes — second write triggers eviction of first.
+        session = Session(
+            session_id="path-a", root=Path(t), attachment_dir_cap_mb=1
+        )
+        first = session.write_attachment("read_file", "F" * 700_000)
+        second = session.write_attachment("read_file", "S" * 700_000)
+        # First should be evicted; second is the just-written and stays.
+        assert not first.exists(), f"expected {first} to be evicted"
+        assert second.exists(), f"just-written {second} must remain"
+
+        # Pre-approve the temp path so read_file's permission gate
+        # passes (the path is outside the workspace).
+        permissions.pre_approve(first)
+        result = agent_tools.read_file(str(first))
+        assert isinstance(result, str), type(result)
+        assert result == f"<file not found: {first}>", result
+
+        # And the just-written file IS readable — confirms read_file
+        # is working in this test, the failure above is genuinely
+        # the eviction (not a permission/path issue).
+        permissions.pre_approve(second)
+        result = agent_tools.read_file(str(second))
+        assert "S" in result, result[:100]
+    print("✓ path A: evicted file → <file not found: ...> from read_file")
+
+
 def main() -> None:
     _check_under_cap_no_eviction()
     _check_over_cap_oldest_atime_evicted()
@@ -187,6 +292,8 @@ def main() -> None:
     _check_cap_zero_disables_eviction()
     _check_config_wiring()
     _check_class_default_unchanged()
+    _check_validation_warns_and_falls_back()
+    _check_path_a_contract()
     print("\nALL CHECKS PASSED")
 
 

--- a/tests/smoke_attachment_lru.py
+++ b/tests/smoke_attachment_lru.py
@@ -1,0 +1,194 @@
+"""Smoke for the per-session attachments LRU cap (issue #86).
+
+Locks five behaviors:
+
+  1. **Under cap → no eviction.** Several small writes keep total
+     under cap; every file remains.
+  2. **Over cap → oldest atime evicted.** With controlled atimes via
+     `os.utime`, the file with the oldest atime is the one removed
+     when a new write pushes total over cap.
+  3. **Just-written file is exempt.** A single huge write that alone
+     exceeds the cap stays put; older smaller files are evicted.
+     Even when the just-written file is "older" by atime than other
+     files in the dir, eviction must not pick it.
+  4. **cap=0 disables eviction.** Many large writes can pile up and
+     no eviction runs.
+  5. **Config wiring.** `[session] attachment_dir_cap_mb = 5` in a
+     temp config flows through to a `Session(attachment_dir_cap_mb=5)`
+     when constructed via the CLI startup pattern (mirrors
+     `pyagent/cli.py` Session construction).
+
+No subprocess, no network. Run with:
+    .venv/bin/python -m tests.smoke_attachment_lru
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+from pyagent import config as config_mod
+from pyagent.session import Session
+
+
+def _dir_size(p: Path) -> int:
+    return sum(f.stat().st_size for f in p.iterdir() if f.is_file())
+
+
+def _check_under_cap_no_eviction() -> None:
+    """A handful of small writes keep dir under cap; everything stays."""
+    with tempfile.TemporaryDirectory(prefix="pyagent-lru-") as t:
+        session = Session(
+            session_id="under", root=Path(t), attachment_dir_cap_mb=5
+        )
+        paths = []
+        for i in range(4):
+            # Each write is 200KB, four writes = 800KB << 5MB cap.
+            paths.append(session.write_attachment("read_file", "a" * 200_000))
+        # All four files still on disk.
+        for p in paths:
+            assert p.exists(), f"unexpected eviction of {p}"
+        # And the dir total reflects all four.
+        total = _dir_size(session.attachments_dir)
+        assert 750_000 < total < 850_000, total
+    print("✓ under cap: no files evicted")
+
+
+def _check_over_cap_oldest_atime_evicted() -> None:
+    """Oldest-atime files go first when the dir crosses the cap."""
+    with tempfile.TemporaryDirectory(prefix="pyagent-lru-") as t:
+        # 3 MB cap, 1 MB writes — fourth write should trigger eviction.
+        session = Session(
+            session_id="over", root=Path(t), attachment_dir_cap_mb=3
+        )
+        # First three writes: stamp each with a known atime so we can
+        # predict which one the eviction pass picks. Oldest first.
+        p1 = session.write_attachment("read_file", "1" * 1_100_000)
+        os.utime(p1, (1_000.0, 1_000.0))
+        p2 = session.write_attachment("read_file", "2" * 1_100_000)
+        os.utime(p2, (2_000.0, 2_000.0))
+        p3 = session.write_attachment("read_file", "3" * 1_100_000)
+        os.utime(p3, (3_000.0, 3_000.0))
+        # All three live so far (3 * 1.1 MB = 3.3 MB > 3 MB cap, so the
+        # third write itself already triggered eviction of p1). Confirm.
+        assert not p1.exists(), "p1 should have been evicted on third write"
+        assert p2.exists() and p3.exists(), "p2/p3 should still be present"
+        # Now write a fourth, bigger one. p2 is oldest-atime remaining
+        # and should be the one evicted.
+        p4 = session.write_attachment("read_file", "4" * 1_200_000)
+        assert not p2.exists(), "p2 (oldest atime) should have been evicted"
+        assert p3.exists(), "p3 should remain"
+        assert p4.exists(), "just-written p4 must remain"
+    print("✓ over cap: oldest-atime file evicted, newer ones preserved")
+
+
+def _check_just_written_exempt_even_when_over_alone() -> None:
+    """A single huge write that alone exceeds the cap stays; older
+    files are evicted but the just-written one is preserved."""
+    with tempfile.TemporaryDirectory(prefix="pyagent-lru-") as t:
+        session = Session(
+            session_id="huge", root=Path(t), attachment_dir_cap_mb=2
+        )
+        # Seed two small files with old atimes.
+        small1 = session.write_attachment("read_file", "x" * 500_000)
+        os.utime(small1, (1_000.0, 1_000.0))
+        small2 = session.write_attachment("read_file", "y" * 500_000)
+        os.utime(small2, (2_000.0, 2_000.0))
+        assert small1.exists() and small2.exists()
+        # Now drop a single 5 MB write — this alone exceeds the 2 MB cap.
+        # The just-written file must survive; the two small ones go.
+        big = session.write_attachment("read_file", "Z" * 5_000_000)
+        # The just-written file is exempt. Even though its atime might
+        # be newer than the others, the eviction loop explicitly skips
+        # it, so confirm it's still there.
+        assert big.exists(), "just-written huge file must not be evicted"
+        assert not small1.exists(), "old small file should have been evicted"
+        assert not small2.exists(), "old small file should have been evicted"
+
+        # Edge case: exempt holds even when the just-written file is
+        # older by atime than other files in the dir. Force big's atime
+        # to be the oldest, then write another file to trigger another
+        # eviction pass — big must still be exempt during that pass
+        # because it's the just-written one for THAT pass... wait, no:
+        # only the freshest write is exempt. So we need a different
+        # check: a follow-up write whose addition pushes us over cap
+        # again. The just-written follow-up is exempt; big becomes a
+        # candidate. With big's atime forced ancient, big is the LRU
+        # pick and goes first.
+        os.utime(big, (500.0, 500.0))  # ancient
+        new_small = session.write_attachment("read_file", "n" * 100_000)
+        # 5 MB + 0.1 MB = 5.1 MB > 2 MB; eviction picks LRU (big).
+        assert not big.exists(), (
+            "after a fresh write, the previously-just-written file "
+            "loses its exemption and is a normal LRU candidate"
+        )
+        assert new_small.exists(), "newly-written file must be exempt"
+    print("✓ just-written file exempt; loses exemption on next write")
+
+
+def _check_cap_zero_disables_eviction() -> None:
+    """cap=0 means "disabled" — no eviction ever runs."""
+    with tempfile.TemporaryDirectory(prefix="pyagent-lru-") as t:
+        session = Session(
+            session_id="off", root=Path(t), attachment_dir_cap_mb=0
+        )
+        paths = []
+        # Write 5 MB worth of data; with cap disabled, all stays.
+        for _ in range(5):
+            paths.append(
+                session.write_attachment("read_file", "q" * 1_000_000)
+            )
+        for p in paths:
+            assert p.exists(), f"cap=0 should not evict, but {p} is gone"
+        total = _dir_size(session.attachments_dir)
+        assert total > 4_500_000, total
+    print("✓ cap=0: eviction disabled")
+
+
+def _check_config_wiring() -> None:
+    """A `[session] attachment_dir_cap_mb` value in config flows into
+    Session via the same pattern cli.py uses on startup."""
+    # Mirror cli.py: cfg = config.load(); cap = cfg["session"][...]
+    # We can't easily inject a temp config.toml without monkey-
+    # patching paths.config_dir(); just exercise the resolution logic
+    # the CLI uses against a synthesized cfg dict.
+    cfg = {"session": {"attachment_dir_cap_mb": 5}}
+    cap_mb = int(cfg.get("session", {}).get("attachment_dir_cap_mb", 25))
+    assert cap_mb == 5
+    with tempfile.TemporaryDirectory(prefix="pyagent-lru-") as t:
+        session = Session(
+            session_id="cfg", root=Path(t), attachment_dir_cap_mb=cap_mb
+        )
+        assert session.attachment_dir_cap_mb == 5
+
+    # And confirm the config defaults expose the key (so users can see
+    # it via `pyagent-config defaults` and override it).
+    defaults = config_mod.DEFAULTS
+    assert "session" in defaults, defaults
+    assert defaults["session"].get("attachment_dir_cap_mb") == 25, defaults
+    print("✓ config wiring: [session] attachment_dir_cap_mb=5 → cap_mb=5")
+
+
+def _check_class_default_unchanged() -> None:
+    """The class-level default stays at 25 MB; an instance with no
+    override inherits it. Locks the "single source of truth" claim."""
+    assert Session.attachment_dir_cap_mb == 25, Session.attachment_dir_cap_mb
+    with tempfile.TemporaryDirectory(prefix="pyagent-lru-") as t:
+        session = Session(session_id="default", root=Path(t))
+        assert session.attachment_dir_cap_mb == 25, session.attachment_dir_cap_mb
+    print("✓ class default = 25 MB; instance without kwarg inherits it")
+
+
+def main() -> None:
+    _check_under_cap_no_eviction()
+    _check_over_cap_oldest_atime_evicted()
+    _check_just_written_exempt_even_when_over_alone()
+    _check_cap_zero_disables_eviction()
+    _check_config_wiring()
+    _check_class_default_unchanged()
+    print("\nALL CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Motivation

Closes #86. Per-session `attachments/` dirs grow unbounded today — every `fetch_url` HTML body, `execute` output, and `html_to_md` result lands as a file and sticks forever once referenced in `conversation.jsonl`. The orphan sweep only catches *unreferenced* files, so a long research session (the trigger case in #86) accumulated 56 files / 10MB+ with several individual attachments over 1MB.

## What this does

- Adds `Session.attachment_dir_cap_mb` (class default 25 MB).
- After every `write_attachment(...)`, if the dir total exceeds the cap, evict least-recently-accessed files (atime, mtime fallback) until under cap.
- The just-written file is **always exempt** — a single huge write that alone exceeds the cap stays put while older files clear out around it. This preserves forward progress mid-task, which is the whole reason for picking LRU eviction over a hard cap.
- `cap=0` disables eviction entirely.
- New `[session] attachment_dir_cap_mb = 25` config knob. CLI loads it once at startup and threads the value into `Session(attachment_dir_cap_mb=...)`. Subagents inherit through the existing `base_config` dict, so each subagent has its own cap on its own attachments dir.

## Default cap rationale

25 MB is generous — the in-the-wild worst case in #86 was ~10 MB. 25 leaves headroom for legitimately heavier sessions while still bounding the dir at "small enough that nobody notices on disk" rather than "big enough to be suspicious." Tunable per-user / per-project via config.

## Reference contract for evicted files (Path A)

Per the issue and the design discussion: when an evicted file is still referenced in `conversation.jsonl`, we **do not** rewrite the JSONL. The disk eviction is unconditional. If the agent later tries to re-read the path, it gets the standard `<file not found: ...>` marker — acceptable signal without the invasive Path B rewrite.

This is documented in the `_evict_lru_until_under_cap` docstring so it's grep-able alongside the eviction logic. Path B (rewrite the tool-result string with an `[attachment evicted: ...]` marker) is left as a future option if the file-not-found signal proves too thin in practice.

## Files touched

- `pyagent/session.py` — class attr, kwarg, eviction helper, hook in `write_attachment`.
- `pyagent/config.py` — `[session] attachment_dir_cap_mb` default + docstring.
- `pyagent/cli.py` — load cfg at startup, pass cap to `Session()` and through `agent_config`.
- `pyagent/agent_proc.py` — pass cap to `Session()` for both root and subagent paths.
- `tests/smoke_attachment_lru.py` — new smoke (6 checks).

## Test plan

- [x] `python -m tests.smoke_attachment_lru` — 6/6 pass
  - under cap → no eviction
  - over cap → oldest-atime evicted
  - just-written exempt even when alone exceeds cap; loses exemption on next write
  - cap=0 → disabled
  - config wiring (synthesized cfg dict matching cli.py path)
  - class default = 25 MB; instance without kwarg inherits
- [x] `python -m tests.smoke_session_replay` — passes (offload stub contract intact)
- [x] `python -m tests.smoke_read_file_ceiling` — passes (offload thresholds intact)
- [x] `python -m tests.smoke_session_audit` — passes (audit/render unaffected)
- [x] `python -m tests.smoke_plugins` — passes (`write_session_attachment` plugin path unchanged)
- [x] `python -m tests.smoke_subagent_caps` — passes (subagent config plumbing unaffected)
- [ ] Manual: run a real research session to confirm cap holds in practice; verify nothing regresses on the offload/preview path

## Caveats / open questions

- **atime reliability:** I prefer atime where available, but on `noatime` mounts atime equals ctime/mtime, so behavior degrades to mtime LRU implicitly. The implementation tie-breaks ties by size-descending so a cluster of same-atime files prefers to drop bigger ones first — fewer evictions to get under cap.
- **Path A vs Path B:** if the agent encounters the file-not-found marker on a re-read of an evicted path, today it just sees the same generic marker any missing file produces. If that proves confusing in practice, a follow-up could either annotate the marker with eviction context, or upgrade to Path B (JSONL rewrite). Leaving for now.
- **No metric / log line on eviction.** `logger.warning` fires only on unlink failures. A debug-level "evicted N files" log might help observability but I left it off to keep the change minimal — easy to add later if needed.