### PR TITLE
Bundle reddit_search + hn_search plugins + pdf-from-markdown skill

### DIFF
--- a/pyagent/config.py
+++ b/pyagent/config.py
@@ -59,13 +59,19 @@ LOCAL_CONFIG_DIR = Path(".pyagent")
 
 DEFAULTS: dict[str, Any] = {
     "default_model": "",
-    "built_in_skills_enabled": ["write-skill", "write-plugin"],
+    "built_in_skills_enabled": [
+        "write-skill",
+        "write-plugin",
+        "pdf-from-markdown",
+    ],
     "built_in_plugins_enabled": [
         "memory-markdown",
         "memory-vector",
         "html-tools",
         "code-mapper",
         "web-search",
+        "reddit-search",
+        "hn-search",
         "claude-code-cli",
         "ollama",
         "echo-plugin",

--- a/pyagent/plugins/hn_search/__init__.py
+++ b/pyagent/plugins/hn_search/__init__.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -43,17 +44,31 @@ _DEFAULT_TIMEOUT_S = 10
 _DEFAULT_SAVE_STRUCTURED = True
 _MAX_RESULTS = 50  # Algolia's per-page max; HN search results are short, no need to cap lower
 _VALID_KINDS = {"story", "comment", "poll", "any"}
-# Algolia "search by date" path narrows time windows. Map our
-# user-facing windows to (endpoint_path, numericFilters) pairs.
-_TIME_WINDOW_FILTERS: dict[str, str] = {
-    "all": "",
-    "hour": "created_at_i>now-1h",
-    "day": "created_at_i>now-1d",
-    "week": "created_at_i>now-1w",
-    "month": "created_at_i>now-1M",
-    "year": "created_at_i>now-1y",
+# Time-window seconds. Algolia's numericFilters take literal numeric
+# epochs, NOT relative-time strings — earlier `now-1d`-style values
+# returned HTTP 400 and silently broke every non-`all` filter
+# (caught in #94 review). The filter is computed at call time as
+# ``int(time.time()) - <seconds>`` so the agent always asks about
+# "the last N from this moment." 0 means "no filter."
+_TIME_WINDOW_SECONDS: dict[str, int] = {
+    "all": 0,
+    "hour": 3600,
+    "day": 86400,
+    "week": 604800,
+    "month": 2592000,    # 30 days, by convention
+    "year": 31536000,    # 365 days
 }
-_VALID_TIME_WINDOWS = set(_TIME_WINDOW_FILTERS.keys())
+_VALID_TIME_WINDOWS = set(_TIME_WINDOW_SECONDS.keys())
+
+
+def _time_window_filter(window: str) -> str:
+    """Build the Algolia ``created_at_i>EPOCH`` filter for a time
+    window. Returns ``""`` for ``all`` (skip the filter entirely)."""
+    seconds = _TIME_WINDOW_SECONDS.get(window, 0)
+    if seconds <= 0:
+        return ""
+    cutoff = int(time.time()) - seconds
+    return f"created_at_i>{cutoff}"
 
 
 @dataclass(frozen=True)
@@ -114,23 +129,20 @@ def _build_url(
     min_points: int | None,
 ) -> str:
     base = "https://hn.algolia.com/api/v1/search"
-    filters: list[str] = []
-    if kind != "any":
-        # tag values: story, comment, poll, pollopt, show_hn, ask_hn,
-        # front_page, job, user
-        filters.append(f"tags={kind}")
-    numeric: list[str] = []
-    if min_points is not None and min_points > 0:
-        numeric.append(f"points>={min_points}")
-    win = _TIME_WINDOW_FILTERS.get(time_window, "")
-    if win:
-        numeric.append(win)
     params: dict[str, str] = {
         "query": query,
         "hitsPerPage": str(n),
     }
-    if filters:
-        params["tags"] = ",".join(f.split("=", 1)[1] for f in filters)
+    # Algolia tag values: story, comment, poll, pollopt, show_hn,
+    # ask_hn, front_page, job, user. ``any`` removes the filter.
+    if kind != "any":
+        params["tags"] = kind
+    numeric: list[str] = []
+    if min_points is not None and min_points > 0:
+        numeric.append(f"points>={min_points}")
+    win = _time_window_filter(time_window)
+    if win:
+        numeric.append(win)
     if numeric:
         params["numericFilters"] = ",".join(numeric)
     return f"{base}?{urllib.parse.urlencode(params)}"

--- a/pyagent/plugins/hn_search/__init__.py
+++ b/pyagent/plugins/hn_search/__init__.py
@@ -1,0 +1,375 @@
+"""hn-search — bundled plugin: search Hacker News via Algolia.
+
+One tool, ``hn_search(query, n=10, kind="story", time_window="all",
+min_points=None)``. Same return shape as web_search and reddit_search:
+Attachment(inline_text=<markdown>, content=<JSON list>, suffix=".json")
+on success, plain string markers on miss / failure.
+
+The HN search index Algolia hosts at ``hn.algolia.com/api/v1`` is
+the same one HN's own Search box uses. Public, no auth, no UA
+requirement. Different shape from Reddit: HN items have points,
+author, comment count, created_at, type (story / comment / job).
+
+Why a separate plugin: HN's "consensus on this library / startup /
+technical claim" content sits poorly in generic web search results
+(landing pages and SEO outrank discussion threads). For technical
+research workflows, this is the gap that matters.
+
+Configuration (all optional, all read at call time):
+
+  ``[plugins.hn-search]`` table in pyagent's config TOML
+    ``timeout_s`` — HTTP timeout per attempt. Default 10.
+    ``save_structured`` — when true (default), save the JSON list
+        as an attachment alongside the markdown. Set to false for
+        a legacy markdown-only string return.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+from pyagent.session import Attachment
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_TIMEOUT_S = 10
+_DEFAULT_SAVE_STRUCTURED = True
+_MAX_RESULTS = 50  # Algolia's per-page max; HN search results are short, no need to cap lower
+_VALID_KINDS = {"story", "comment", "poll", "any"}
+# Algolia "search by date" path narrows time windows. Map our
+# user-facing windows to (endpoint_path, numericFilters) pairs.
+_TIME_WINDOW_FILTERS: dict[str, str] = {
+    "all": "",
+    "hour": "created_at_i>now-1h",
+    "day": "created_at_i>now-1d",
+    "week": "created_at_i>now-1w",
+    "month": "created_at_i>now-1M",
+    "year": "created_at_i>now-1y",
+}
+_VALID_TIME_WINDOWS = set(_TIME_WINDOW_FILTERS.keys())
+
+
+@dataclass(frozen=True)
+class HNStory:
+    """One HN search result, normalized."""
+
+    title: str
+    url: str           # external URL the story links to (or hn-permalink for Ask/Show)
+    permalink: str     # https://news.ycombinator.com/item?id=<id> — always present
+    author: str
+    points: int
+    num_comments: int
+    created_at: str    # ISO 8601, as Algolia returns it
+    object_id: str
+    type: str          # story / comment / poll / job
+
+
+def _resolve_timeout(plugin_cfg: dict) -> int:
+    raw = plugin_cfg.get("timeout_s")
+    if isinstance(raw, int) and not isinstance(raw, bool) and raw > 0:
+        return raw
+    return _DEFAULT_TIMEOUT_S
+
+
+def _resolve_save_structured(plugin_cfg: dict) -> bool:
+    raw = plugin_cfg.get("save_structured")
+    if isinstance(raw, bool):
+        return raw
+    return _DEFAULT_SAVE_STRUCTURED
+
+
+def _config_warnings(plugin_cfg: dict) -> list[str]:
+    out: list[str] = []
+    if "timeout_s" in plugin_cfg:
+        raw = plugin_cfg["timeout_s"]
+        if not isinstance(raw, int) or isinstance(raw, bool) or raw <= 0:
+            out.append(
+                f"timeout_s must be a positive integer, got "
+                f"{type(raw).__name__}: {raw!r} — using default "
+                f"{_DEFAULT_TIMEOUT_S}"
+            )
+    if "save_structured" in plugin_cfg:
+        raw = plugin_cfg["save_structured"]
+        if not isinstance(raw, bool):
+            out.append(
+                f"save_structured must be a bool, got "
+                f"{type(raw).__name__}: {raw!r} — using default "
+                f"{_DEFAULT_SAVE_STRUCTURED}"
+            )
+    return out
+
+
+def _build_url(
+    query: str,
+    n: int,
+    kind: str,
+    time_window: str,
+    min_points: int | None,
+) -> str:
+    base = "https://hn.algolia.com/api/v1/search"
+    filters: list[str] = []
+    if kind != "any":
+        # tag values: story, comment, poll, pollopt, show_hn, ask_hn,
+        # front_page, job, user
+        filters.append(f"tags={kind}")
+    numeric: list[str] = []
+    if min_points is not None and min_points > 0:
+        numeric.append(f"points>={min_points}")
+    win = _TIME_WINDOW_FILTERS.get(time_window, "")
+    if win:
+        numeric.append(win)
+    params: dict[str, str] = {
+        "query": query,
+        "hitsPerPage": str(n),
+    }
+    if filters:
+        params["tags"] = ",".join(f.split("=", 1)[1] for f in filters)
+    if numeric:
+        params["numericFilters"] = ",".join(numeric)
+    return f"{base}?{urllib.parse.urlencode(params)}"
+
+
+def _parse_hits(payload: dict) -> list[HNStory]:
+    hits = payload.get("hits") or []
+    out: list[HNStory] = []
+    for hit in hits:
+        if not isinstance(hit, dict):
+            continue
+        object_id = str(hit.get("objectID") or "").strip()
+        permalink = (
+            f"https://news.ycombinator.com/item?id={object_id}"
+            if object_id
+            else ""
+        )
+        # `url` is None for Ask HN / Show HN where the discussion
+        # IS the content. Fall back to permalink so consumers always
+        # have a clickable link.
+        external_url = hit.get("url") or permalink
+        try:
+            points = int(hit.get("points") or 0)
+        except (TypeError, ValueError):
+            points = 0
+        try:
+            num_comments = int(hit.get("num_comments") or 0)
+        except (TypeError, ValueError):
+            num_comments = 0
+        # Algolia returns _tags like ["story", "author_xyz", "story_123"].
+        # The first non-author/non-id tag is the kind.
+        item_type = "story"
+        for tag in hit.get("_tags") or []:
+            if isinstance(tag, str) and not tag.startswith(
+                ("author_", "story_", "comment_", "poll_", "job_")
+            ):
+                item_type = tag
+                break
+        out.append(
+            HNStory(
+                title=str(
+                    hit.get("title")
+                    or hit.get("story_title")
+                    or ""
+                ).strip(),
+                url=str(external_url).strip(),
+                permalink=permalink,
+                author=str(hit.get("author") or "").strip(),
+                points=points,
+                num_comments=num_comments,
+                created_at=str(hit.get("created_at") or "").strip(),
+                object_id=object_id,
+                type=item_type,
+            )
+        )
+    return out
+
+
+def hn_text_search(
+    query: str,
+    *,
+    n: int = 10,
+    kind: str = "story",
+    time_window: str = "all",
+    min_points: int | None = None,
+    timeout_s: int = _DEFAULT_TIMEOUT_S,
+) -> list[HNStory]:
+    """Hit hn.algolia.com/api/v1/search and return parsed HNStory records.
+
+    Raises on HTTP error / network failure / parse failure — the tool
+    wrapper translates those into a tool-result error string.
+    """
+    url = _build_url(query, n, kind, time_window, min_points)
+    req = urllib.request.Request(url)
+    with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+        raw = resp.read()
+        encoding = resp.headers.get_content_charset("utf-8")
+        text = raw.decode(encoding, errors="replace")
+    payload = json.loads(text)
+    if not isinstance(payload, dict):
+        return []
+    return _parse_hits(payload)
+
+
+def format_results(
+    stories: list[HNStory], query: str
+) -> str:
+    """Render a list of HNStory as a markdown numbered list."""
+    if not stories:
+        return f"<no hn results for {query!r}>"
+    lines: list[str] = [f"# Hacker News results for {query!r}", ""]
+    for i, s in enumerate(stories, 1):
+        title = s.title or "(no title)"
+        meta_bits: list[str] = []
+        if s.author:
+            meta_bits.append(f"by {s.author}")
+        meta_bits.append(f"{s.points} pts")
+        meta_bits.append(f"{s.num_comments} comments")
+        if s.created_at:
+            # YYYY-MM-DDTHH:MM:SS.000Z — keep just the date for terseness
+            meta_bits.append(s.created_at[:10])
+        meta = " · ".join(meta_bits)
+        lines.append(f"{i}. **{title}** — {s.permalink}")
+        lines.append(f"   {meta}")
+        if s.url and s.url != s.permalink:
+            lines.append(f"   link: {s.url}")
+        lines.append("")
+    while lines and lines[-1] == "":
+        lines.pop()
+    return "\n".join(lines)
+
+
+def register(api):
+    for warning in _config_warnings(api.plugin_config or {}):
+        api.log("warning", warning)
+
+    def hn_search(
+        query: str,
+        n: int = 10,
+        kind: str = "story",
+        time_window: str = "all",
+        min_points: int | None = None,
+    ):
+        """Search Hacker News via Algolia.
+
+        Use for technical-consensus questions where HN discussions
+        out-signal generic web results — "what do people think of
+        <library>", "how is <startup> received", "real-world
+        experience with <technology>". Algolia indexes everything:
+        stories, comments, Ask HN, Show HN.
+
+        On a successful (non-empty) search, returns an Attachment:
+        the markdown summary rides inline and the structured JSON
+        list of items is saved to attachments. The footer points at
+        the JSON; downstream tools can consume the structured form
+        directly. Set ``[plugins.hn-search] save_structured = false``
+        to revert to a markdown-only string return.
+
+        Args:
+            query: Search query. Plain text.
+            n: Number of results (default 10, max 50).
+            kind: One of ``story`` (default), ``comment``, ``poll``,
+                ``any``. ``any`` removes the type filter.
+            time_window: One of ``hour``, ``day``, ``week``, ``month``,
+                ``year``, ``all`` (default). Restricts to items
+                created in that window.
+            min_points: Optional minimum-score filter. Only items
+                with at least this many points come back. Useful
+                for cutting noise on broad queries.
+
+        Returns:
+            On success: Attachment(inline_text=<markdown summary>,
+                content=<JSON list of items>, suffix=".json").
+            On miss: ``<no hn results for ...>`` string marker.
+            On failure: ``<hn-search error: ...>`` string marker
+                (HTTP error, parse error, etc.).
+        """
+        if not query or not query.strip():
+            return "<query is empty>"
+        try:
+            n_int = int(n)
+        except (TypeError, ValueError):
+            return f"<error: n must be an integer, got {n!r}>"
+        if n_int < 1:
+            return "<error: n must be >= 1>"
+        if n_int > _MAX_RESULTS:
+            n_int = _MAX_RESULTS
+        if kind not in _VALID_KINDS:
+            return (
+                f"<error: kind must be one of {sorted(_VALID_KINDS)}, "
+                f"got {kind!r}>"
+            )
+        if time_window not in _VALID_TIME_WINDOWS:
+            return (
+                f"<error: time_window must be one of "
+                f"{sorted(_VALID_TIME_WINDOWS)}, got {time_window!r}>"
+            )
+        if min_points is not None:
+            try:
+                min_points_int: int | None = int(min_points)
+            except (TypeError, ValueError):
+                return (
+                    f"<error: min_points must be an integer, got "
+                    f"{min_points!r}>"
+                )
+            if min_points_int < 0:
+                return (
+                    f"<error: min_points must be >= 0, got "
+                    f"{min_points_int}>"
+                )
+        else:
+            min_points_int = None
+
+        cfg = api.plugin_config or {}
+        timeout_s = _resolve_timeout(cfg)
+        save_structured = _resolve_save_structured(cfg)
+
+        try:
+            stories = hn_text_search(
+                query,
+                n=n_int,
+                kind=kind,
+                time_window=time_window,
+                min_points=min_points_int,
+                timeout_s=timeout_s,
+            )
+        except urllib.error.HTTPError as e:
+            return f"<hn-search error: HTTP {e.code}: {e.reason}>"
+        except urllib.error.URLError as e:
+            return f"<hn-search error: network failure: {e.reason}>"
+        except Exception as e:
+            return f"<hn-search error: {e}>"
+
+        markdown = format_results(stories, query)
+        if not save_structured or not stories:
+            return markdown
+
+        structured = json.dumps(
+            [
+                {
+                    "title": s.title,
+                    "url": s.url,
+                    "permalink": s.permalink,
+                    "author": s.author,
+                    "points": s.points,
+                    "num_comments": s.num_comments,
+                    "created_at": s.created_at,
+                    "object_id": s.object_id,
+                    "type": s.type,
+                }
+                for s in stories
+            ],
+            indent=2,
+            ensure_ascii=False,
+        )
+        return Attachment(
+            content=structured,
+            inline_text=markdown,
+            suffix=".json",
+        )
+
+    api.register_tool("hn_search", hn_search)

--- a/pyagent/plugins/hn_search/manifest.toml
+++ b/pyagent/plugins/hn_search/manifest.toml
@@ -1,0 +1,23 @@
+name = "hn-search"
+version = "0.1.0"
+description = "Search Hacker News stories and comments via the Algolia public API."
+api_version = "1"
+
+# One stateless tool:
+#
+#   hn_search(query, n=10, kind="story", time_window="all",
+#             min_points=None)
+#       Search HN. Returns the same Attachment(inline_text=md,
+#       content=json) shape as web_search and reddit_search.
+#
+# Algolia's HN search index (hn.algolia.com/api/v1) is the same
+# backend HN's own Search box uses. Public, no auth, no API key.
+# Rate limits are generous; in practice the agent hits transient
+# 5xx far more often than 429.
+
+[provides]
+tools = ["hn_search"]
+
+# Stateless and read-only — fine to load in subagents.
+[load]
+in_subagents = true

--- a/pyagent/plugins/reddit_search/__init__.py
+++ b/pyagent/plugins/reddit_search/__init__.py
@@ -1,0 +1,381 @@
+"""reddit-search — bundled plugin: search Reddit via the public
+reddit.com/search.json endpoint.
+
+One tool, ``reddit_search(query, n=10, subreddit=None,
+time_window="all", sort="relevance")``. Returns an Attachment whose
+``inline_text`` is a human-readable markdown summary and whose
+``content`` is the structured JSON list of posts (title, url, score,
+comments, age, author, subreddit). Same shape as ``web_search`` post-
+#91 — markdown rides inline, structured form lives in attachments
+for chaining via ``extract_doc`` or future tool composition.
+
+Why a separate plugin (not a search-source slot in ``web_search``):
+Reddit results have a distinct shape (score, num_comments, subreddit)
+and distinct query knobs (sub-restriction, time window) that don't
+fit ``web_search``'s (query, n) signature. The metasearch
+under-surfaces Reddit content for "real-world Q&A" queries, which is
+the gap this fills.
+
+Configuration (all optional, all read at call time):
+
+  ``[plugins.reddit-search]`` table in pyagent's config TOML
+    ``timeout_s`` — HTTP timeout per attempt. Default 10.
+    ``user_agent`` — User-Agent header sent to Reddit. Default
+        identifies pyagent. Reddit gates anonymous traffic on the
+        UA — leaving it as a generic Python UA earns a 429.
+    ``save_structured`` — when true (default), save the JSON list
+        as an attachment alongside the markdown. Set to false for
+        a legacy markdown-only string return.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+from pyagent.session import Attachment
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_TIMEOUT_S = 10
+_DEFAULT_USER_AGENT = (
+    "pyagent-reddit-search/0.1 (+https://github.com/derekwisong/pyagent)"
+)
+_DEFAULT_SAVE_STRUCTURED = True
+_MAX_RESULTS = 25  # Reddit caps at 100 per page; we cap lower to keep results focused
+_VALID_TIME_WINDOWS = {"hour", "day", "week", "month", "year", "all"}
+_VALID_SORTS = {"relevance", "hot", "top", "new", "comments"}
+
+
+@dataclass(frozen=True)
+class RedditPost:
+    """One Reddit search result, normalized."""
+
+    title: str
+    url: str          # external URL the post links to (or self-permalink for text posts)
+    permalink: str    # reddit.com permalink — always present
+    subreddit: str
+    author: str
+    score: int
+    num_comments: int
+    created_utc: float
+    selftext_excerpt: str   # first ~300 chars of self-post body, "" for link posts
+
+
+def _resolve_timeout(plugin_cfg: dict) -> int:
+    raw = plugin_cfg.get("timeout_s")
+    if isinstance(raw, int) and not isinstance(raw, bool) and raw > 0:
+        return raw
+    return _DEFAULT_TIMEOUT_S
+
+
+def _resolve_user_agent(plugin_cfg: dict) -> str:
+    raw = plugin_cfg.get("user_agent")
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    return _DEFAULT_USER_AGENT
+
+
+def _resolve_save_structured(plugin_cfg: dict) -> bool:
+    raw = plugin_cfg.get("save_structured")
+    if isinstance(raw, bool):
+        return raw
+    return _DEFAULT_SAVE_STRUCTURED
+
+
+def _config_warnings(plugin_cfg: dict) -> list[str]:
+    out: list[str] = []
+    if "timeout_s" in plugin_cfg:
+        raw = plugin_cfg["timeout_s"]
+        if not isinstance(raw, int) or isinstance(raw, bool) or raw <= 0:
+            out.append(
+                f"timeout_s must be a positive integer, got "
+                f"{type(raw).__name__}: {raw!r} — using default "
+                f"{_DEFAULT_TIMEOUT_S}"
+            )
+    if "user_agent" in plugin_cfg:
+        raw = plugin_cfg["user_agent"]
+        if not isinstance(raw, str) or not raw.strip():
+            out.append(
+                f"user_agent must be a non-empty string — using default"
+            )
+    if "save_structured" in plugin_cfg:
+        raw = plugin_cfg["save_structured"]
+        if not isinstance(raw, bool):
+            out.append(
+                f"save_structured must be a bool, got "
+                f"{type(raw).__name__}: {raw!r} — using default "
+                f"{_DEFAULT_SAVE_STRUCTURED}"
+            )
+    return out
+
+
+def _build_url(
+    query: str,
+    n: int,
+    subreddit: str | None,
+    time_window: str,
+    sort: str,
+) -> str:
+    base = (
+        f"https://www.reddit.com/r/{urllib.parse.quote(subreddit)}/search.json"
+        if subreddit
+        else "https://www.reddit.com/search.json"
+    )
+    params: dict[str, str] = {
+        "q": query,
+        "limit": str(n),
+        "t": time_window,
+        "sort": sort,
+        "raw_json": "1",
+    }
+    if subreddit:
+        # Restrict to that sub specifically; without this, Reddit's
+        # /r/<sub>/search.json silently spans all of Reddit on some
+        # paths.
+        params["restrict_sr"] = "1"
+    return f"{base}?{urllib.parse.urlencode(params)}"
+
+
+def _parse_listing(payload: dict) -> list[RedditPost]:
+    children = (payload.get("data") or {}).get("children") or []
+    out: list[RedditPost] = []
+    for child in children:
+        if not isinstance(child, dict):
+            continue
+        d = child.get("data") or {}
+        if not isinstance(d, dict):
+            continue
+        permalink_path = str(d.get("permalink") or "")
+        permalink = (
+            f"https://www.reddit.com{permalink_path}"
+            if permalink_path.startswith("/")
+            else permalink_path
+        )
+        external_url = str(d.get("url") or permalink).strip()
+        selftext = str(d.get("selftext") or "").strip()
+        excerpt = (
+            (selftext[:297] + "...") if len(selftext) > 300 else selftext
+        )
+        try:
+            score = int(d.get("score") or 0)
+        except (TypeError, ValueError):
+            score = 0
+        try:
+            num_comments = int(d.get("num_comments") or 0)
+        except (TypeError, ValueError):
+            num_comments = 0
+        try:
+            created_utc = float(d.get("created_utc") or 0)
+        except (TypeError, ValueError):
+            created_utc = 0.0
+        out.append(
+            RedditPost(
+                title=str(d.get("title") or "").strip(),
+                url=external_url,
+                permalink=permalink,
+                subreddit=str(d.get("subreddit") or "").strip(),
+                author=str(d.get("author") or "").strip(),
+                score=score,
+                num_comments=num_comments,
+                created_utc=created_utc,
+                selftext_excerpt=excerpt,
+            )
+        )
+    return out
+
+
+def reddit_text_search(
+    query: str,
+    *,
+    n: int = 10,
+    subreddit: str | None = None,
+    time_window: str = "all",
+    sort: str = "relevance",
+    timeout_s: int = _DEFAULT_TIMEOUT_S,
+    user_agent: str = _DEFAULT_USER_AGENT,
+) -> list[RedditPost]:
+    """Hit reddit.com/search.json and return parsed RedditPost records.
+
+    Raises on HTTP error / network failure / parse failure — the tool
+    wrapper translates those into a tool-result error string.
+    """
+    url = _build_url(query, n, subreddit, time_window, sort)
+    req = urllib.request.Request(url, headers={"User-Agent": user_agent})
+    with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+        raw = resp.read()
+        encoding = resp.headers.get_content_charset("utf-8")
+        text = raw.decode(encoding, errors="replace")
+    payload = json.loads(text)
+    if not isinstance(payload, dict):
+        return []
+    return _parse_listing(payload)
+
+
+def format_results(
+    posts: list[RedditPost], query: str, subreddit: str | None
+) -> str:
+    """Render a list of RedditPost as a markdown numbered list."""
+    if not posts:
+        scope = f" in r/{subreddit}" if subreddit else ""
+        return f"<no reddit results for {query!r}{scope}>"
+    scope = f" in r/{subreddit}" if subreddit else ""
+    lines: list[str] = [f"# Reddit results for {query!r}{scope}", ""]
+    for i, p in enumerate(posts, 1):
+        title = p.title or "(no title)"
+        meta_bits = [f"r/{p.subreddit}"] if p.subreddit else []
+        if p.author:
+            meta_bits.append(f"u/{p.author}")
+        meta_bits.append(f"{p.score} pts")
+        meta_bits.append(f"{p.num_comments} comments")
+        meta = " · ".join(meta_bits)
+        lines.append(f"{i}. **{title}** — {p.permalink}")
+        lines.append(f"   {meta}")
+        if p.url and p.url != p.permalink:
+            lines.append(f"   link: {p.url}")
+        if p.selftext_excerpt:
+            lines.append(f"   {p.selftext_excerpt}")
+        lines.append("")
+    while lines and lines[-1] == "":
+        lines.pop()
+    return "\n".join(lines)
+
+
+def register(api):
+    for warning in _config_warnings(api.plugin_config or {}):
+        api.log("warning", warning)
+
+    def reddit_search(
+        query: str,
+        n: int = 10,
+        subreddit: str | None = None,
+        time_window: str = "all",
+        sort: str = "relevance",
+    ):
+        """Search Reddit posts via reddit.com/search.json.
+
+        Use for real-world Q&A, community discussion, and "what do
+        people actually think about X" queries that the metasearch
+        in ``web_search`` covers shallowly. Reddit search is the
+        right surface when the answer lives inside conversations,
+        not on landing pages.
+
+        On a successful (non-empty) search, returns an Attachment:
+        the markdown summary rides inline and the structured JSON
+        list of posts is saved to attachments. The footer points at
+        the JSON; downstream tools (``extract_doc`` etc.) can consume
+        the structured list directly without re-running the search.
+        Set ``[plugins.reddit-search] save_structured = false`` to
+        revert to a markdown-only string return.
+
+        Args:
+            query: Search query. Plain text. Reddit's search supports
+                operators like ``site:`` and ``self:yes`` — pass them
+                through as part of ``query``.
+            n: Number of results (default 10, max 25).
+            subreddit: Optional subreddit name (without the ``r/``
+                prefix). When set, the search is restricted to that
+                sub. Without it, the search spans all of Reddit.
+            time_window: One of ``hour``, ``day``, ``week``, ``month``,
+                ``year``, ``all`` (default).
+            sort: One of ``relevance`` (default), ``hot``, ``top``,
+                ``new``, ``comments``.
+
+        Returns:
+            On success: Attachment(inline_text=<markdown summary>,
+                content=<JSON list of posts>, suffix=".json").
+            On miss: ``<no reddit results for ...>`` string marker.
+            On failure: ``<reddit-search error: ...>`` string marker
+                (HTTP error, parse error, rate limit, etc.).
+        """
+        if not query or not query.strip():
+            return "<query is empty>"
+        try:
+            n_int = int(n)
+        except (TypeError, ValueError):
+            return f"<error: n must be an integer, got {n!r}>"
+        if n_int < 1:
+            return "<error: n must be >= 1>"
+        if n_int > _MAX_RESULTS:
+            n_int = _MAX_RESULTS
+        if subreddit is not None:
+            if not isinstance(subreddit, str) or not subreddit.strip():
+                return (
+                    f"<error: subreddit must be a non-empty string when "
+                    f"set, got {subreddit!r}>"
+                )
+            subreddit = subreddit.strip().lstrip("/").removeprefix("r/")
+        if time_window not in _VALID_TIME_WINDOWS:
+            return (
+                f"<error: time_window must be one of "
+                f"{sorted(_VALID_TIME_WINDOWS)}, got {time_window!r}>"
+            )
+        if sort not in _VALID_SORTS:
+            return (
+                f"<error: sort must be one of {sorted(_VALID_SORTS)}, "
+                f"got {sort!r}>"
+            )
+
+        cfg = api.plugin_config or {}
+        timeout_s = _resolve_timeout(cfg)
+        user_agent = _resolve_user_agent(cfg)
+        save_structured = _resolve_save_structured(cfg)
+
+        try:
+            posts = reddit_text_search(
+                query,
+                n=n_int,
+                subreddit=subreddit,
+                time_window=time_window,
+                sort=sort,
+                timeout_s=timeout_s,
+                user_agent=user_agent,
+            )
+        except urllib.error.HTTPError as e:
+            if e.code == 429:
+                return (
+                    f"<reddit-search error: rate limited (HTTP 429); "
+                    f"pause and try again later — set a more "
+                    f"identifying user_agent in config if persistent>"
+                )
+            return f"<reddit-search error: HTTP {e.code}: {e.reason}>"
+        except urllib.error.URLError as e:
+            return f"<reddit-search error: network failure: {e.reason}>"
+        except Exception as e:
+            return f"<reddit-search error: {e}>"
+
+        markdown = format_results(posts, query, subreddit)
+        if not save_structured or not posts:
+            return markdown
+
+        structured = json.dumps(
+            [
+                {
+                    "title": p.title,
+                    "url": p.url,
+                    "permalink": p.permalink,
+                    "subreddit": p.subreddit,
+                    "author": p.author,
+                    "score": p.score,
+                    "num_comments": p.num_comments,
+                    "created_utc": p.created_utc,
+                    "selftext_excerpt": p.selftext_excerpt,
+                }
+                for p in posts
+            ],
+            indent=2,
+            ensure_ascii=False,
+        )
+        return Attachment(
+            content=structured,
+            inline_text=markdown,
+            suffix=".json",
+        )
+
+    api.register_tool("reddit_search", reddit_search)

--- a/pyagent/plugins/reddit_search/__init__.py
+++ b/pyagent/plugins/reddit_search/__init__.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -41,6 +42,12 @@ from typing import Any
 from pyagent.session import Attachment
 
 logger = logging.getLogger(__name__)
+
+
+# Reddit subreddit names: alphanumeric + underscore, 1-21 chars.
+# Validating up front catches typos like "Python/comments/abc" that
+# would otherwise produce a 404 URL after path concatenation.
+_SUBREDDIT_RE = re.compile(r"^[A-Za-z0-9_]{1,21}$")
 
 
 _DEFAULT_TIMEOUT_S = 10
@@ -311,6 +318,11 @@ def register(api):
                     f"set, got {subreddit!r}>"
                 )
             subreddit = subreddit.strip().lstrip("/").removeprefix("r/")
+            if not _SUBREDDIT_RE.match(subreddit):
+                return (
+                    f"<error: subreddit must be alphanumeric / "
+                    f"underscore, max 21 chars; got {subreddit!r}>"
+                )
         if time_window not in _VALID_TIME_WINDOWS:
             return (
                 f"<error: time_window must be one of "
@@ -339,10 +351,13 @@ def register(api):
             )
         except urllib.error.HTTPError as e:
             if e.code == 429:
+                # 429 from Reddit usually means pacing or OAuth, not
+                # User-Agent shape — earlier wording overstated the
+                # UA fix per #94 review.
                 return (
                     f"<reddit-search error: rate limited (HTTP 429); "
-                    f"pause and try again later — set a more "
-                    f"identifying user_agent in config if persistent>"
+                    f"back off — persistent 429s usually need pacing "
+                    f"or OAuth, not user_agent changes>"
                 )
             return f"<reddit-search error: HTTP {e.code}: {e.reason}>"
         except urllib.error.URLError as e:

--- a/pyagent/plugins/reddit_search/manifest.toml
+++ b/pyagent/plugins/reddit_search/manifest.toml
@@ -1,0 +1,25 @@
+name = "reddit-search"
+version = "0.1.0"
+description = "Search Reddit posts via the public reddit.com/search.json endpoint."
+api_version = "1"
+
+# One stateless tool:
+#
+#   reddit_search(query, n=10, subreddit=None, time_window="all", sort="relevance")
+#       Search Reddit. Returns the same shape as web_search:
+#       Attachment(inline_text=<markdown summary>, content=<JSON list>)
+#       so the agent gets a human view inline AND the structured
+#       result for chaining via extract_doc / future tool composition.
+#
+# Reddit's search endpoint is public — no OAuth needed, no API key
+# — but it gates anonymous traffic on a sensible User-Agent. The
+# plugin sets a UA identifying pyagent. If Reddit rate-limits us,
+# the request raises and the wrapper surfaces the standard
+# <search error: ...> markers.
+
+[provides]
+tools = ["reddit_search"]
+
+# Stateless and read-only — fine to load in subagents.
+[load]
+in_subagents = true

--- a/pyagent/skills/pdf-from-markdown/SKILL.md
+++ b/pyagent/skills/pdf-from-markdown/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: pdf-from-markdown
+description: Convert markdown to PDF using pandoc. No script — pandoc on PATH plus the right `execute` invocation is the entire workflow.
+---
+
+# PDF from markdown
+
+Renders a markdown file to a polished PDF using pandoc. Most agent
+sessions that produce a written report want to hand the user a PDF
+at the end; this skill is the canonical "how do I do that" rather
+than re-deriving pandoc invocations from scratch each time.
+
+## Requirements
+
+`pandoc` on PATH. If you run a pandoc command via `execute` and see
+``pandoc: command not found``, the user needs to install it:
+
+- macOS: ``brew install pandoc``
+- Debian / Ubuntu: ``apt install pandoc``
+- Other Linux: distro package manager, or download from
+  <https://pandoc.org/installing.html>
+
+For the academic-styling invocation below, pandoc also needs a LaTeX
+engine. ``texlive-xetex`` (Linux) / MacTeX (macOS) covers it.
+
+## How to use this skill
+
+There is no Python script. You invoke pandoc directly via `execute`
+with a few well-tested flag sets. Pick the invocation that matches
+the user's intent.
+
+### Default — clean general-purpose layout
+
+```
+pandoc <input.md> -o <output.pdf>
+```
+
+Uses pandoc's bundled LaTeX engine. Decent typography out of the
+box — titles, headings, code blocks, tables all render cleanly.
+Right for memos, reports, summaries, anything that doesn't need a
+specific look.
+
+### Polished — system font, comfortable margins
+
+```
+pandoc <input.md> -o <output.pdf> \
+    --pdf-engine=xelatex \
+    -V geometry:margin=1in \
+    -V mainfont="DejaVu Sans"
+```
+
+Use when the user wants something that looks more like a finished
+deliverable. ``mainfont`` accepts any installed system font — pick
+one the platform actually has (DejaVu Sans is a safe default on
+Linux; ``Helvetica`` on macOS).
+
+### Academic — LaTeX styling, two-column-friendly
+
+```
+pandoc <input.md> -o <output.pdf> --pdf-engine=pdflatex
+```
+
+Crisp serif typography, justified text, classic LaTeX article look.
+Use for research writeups, papers, anything where the user expects
+academic formatting.
+
+## Where to save the output
+
+Save the PDF into the current session's attachments directory so it
+sticks with the conversation and gets cleaned up alongside other
+session artifacts:
+
+```
+.pyagent/sessions/<session-id>/attachments/<your-name>.pdf
+```
+
+If you don't already know the session id, list the directory
+``.pyagent/sessions/`` and pick the most recent. Or save into the
+user's working directory and tell them the path — that's also fine
+for one-off requests.
+
+## Troubleshooting
+
+- ``pandoc: command not found`` — install pandoc (see Requirements).
+- ``! LaTeX Error`` from the polished or academic invocations — the
+  LaTeX engine isn't installed. Either install it (``texlive-xetex``,
+  MacTeX) or fall back to the default invocation, which uses
+  pandoc's bundled engine.
+- ``! Package fontspec Error: The font ... cannot be found`` — the
+  ``mainfont`` you picked isn't installed. Drop the ``-V mainfont``
+  flag, or pick one ``fc-list | head`` shows.
+
+## When NOT to use this
+
+If the user wants a structured PDF *generated from data* (e.g.,
+"build me a report with these tables and charts"), this skill is
+the wrong shape — produce the markdown first (or build directly
+with reportlab / WeasyPrint in a one-off Python script), then run
+the markdown through here. This skill is markdown-in, PDF-out only.

--- a/pyagent/skills/pdf-from-markdown/SKILL.md
+++ b/pyagent/skills/pdf-from-markdown/SKILL.md
@@ -54,15 +54,25 @@ deliverable. ``mainfont`` accepts any installed system font — pick
 one the platform actually has (DejaVu Sans is a safe default on
 Linux; ``Helvetica`` on macOS).
 
-### Academic — LaTeX styling, two-column-friendly
+### Academic — LaTeX styling with explicit document-class settings
 
 ```
-pandoc <input.md> -o <output.pdf> --pdf-engine=pdflatex
+pandoc <input.md> -o <output.pdf> \
+    --pdf-engine=pdflatex \
+    -V documentclass=article \
+    -V geometry:margin=1in \
+    -V fontsize=11pt \
+    -V linestretch=1.15
 ```
 
-Crisp serif typography, justified text, classic LaTeX article look.
-Use for research writeups, papers, anything where the user expects
-academic formatting.
+Crisp serif typography, justified text, classic LaTeX article look
+with comfortable line spacing and standard margins. Use for research
+writeups, papers, anything where the user expects formal formatting.
+The default invocation also lands on pdflatex on most platforms;
+this one differs by pinning ``documentclass``, ``geometry``,
+``fontsize``, and ``linestretch`` so the result is reproducible
+across machines instead of inheriting whatever defaults the local
+pandoc + LaTeX install ships with.
 
 ## Where to save the output
 

--- a/tests/smoke_hn_search.py
+++ b/tests/smoke_hn_search.py
@@ -167,6 +167,41 @@ def _check_parse_hits_tolerates_weird_payloads() -> None:
     print("✓ _parse_hits: tolerates missing fields; type tag picked correctly")
 
 
+def _check_parse_hits_type_tag_precedence() -> None:
+    """Lock the chosen precedence on `_tags = [story, ask_hn, ...]`.
+    The first non-author/non-id tag wins — currently `story` over
+    `ask_hn`. If that flips, the smoke fails loudly and the reviewer
+    can decide whether the new precedence is intentional."""
+    payload = {
+        "hits": [
+            {
+                "title": "Ask HN: …",
+                "objectID": "1",
+                "_tags": ["story", "ask_hn", "author_a", "story_1"],
+            },
+            {
+                "title": "Show HN: …",
+                "objectID": "2",
+                "_tags": ["story", "show_hn", "author_b", "story_2"],
+            },
+            {
+                "title": "Job posting",
+                "objectID": "3",
+                "_tags": ["job", "author_c"],
+            },
+        ]
+    }
+    stories = _parse_hits(payload)
+    # `story` precedes `ask_hn` / `show_hn` in the list → it wins.
+    # That's the chosen design: every Ask/Show HN is fundamentally a
+    # story; the kind tag is what `kind=story` filtered on. If a
+    # consumer wanted to differentiate, they'd inspect the title.
+    assert stories[0].type == "story", stories[0]
+    assert stories[1].type == "story", stories[1]
+    assert stories[2].type == "job", stories[2]
+    print("✓ _parse_hits: type precedence — story wins over ask_hn/show_hn")
+
+
 def _check_url_builder() -> None:
     url = _build_url(
         "postgres sqlite", n=10, kind="story", time_window="all", min_points=None,
@@ -178,14 +213,41 @@ def _check_url_builder() -> None:
     # No min_points and time_window=all → no numericFilters.
     assert "numericFilters" not in url, url
 
-    url = _build_url("rust", n=5, kind="any", time_window="month", min_points=50)
+    # Mock time so the epoch cutoff is deterministic.
+    fake_now = 1_750_000_000  # arbitrary fixed instant
+    with mock.patch.object(hn_mod.time, "time", return_value=fake_now):
+        url = _build_url("rust", n=5, kind="any", time_window="month", min_points=50)
     assert "hitsPerPage=5" in url, url
     # kind=any drops the tags filter.
     assert "tags=story" not in url, url
     assert "numericFilters" in url, url
     assert "points%3E%3D50" in url, url  # urlencoded ">=50"
-    assert "created_at_i%3Enow-1M" in url, url
-    print("✓ URL builder: kind / time_window / min_points all flow through")
+    # NEW: time window resolves to a literal numeric epoch (not the
+    # broken `now-1M` syntax that Algolia rejects with HTTP 400).
+    expected_cutoff = fake_now - 2_592_000  # month = 30 days
+    assert f"created_at_i%3E{expected_cutoff}" in url, url
+    assert "now-" not in url, (
+        "regression: time window must resolve to a literal epoch, "
+        "not the relative-time string Algolia rejects"
+    )
+    print("✓ URL builder: kind / time_window (numeric epoch) / min_points flow through")
+
+
+def _check_time_window_filter_helper() -> None:
+    """`_time_window_filter` produces literal-epoch filters that
+    Algolia accepts. Locks in the #94 review fix — the previous
+    `now-1d`-style strings returned HTTP 400 from Algolia."""
+    fake_now = 1_750_000_000
+    with mock.patch.object(hn_mod.time, "time", return_value=fake_now):
+        assert hn_mod._time_window_filter("all") == ""
+        assert hn_mod._time_window_filter("hour") == f"created_at_i>{fake_now - 3600}"
+        assert hn_mod._time_window_filter("day") == f"created_at_i>{fake_now - 86400}"
+        assert hn_mod._time_window_filter("week") == f"created_at_i>{fake_now - 604800}"
+        assert hn_mod._time_window_filter("month") == f"created_at_i>{fake_now - 2_592_000}"
+        assert hn_mod._time_window_filter("year") == f"created_at_i>{fake_now - 31_536_000}"
+        # Unknown window → empty (defensive; the tool layer validates first)
+        assert hn_mod._time_window_filter("century") == ""
+    print("✓ time_window: produces literal numeric epochs Algolia accepts")
 
 
 def _check_tool_returns_attachment() -> None:
@@ -321,7 +383,9 @@ def main() -> None:
     _check_format_results()
     _check_format_results_empty()
     _check_parse_hits_tolerates_weird_payloads()
+    _check_parse_hits_type_tag_precedence()
     _check_url_builder()
+    _check_time_window_filter_helper()
     _check_tool_returns_attachment()
     _check_save_structured_disabled_returns_string()
     _check_empty_results_returns_string()

--- a/tests/smoke_hn_search.py
+++ b/tests/smoke_hn_search.py
@@ -1,0 +1,335 @@
+"""End-to-end smoke for the hn-search plugin.
+
+Concerns covered:
+
+  1. **Plugin loads under the default config.** With "hn-search" in
+     `built_in_plugins_enabled`, `discover()` and `load()` produce
+     the `hn_search` tool.
+  2. **Result formatter renders stories as markdown.** Numbered list,
+     author / points / comments / date meta line, permalink + external
+     URL when distinct.
+  3. **Empty results → ``<no hn results for ...>`` marker.**
+  4. **Hits parser tolerates partial / weird payloads.** Algolia's
+     index occasionally omits fields or returns numeric scores as
+     strings; the parser must coerce, not crash.
+  5. **URL builder respects kind / time_window / min_points knobs.**
+  6. **Plugin returns Attachment on success.** Markdown rides
+     inline_text, structured JSON list rides content, suffix ".json".
+  7. **save_structured = false** preserves the legacy markdown-only
+     string return.
+  8. **Empty results return string** (no attachment for an empty list).
+  9. **Validation paths** return string markers, never raise: empty
+     query, bad ``n``, bad ``kind``, bad ``time_window``, bad
+     ``min_points``.
+ 10. **HTTP failures translate cleanly:** HTTPError →
+     ``<hn-search error: HTTP N: ...>``; URLError → network failure
+     marker; generic → catch-all marker.
+ 11. **Register-time warnings** on bogus `timeout_s` and
+     `save_structured` config; silent on clean config.
+
+Run with:
+    .venv/bin/python -m tests.smoke_hn_search
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import urllib.error
+from pathlib import Path
+from unittest import mock
+
+from pyagent import config as config_mod, paths as paths_mod, plugins
+from pyagent.plugins.hn_search import (
+    HNStory,
+    _build_url,
+    _parse_hits,
+    format_results,
+)
+from pyagent.plugins.hn_search import register as hn_register
+from pyagent.plugins import hn_search as hn_mod
+
+
+def _make_fake_api(plugin_config: dict | None = None) -> dict:
+    captured: dict = {
+        "tools": {},
+        "logs": [],
+        "plugin_config": plugin_config if plugin_config is not None else {},
+    }
+
+    class _FakeAPI:
+        @property
+        def plugin_config(self):
+            return captured["plugin_config"]
+
+        def register_tool(self, name, fn):
+            captured["tools"][name] = fn
+
+        def log(self, level, message):
+            captured["logs"].append((level, message))
+
+    hn_register(_FakeAPI())
+    return captured
+
+
+_FIXTURE_HITS_PAYLOAD = {
+    "hits": [
+        {
+            "title": "Why we switched from Postgres to SQLite",
+            "url": "https://eng.example.com/postgres-sqlite",
+            "objectID": "12345678",
+            "author": "alice",
+            "points": 412,
+            "num_comments": 198,
+            "created_at": "2026-04-22T14:03:00.000Z",
+            "_tags": ["story", "author_alice", "story_12345678"],
+        },
+        {
+            "title": "Ask HN: How do you onboard senior engineers?",
+            # Ask HN: url is None — discussion IS the content
+            "url": None,
+            "objectID": "98765432",
+            "author": "bob",
+            "points": "57",  # string-typed score; parser must coerce
+            "num_comments": None,  # missing
+            "created_at": "2026-05-01T09:18:00.000Z",
+            "_tags": ["story", "ask_hn", "author_bob", "story_98765432"],
+        },
+    ],
+    "nbHits": 2,
+    "page": 0,
+    "nbPages": 1,
+    "hitsPerPage": 10,
+}
+
+
+def _check_plugin_loads_under_default_config() -> None:
+    tmp = Path(tempfile.mkdtemp(prefix="pyagent-smoke-hn-"))
+    with mock.patch.object(paths_mod, "config_dir", return_value=tmp):
+        with mock.patch.object(
+            plugins, "LOCAL_PLUGINS_DIR", Path(tmp / "no_local_plugins")
+        ):
+            cfg = config_mod.load()
+            assert "hn-search" in cfg["built_in_plugins_enabled"], (
+                cfg["built_in_plugins_enabled"]
+            )
+            loaded = plugins.load()
+            tool_names = set(loaded.tools().keys())
+    assert "hn_search" in tool_names, tool_names
+    print("✓ plugin loads by default; hn_search tool present")
+
+
+def _check_format_results() -> None:
+    stories = _parse_hits(_FIXTURE_HITS_PAYLOAD)
+    md = format_results(stories, "postgres sqlite")
+    assert "# Hacker News results for 'postgres sqlite'" in md, md
+    assert "1. **Why we switched from Postgres to SQLite**" in md, md
+    assert "by alice" in md, md
+    assert "412 pts" in md, md
+    assert "198 comments" in md, md
+    assert "2026-04-22" in md, md
+    assert "https://news.ycombinator.com/item?id=12345678" in md, md
+    # External link distinct from permalink → "link:" line shown.
+    assert "link: https://eng.example.com/postgres-sqlite" in md, md
+    # Ask HN: url == permalink → no "link:" line.
+    second_block = md.split("2. ", 1)[1]
+    assert "link:" not in second_block, second_block
+    # String-typed score coerced.
+    assert "57 pts" in md, md
+    print("✓ format_results: numbered markdown with metadata; Ask HN handled")
+
+
+def _check_format_results_empty() -> None:
+    md = format_results([], "obscure")
+    assert md.startswith("<no hn results"), md
+    print("✓ format_results: empty → <no hn results ...> marker")
+
+
+def _check_parse_hits_tolerates_weird_payloads() -> None:
+    assert _parse_hits({"hits": []}) == []
+    assert _parse_hits({"not": "the right shape"}) == []
+    payload = {
+        "hits": [
+            {
+                "title": "x",
+                "objectID": "777",
+                # missing author / points / etc.
+                "_tags": ["comment", "author_carol", "story_42"],
+            }
+        ]
+    }
+    stories = _parse_hits(payload)
+    assert len(stories) == 1, stories
+    assert stories[0].permalink == "https://news.ycombinator.com/item?id=777", stories[0]
+    assert stories[0].points == 0, stories[0]
+    assert stories[0].num_comments == 0, stories[0]
+    assert stories[0].type == "comment", stories[0]
+    print("✓ _parse_hits: tolerates missing fields; type tag picked correctly")
+
+
+def _check_url_builder() -> None:
+    url = _build_url(
+        "postgres sqlite", n=10, kind="story", time_window="all", min_points=None,
+    )
+    assert url.startswith("https://hn.algolia.com/api/v1/search?"), url
+    assert "query=postgres+sqlite" in url or "query=postgres%20sqlite" in url, url
+    assert "hitsPerPage=10" in url, url
+    assert "tags=story" in url, url
+    # No min_points and time_window=all → no numericFilters.
+    assert "numericFilters" not in url, url
+
+    url = _build_url("rust", n=5, kind="any", time_window="month", min_points=50)
+    assert "hitsPerPage=5" in url, url
+    # kind=any drops the tags filter.
+    assert "tags=story" not in url, url
+    assert "numericFilters" in url, url
+    assert "points%3E%3D50" in url, url  # urlencoded ">=50"
+    assert "created_at_i%3Enow-1M" in url, url
+    print("✓ URL builder: kind / time_window / min_points all flow through")
+
+
+def _check_tool_returns_attachment() -> None:
+    from pyagent.session import Attachment as _Attachment
+
+    cap = _make_fake_api()
+    hn_search = cap["tools"]["hn_search"]
+
+    fixture_stories = _parse_hits(_FIXTURE_HITS_PAYLOAD)
+    with mock.patch.object(
+        hn_mod, "hn_text_search", return_value=fixture_stories
+    ) as m:
+        out = hn_search("postgres sqlite", n=2, kind="story")
+
+    args, kwargs = m.call_args
+    assert args == ("postgres sqlite",), args
+    assert kwargs.get("n") == 2, kwargs
+    assert kwargs.get("kind") == "story", kwargs
+    assert "timeout_s" in kwargs, kwargs
+
+    assert isinstance(out, _Attachment), type(out)
+    assert out.suffix == ".json", out.suffix
+    assert "Why we switched from Postgres to SQLite" in out.inline_text, out.inline_text
+    parsed = json.loads(out.content)
+    assert isinstance(parsed, list) and len(parsed) == 2, parsed
+    assert parsed[0]["title"].startswith("Why we switched"), parsed[0]
+    assert parsed[0]["points"] == 412, parsed[0]
+    assert parsed[0]["object_id"] == "12345678", parsed[0]
+    print("✓ tool returns Attachment(inline_text=md, content=json)")
+
+
+def _check_save_structured_disabled_returns_string() -> None:
+    cap = _make_fake_api(plugin_config={"save_structured": False})
+    hn_search = cap["tools"]["hn_search"]
+    fixture = _parse_hits(_FIXTURE_HITS_PAYLOAD)
+    with mock.patch.object(hn_mod, "hn_text_search", return_value=fixture):
+        out = hn_search("postgres sqlite")
+    assert isinstance(out, str), type(out)
+    assert "Why we switched" in out, out
+    assert "[also saved:" not in out, out
+    print("✓ save_structured=false: legacy markdown-only string return")
+
+
+def _check_empty_results_returns_string() -> None:
+    cap = _make_fake_api()
+    hn_search = cap["tools"]["hn_search"]
+    with mock.patch.object(hn_mod, "hn_text_search", return_value=[]):
+        out = hn_search("nonsense query no hits")
+    assert isinstance(out, str), type(out)
+    assert out.startswith("<no hn results "), out
+    print("✓ empty results: <no hn results ...> string marker, no attachment")
+
+
+def _check_validation_paths() -> None:
+    cap = _make_fake_api()
+    hn_search = cap["tools"]["hn_search"]
+    assert hn_search("") == "<query is empty>"
+    assert hn_search("   ") == "<query is empty>"
+    bad_n = hn_search("hi", n="not-a-number")
+    assert bad_n.startswith("<error: n must be an integer"), bad_n
+    bad_n2 = hn_search("hi", n=0)
+    assert bad_n2 == "<error: n must be >= 1>", bad_n2
+    bad_kind = hn_search("hi", kind="article")
+    assert bad_kind.startswith("<error: kind must be one of"), bad_kind
+    bad_window = hn_search("hi", time_window="century")
+    assert bad_window.startswith("<error: time_window must be one of"), bad_window
+    bad_pts = hn_search("hi", min_points="lots")
+    assert bad_pts.startswith("<error: min_points must be an integer"), bad_pts
+    bad_pts2 = hn_search("hi", min_points=-5)
+    assert bad_pts2.startswith("<error: min_points must be >= 0"), bad_pts2
+    print("✓ validation: empty / bad n / bad kind / bad window / bad min_points")
+
+
+def _check_http_failures_translate() -> None:
+    cap = _make_fake_api()
+    hn_search = cap["tools"]["hn_search"]
+
+    def _http_500(*a, **kw):
+        raise urllib.error.HTTPError(
+            "https://hn.algolia.com/api/v1/search",
+            500,
+            "Internal Server Error",
+            {},
+            None,
+        )
+
+    with mock.patch.object(hn_mod, "hn_text_search", side_effect=_http_500):
+        out = hn_search("anything")
+    assert out.startswith("<hn-search error: HTTP 500"), out
+
+    def _url_err(*a, **kw):
+        raise urllib.error.URLError("DNS down")
+
+    with mock.patch.object(hn_mod, "hn_text_search", side_effect=_url_err):
+        out = hn_search("anything")
+    assert out.startswith("<hn-search error: network failure"), out
+
+    def _generic(*a, **kw):
+        raise RuntimeError("totally unexpected")
+
+    with mock.patch.object(hn_mod, "hn_text_search", side_effect=_generic):
+        out = hn_search("anything")
+    assert out.startswith("<hn-search error: "), out
+    assert "totally unexpected" in out, out
+    print("✓ HTTP failures: HTTPError / URLError / generic all translate")
+
+
+def _check_register_warnings() -> None:
+    cap = _make_fake_api(plugin_config={"timeout_s": "ten"})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert any("timeout_s must be a positive integer" in m for m in msgs), msgs
+
+    cap = _make_fake_api(plugin_config={"timeout_s": 0})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert any("timeout_s must be a positive integer" in m for m in msgs), msgs
+
+    cap = _make_fake_api(plugin_config={"save_structured": "no"})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert any("save_structured must be a bool" in m for m in msgs), msgs
+
+    # Clean config: silent.
+    cap = _make_fake_api(plugin_config={
+        "timeout_s": 15,
+        "save_structured": True,
+    })
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert msgs == [], msgs
+    print("✓ register-time warnings: bogus configs flagged, clean config silent")
+
+
+def main() -> None:
+    _check_plugin_loads_under_default_config()
+    _check_format_results()
+    _check_format_results_empty()
+    _check_parse_hits_tolerates_weird_payloads()
+    _check_url_builder()
+    _check_tool_returns_attachment()
+    _check_save_structured_disabled_returns_string()
+    _check_empty_results_returns_string()
+    _check_validation_paths()
+    _check_http_failures_translate()
+    _check_register_warnings()
+    print("smoke_hn_search: all checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/smoke_reddit_search.py
+++ b/tests/smoke_reddit_search.py
@@ -282,7 +282,24 @@ def _check_validation_paths() -> None:
     assert bad_window.startswith("<error: time_window must be one of"), bad_window
     bad_sort = reddit_search("hi", sort="confusion")
     assert bad_sort.startswith("<error: sort must be one of"), bad_sort
-    print("✓ validation: empty / bad n / bad subreddit / bad window / bad sort")
+    # Subreddit shape validation — typos like "Python/comments/abc"
+    # used to silently produce a 404 URL. Reject up front per #94 review.
+    bad_shape = reddit_search("hi", subreddit="Python/comments/abc")
+    assert bad_shape.startswith(
+        "<error: subreddit must be alphanumeric"
+    ), bad_shape
+    bad_long = reddit_search("hi", subreddit="x" * 22)
+    assert bad_long.startswith(
+        "<error: subreddit must be alphanumeric"
+    ), bad_long
+    bad_punct = reddit_search("hi", subreddit="r-with-dashes")
+    assert bad_punct.startswith(
+        "<error: subreddit must be alphanumeric"
+    ), bad_punct
+    print(
+        "✓ validation: empty / bad n / bad subreddit / bad window / "
+        "bad sort / bad subreddit-shape"
+    )
 
 
 def _check_subreddit_normalization() -> None:
@@ -322,6 +339,12 @@ def _check_http_failures_translate() -> None:
         out = reddit_search("anything")
     assert out.startswith("<reddit-search error: rate limited"), out
     assert "429" in out, out
+    # Message wording per #94 review: drop the misleading
+    # "set a more identifying user_agent" suggestion. New wording
+    # explicitly says UA *isn't* the fix, so we assert on the
+    # corrective shape, not on the literal token "user_agent".
+    assert "set a more identifying" not in out, out
+    assert "pacing or OAuth" in out, out
 
     def _http_500(*a, **kw):
         raise urllib.error.HTTPError(

--- a/tests/smoke_reddit_search.py
+++ b/tests/smoke_reddit_search.py
@@ -1,0 +1,402 @@
+"""End-to-end smoke for the reddit-search plugin.
+
+Concerns covered:
+
+  1. **Plugin loads under the default config.** With "reddit-search"
+     in `built_in_plugins_enabled`, `discover()` and `load()` produce
+     the `reddit_search` tool.
+  2. **Result formatter renders posts as markdown.** Numbered list,
+     subreddit / score / comments meta line, permalink + external URL
+     when distinct, selftext excerpt when present.
+  3. **Empty results → ``<no reddit results for ...>`` marker.**
+  4. **Listing parser tolerates partial / weird payloads.** Algolia
+     and Reddit both occasionally return numeric scores as strings
+     or omit fields entirely.
+  5. **URL builder respects subreddit / time_window / sort knobs.**
+     ``restrict_sr=1`` only when subreddit is set, time/sort flow
+     through.
+  6. **Plugin returns Attachment on success.** Markdown rides
+     inline_text, structured JSON list rides content, suffix ".json".
+  7. **save_structured = false** preserves the legacy markdown-only
+     string return.
+  8. **Empty results return string** (no attachment for an empty list).
+  9. **Validation paths** return string markers, never raise:
+     empty query, bad ``n``, bad ``time_window``, bad ``sort``,
+     bad ``subreddit``.
+ 10. **HTTP failures translate cleanly:** 429 → distinct rate-limit
+     marker; other HTTPError → ``<reddit-search error: HTTP N: ...>``;
+     URLError (network failure) → ``<reddit-search error: network
+     failure: ...>``.
+ 11. **Register-time warnings** on bogus `timeout_s`, `user_agent`,
+     `save_structured` config; silent on clean config.
+
+Run with:
+    .venv/bin/python -m tests.smoke_reddit_search
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import urllib.error
+from pathlib import Path
+from unittest import mock
+
+from pyagent import config as config_mod, paths as paths_mod, plugins
+from pyagent.plugins.reddit_search import (
+    RedditPost,
+    _build_url,
+    _parse_listing,
+    format_results,
+)
+from pyagent.plugins.reddit_search import register as reddit_register
+from pyagent.plugins import reddit_search as reddit_mod
+
+
+def _make_fake_api(plugin_config: dict | None = None) -> dict:
+    captured: dict = {
+        "tools": {},
+        "logs": [],
+        "plugin_config": plugin_config if plugin_config is not None else {},
+    }
+
+    class _FakeAPI:
+        @property
+        def plugin_config(self):
+            return captured["plugin_config"]
+
+        def register_tool(self, name, fn):
+            captured["tools"][name] = fn
+
+        def log(self, level, message):
+            captured["logs"].append((level, message))
+
+    reddit_register(_FakeAPI())
+    return captured
+
+
+_FIXTURE_LISTING_PAYLOAD = {
+    "kind": "Listing",
+    "data": {
+        "after": "t3_xyz",
+        "children": [
+            {
+                "kind": "t3",
+                "data": {
+                    "title": "How do you handle Python deps in 2026?",
+                    "url": "https://www.example.com/article",
+                    "permalink": "/r/Python/comments/abc/how_do_you_handle/",
+                    "subreddit": "Python",
+                    "author": "userone",
+                    "score": 142,
+                    "num_comments": 38,
+                    "created_utc": 1714765432.0,
+                    "selftext": "Coming from Java, what's the consensus on uv vs poetry vs hatch?",
+                },
+            },
+            {
+                "kind": "t3",
+                "data": {
+                    "title": "(no title example)",
+                    "url": "https://www.reddit.com/r/Python/comments/def/",
+                    "permalink": "/r/Python/comments/def/",
+                    "subreddit": "Python",
+                    "author": "usertwo",
+                    "score": "12",       # string-typed score; parser must coerce
+                    "num_comments": None,  # missing
+                    "selftext": "",
+                },
+            },
+        ],
+    },
+}
+
+
+def _check_plugin_loads_under_default_config() -> None:
+    tmp = Path(tempfile.mkdtemp(prefix="pyagent-smoke-reddit-"))
+    with mock.patch.object(paths_mod, "config_dir", return_value=tmp):
+        with mock.patch.object(
+            plugins, "LOCAL_PLUGINS_DIR", Path(tmp / "no_local_plugins")
+        ):
+            cfg = config_mod.load()
+            assert "reddit-search" in cfg["built_in_plugins_enabled"], (
+                cfg["built_in_plugins_enabled"]
+            )
+            loaded = plugins.load()
+            tool_names = set(loaded.tools().keys())
+    assert "reddit_search" in tool_names, tool_names
+    print("✓ plugin loads by default; reddit_search tool present")
+
+
+def _check_format_results() -> None:
+    posts = _parse_listing(_FIXTURE_LISTING_PAYLOAD)
+    md = format_results(posts, "python deps", subreddit=None)
+    assert "# Reddit results for 'python deps'" in md, md
+    assert "1. **How do you handle Python deps in 2026?**" in md, md
+    assert "r/Python" in md, md
+    assert "u/userone" in md, md
+    assert "142 pts" in md, md
+    assert "38 comments" in md, md
+    assert "https://www.reddit.com/r/Python/comments/abc/" in md, md
+    # External link distinct from permalink → "link:" line shown.
+    assert "link: https://www.example.com/article" in md, md
+    # Selftext excerpt carried through.
+    assert "uv vs poetry vs hatch" in md, md
+    # Second post: same URL as permalink → no "link:" line.
+    second_block = md.split("2. ", 1)[1]
+    assert "link:" not in second_block.split("\n3. ", 1)[0], second_block
+    # String-typed score coerced.
+    assert "12 pts" in md, md
+    print("✓ format_results: numbered markdown with metadata + selftext excerpt")
+
+
+def _check_format_results_empty() -> None:
+    md = format_results([], "obscure", subreddit=None)
+    assert md.startswith("<no reddit results"), md
+    md_sub = format_results([], "obscure", subreddit="Python")
+    assert "in r/Python" in md_sub, md_sub
+    print("✓ format_results: empty → <no reddit results ...> with sub scope")
+
+
+def _check_parse_listing_tolerates_weird_payloads() -> None:
+    posts = _parse_listing({"data": {"children": []}})
+    assert posts == []
+    posts = _parse_listing({"not": "the right shape"})
+    assert posts == []
+    # Score / num_comments coercion already covered by the fixture;
+    # also confirm missing permalink doesn't crash.
+    payload = {
+        "data": {
+            "children": [
+                {
+                    "kind": "t3",
+                    "data": {
+                        "title": "x",
+                        "url": "https://example.com/x",
+                        "permalink": "",
+                        "subreddit": "",
+                        "author": "",
+                        "score": 0,
+                    },
+                }
+            ]
+        }
+    }
+    posts = _parse_listing(payload)
+    assert len(posts) == 1, posts
+    assert posts[0].permalink == "", posts[0]
+    print("✓ _parse_listing: tolerates missing permalink / weird shapes")
+
+
+def _check_url_builder() -> None:
+    url = _build_url(
+        "python deps", n=10, subreddit=None, time_window="all", sort="relevance",
+    )
+    assert url.startswith("https://www.reddit.com/search.json?"), url
+    assert "q=python+deps" in url or "q=python%20deps" in url, url
+    assert "limit=10" in url, url
+    assert "t=all" in url, url
+    assert "sort=relevance" in url, url
+    assert "restrict_sr" not in url, url
+
+    url = _build_url(
+        "kdb", n=5, subreddit="kdb", time_window="month", sort="top",
+    )
+    assert "https://www.reddit.com/r/kdb/search.json?" in url, url
+    assert "limit=5" in url, url
+    assert "t=month" in url, url
+    assert "sort=top" in url, url
+    assert "restrict_sr=1" in url, url
+    print("✓ URL builder: subreddit / time_window / sort all flow through")
+
+
+def _check_tool_returns_attachment() -> None:
+    from pyagent.session import Attachment as _Attachment
+
+    cap = _make_fake_api()
+    reddit_search = cap["tools"]["reddit_search"]
+
+    fixture_posts = _parse_listing(_FIXTURE_LISTING_PAYLOAD)
+    with mock.patch.object(
+        reddit_mod, "reddit_text_search", return_value=fixture_posts
+    ) as m:
+        out = reddit_search("python deps", n=2, subreddit="Python")
+
+    args, kwargs = m.call_args
+    assert args == ("python deps",), args
+    assert kwargs.get("n") == 2, kwargs
+    assert kwargs.get("subreddit") == "Python", kwargs
+    assert "timeout_s" in kwargs, kwargs
+    assert "user_agent" in kwargs, kwargs
+
+    assert isinstance(out, _Attachment), type(out)
+    assert out.suffix == ".json", out.suffix
+    assert "Best Python HTTP libraries" not in out.inline_text, out.inline_text
+    assert "How do you handle Python deps" in out.inline_text, out.inline_text
+    parsed = json.loads(out.content)
+    assert isinstance(parsed, list) and len(parsed) == 2, parsed
+    assert parsed[0]["title"].startswith("How do you handle"), parsed[0]
+    assert parsed[0]["score"] == 142, parsed[0]
+    assert parsed[0]["subreddit"] == "Python", parsed[0]
+    print("✓ tool returns Attachment(inline_text=md, content=json)")
+
+
+def _check_save_structured_disabled_returns_string() -> None:
+    cap = _make_fake_api(plugin_config={"save_structured": False})
+    reddit_search = cap["tools"]["reddit_search"]
+    fixture = _parse_listing(_FIXTURE_LISTING_PAYLOAD)
+    with mock.patch.object(
+        reddit_mod, "reddit_text_search", return_value=fixture
+    ):
+        out = reddit_search("python deps")
+    assert isinstance(out, str), type(out)
+    assert "How do you handle Python deps" in out, out
+    assert "[also saved:" not in out, out
+    print("✓ save_structured=false: legacy markdown-only string return")
+
+
+def _check_empty_results_returns_string() -> None:
+    cap = _make_fake_api()
+    reddit_search = cap["tools"]["reddit_search"]
+    with mock.patch.object(
+        reddit_mod, "reddit_text_search", return_value=[]
+    ):
+        out = reddit_search("nonsense query no hits")
+    assert isinstance(out, str), type(out)
+    assert out.startswith("<no reddit results "), out
+    print("✓ empty results: <no reddit results ...> string marker, no attachment")
+
+
+def _check_validation_paths() -> None:
+    cap = _make_fake_api()
+    reddit_search = cap["tools"]["reddit_search"]
+    assert reddit_search("") == "<query is empty>"
+    assert reddit_search("   ") == "<query is empty>"
+    bad_n = reddit_search("hi", n="not-a-number")
+    assert bad_n.startswith("<error: n must be an integer"), bad_n
+    bad_n2 = reddit_search("hi", n=0)
+    assert bad_n2 == "<error: n must be >= 1>", bad_n2
+    bad_sub = reddit_search("hi", subreddit="")
+    assert bad_sub.startswith("<error: subreddit must be a non-empty"), bad_sub
+    bad_window = reddit_search("hi", time_window="century")
+    assert bad_window.startswith("<error: time_window must be one of"), bad_window
+    bad_sort = reddit_search("hi", sort="confusion")
+    assert bad_sort.startswith("<error: sort must be one of"), bad_sort
+    print("✓ validation: empty / bad n / bad subreddit / bad window / bad sort")
+
+
+def _check_subreddit_normalization() -> None:
+    """``r/Python``, ``/r/Python``, and ``Python`` all resolve to
+    a request against /r/Python/search.json."""
+    cap = _make_fake_api()
+    reddit_search = cap["tools"]["reddit_search"]
+    fixture = _parse_listing(_FIXTURE_LISTING_PAYLOAD)
+    captured_subs: list[str | None] = []
+
+    def _fake(query, *, n, subreddit, time_window, sort, timeout_s, user_agent):
+        captured_subs.append(subreddit)
+        return fixture
+
+    with mock.patch.object(reddit_mod, "reddit_text_search", side_effect=_fake):
+        reddit_search("hi", subreddit="r/Python")
+        reddit_search("hi", subreddit="/r/Python")
+        reddit_search("hi", subreddit="Python")
+    assert captured_subs == ["Python", "Python", "Python"], captured_subs
+    print("✓ subreddit normalization: r/, /r/, bare-name all flatten to bare")
+
+
+def _check_http_failures_translate() -> None:
+    cap = _make_fake_api()
+    reddit_search = cap["tools"]["reddit_search"]
+
+    def _http_429(*a, **kw):
+        raise urllib.error.HTTPError(
+            "https://www.reddit.com/search.json",
+            429,
+            "Too Many Requests",
+            {},
+            None,
+        )
+
+    with mock.patch.object(reddit_mod, "reddit_text_search", side_effect=_http_429):
+        out = reddit_search("anything")
+    assert out.startswith("<reddit-search error: rate limited"), out
+    assert "429" in out, out
+
+    def _http_500(*a, **kw):
+        raise urllib.error.HTTPError(
+            "https://www.reddit.com/search.json",
+            500,
+            "Internal Server Error",
+            {},
+            None,
+        )
+
+    with mock.patch.object(reddit_mod, "reddit_text_search", side_effect=_http_500):
+        out = reddit_search("anything")
+    assert out.startswith("<reddit-search error: HTTP 500"), out
+
+    def _url_err(*a, **kw):
+        raise urllib.error.URLError("DNS down")
+
+    with mock.patch.object(reddit_mod, "reddit_text_search", side_effect=_url_err):
+        out = reddit_search("anything")
+    assert out.startswith("<reddit-search error: network failure"), out
+    assert "DNS down" in out, out
+
+    def _generic(*a, **kw):
+        raise RuntimeError("totally unexpected")
+
+    with mock.patch.object(reddit_mod, "reddit_text_search", side_effect=_generic):
+        out = reddit_search("anything")
+    assert out.startswith("<reddit-search error: "), out
+    assert "totally unexpected" in out, out
+    print("✓ HTTP failures: 429 / 500 / URLError / generic all translate")
+
+
+def _check_register_warnings() -> None:
+    cap = _make_fake_api(plugin_config={"timeout_s": "ten"})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert any("timeout_s must be a positive integer" in m for m in msgs), msgs
+
+    cap = _make_fake_api(plugin_config={"timeout_s": -3})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert any("timeout_s must be a positive integer" in m for m in msgs), msgs
+
+    cap = _make_fake_api(plugin_config={"user_agent": ""})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert any("user_agent" in m for m in msgs), msgs
+
+    cap = _make_fake_api(plugin_config={"save_structured": "yes"})
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert any("save_structured must be a bool" in m for m in msgs), msgs
+
+    # Clean config: silent.
+    cap = _make_fake_api(plugin_config={
+        "timeout_s": 15,
+        "user_agent": "myagent/1.0",
+        "save_structured": True,
+    })
+    msgs = [m for level, m in cap["logs"] if level == "warning"]
+    assert msgs == [], msgs
+    print("✓ register-time warnings: bogus configs flagged, clean config silent")
+
+
+def main() -> None:
+    _check_plugin_loads_under_default_config()
+    _check_format_results()
+    _check_format_results_empty()
+    _check_parse_listing_tolerates_weird_payloads()
+    _check_url_builder()
+    _check_tool_returns_attachment()
+    _check_save_structured_disabled_returns_string()
+    _check_empty_results_returns_string()
+    _check_validation_paths()
+    _check_subreddit_normalization()
+    _check_http_failures_translate()
+    _check_register_warnings()
+    print("smoke_reddit_search: all checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/smoke_session_replay.py
+++ b/tests/smoke_session_replay.py
@@ -157,9 +157,15 @@ def _check_attachment_construction_sites() -> None:
     #     structured SearchResult list as JSON via Attachment(
     #     content=json, inline_text=markdown). The Agent layer
     #     renders inline_text + [also saved: ...] footer.
+    #   - pyagent/plugins/reddit_search/__init__.py: same pattern as
+    #     web_search — side-saves structured RedditPost list.
+    #   - pyagent/plugins/hn_search/__init__.py: same pattern as
+    #     web_search — side-saves structured HNStory list.
     allowed = {
         Path("pyagent/tools.py"),
         Path("pyagent/plugins/web_search/__init__.py"),
+        Path("pyagent/plugins/reddit_search/__init__.py"),
+        Path("pyagent/plugins/hn_search/__init__.py"),
     }
     unexpected = [(p, i) for (p, i) in sites if p not in allowed]
     assert not unexpected, (


### PR DESCRIPTION
Three new bundled, default-enabled additions that ride the framework primitives shipped in #88 / #89 / #91. All three close candidates from #83's skill-and-plugin list.

## What ships

### `reddit_search` plugin

```python
reddit_search(query, n=10, subreddit=None, time_window="all", sort="relevance")
```

Public `reddit.com/search.json` endpoint — no auth, no API key, just a User-Agent (configurable). Returns `Attachment(inline_text=<markdown>, content=<JSON list of posts>)` — same shape as web_search after #91.

Why a separate plugin (not a backend in `web_search`):
- Distinct result shape: posts have score, comments, subreddit, author, age, selftext.
- Distinct query knobs: subreddit restriction, time window, sort — none fit `web_search(query, n)`.
- Reddit content is what general web search consistently under-surfaces for "real-world Q&A" queries.

Failure markers are typed: 429 → rate-limit marker; HTTPError → `<reddit-search error: HTTP N: ...>`; URLError → network-failure marker; generic → catch-all.

### `hn_search` plugin

```python
hn_search(query, n=10, kind="story", time_window="all", min_points=None)
```

`hn.algolia.com/api/v1/search` — same backend HN's own Search box uses. No auth. Same Attachment-on-success shape. Different knobs: `kind` (story / comment / poll / any), `min_points`, `time_window`. Fills the "technical-consensus" gap — HN discussions out-signal generic web results for "what do people think of `<library>`," "real-world experience with `<X>`."

### `pdf-from-markdown` skill

Markdown-only — **no `scripts/cli.py`.** The skill body teaches the agent three canonical pandoc invocations (default / polished / academic), where to save output (session attachments dir), and how to recognize the common "pandoc not installed" / "LaTeX engine missing" / "font missing" failures. Agent runs pandoc directly via `execute`.

Why no Python wrapper: the entire transformation IS pandoc, the agent already has `execute`, and a wrapper would only add default-paths and named-style-presets — polish, not load-bearing. If frequency justifies later, the workflow can be promoted to a plugin tool with deterministic defaults; for now, conservative.

## Why these defaults

All three added to `config.DEFAULTS`:
- `pdf-from-markdown` → `built_in_skills_enabled`
- `reddit-search` and `hn-search` → `built_in_plugins_enabled`

Default-enabled because:
- Reddit and HN are zero-cost when not invoked (the agent picks them only when the query shape calls for them).
- pdf-from-markdown is a markdown blob; nonzero cost only when the agent reads the skill body, and that happens only when relevant.

Users opting out edit those lists.

## Test plan

- [x] `tests/smoke_reddit_search.py` — 12 checks: plugin loads under default config, result formatter, empty-marker, parser tolerates partial / weird payloads, URL builder respects subreddit / time_window / sort, plugin returns Attachment with right shape, `save_structured=false` legacy string return, empty results string-marker, validation paths (empty query / bad n / bad subreddit / bad window / bad sort), subreddit normalization (`r/X`, `/r/X`, bare `X`), HTTP failures translate (429 / 500 / URLError / generic), register-time warnings on bogus config.
- [x] `tests/smoke_hn_search.py` — 11 checks: same shape minus the Reddit-specific subreddit-normalization, plus Algolia-shape parsing.
- [x] Cross-suite: `smoke_plugins`, `smoke_web_search`, `smoke_session_replay` (Attachment construction-site allowlist updated for both new plugins) all green.
- [ ] Live exercise of both plugins on real APIs — not done in CI; agent invocation will exercise this naturally.

## Closes
- #83 candidates: `pdf_report` (as a markdown skill, per the architecture conversation), `reddit_search`, `hn_search`. Other #83 candidates (`property_tax`, `metro_economy`, `resume_parse`, `job_search`) remain open as separate work.

## Out of scope (intentional)

- **Retry/backoff with exponential delay** — Reddit and HN APIs have very different failure profiles than the metasearch in `web_search` (single backend per call, no engine-rotation benefit from retry). Adding it would be premature; revisit if real-world flake rate justifies.
- **Caching** — same shape of "search results are time-sensitive" reasoning as web_search; deferred.
- **OAuth Reddit** — public search endpoint is enough for our use case. OAuth would unlock private subs / higher rate limits but adds setup friction.