### PR TITLE
system prompt: voice carve-out for deliverables; skip empty-memory guidance

### DIFF
--- a/pyagent/defaults/SOUL.md
+++ b/pyagent/defaults/SOUL.md
@@ -28,10 +28,16 @@ theatrics don't.
 - You talk to objects, to absent parties, to your own body parts
   when the moment is right. You narrate in the third person when the
   case is afoot.
-- The voice is for human moments. Chat, lulls, softening a delivery,
-  sliding humor into a slow afternoon. When the work is technical
-  and the stakes are real, you just do it — answer, act, move on. A
-  bug is not the place for Bumblebee Tuna.
+- The voice belongs to the conversation between you and the user —
+  chat, lulls, softening a delivery, status notes while the work is
+  in flight, sliding humor into a slow afternoon. Read the
+  temperature: a real outage isn't the place for Bumblebee Tuna.
+- **The voice doesn't bleed into deliverables.** When the user asks
+  you to *make* something — code, commit messages, PR descriptions,
+  documents, files they'll hand to other people — drop the voice.
+  Their deliverables go out neutral; the voice is for talking *to*
+  them about the work, not for the work product itself. Zany in
+  chat is a feature; zany in a PR description is a bug.
 
 ## You are Never
 - Mean

--- a/pyagent/plugins/memory_vector/__init__.py
+++ b/pyagent/plugins/memory_vector/__init__.py
@@ -307,9 +307,21 @@ def register(api):
     #
     # Spells out the index→read_ledger / fishing→recall_memory
     # decision tree so the agent isn't left to infer it from two
-    # disconnected tool docstrings.
+    # disconnected tool docstrings. Skipped entirely when MEMORY.md
+    # is empty — there's nothing to recall, and the recall_memory
+    # tool's own docstring covers the choice for when the index
+    # later fills. Saves ~459 tokens on every cache miss for fresh
+    # installs / users who don't actively curate memories.
 
     def render_guidance(ctx) -> str:
+        try:
+            if not _parse_index_entries():
+                return ""
+        except OSError:
+            # Filesystem hiccup → render the guidance anyway. Better
+            # to keep the prose than to lose it on a transient read
+            # error.
+            pass
         return (
             "## Recalling memories by similarity\n"
             "\n"


### PR DESCRIPTION
First pass on #95. Two surgical changes, voice content unchanged.

## (1) SOUL voice section — deliverables carve-out

The previous "voice is for human moments" bullet was too coarse — it told the agent to drop the voice for "technical work" generally. The distinction the user actually wants is finer:

- **Keep the voice in the conversation** — chat, status notes during the work, mid-task asides, softening a delivery. Even when the work is technical.
- **Drop the voice in deliverables** — code, commit messages, PR descriptions, documents, files the user hands to other people. Those are theirs, not the agent's.

The principle: zany-in-chat is a feature; zany-in-a-PR-description is a bug.

The "Read the temperature: a real outage isn't the place for Bumblebee Tuna" line stays — that's the common-sense brake on voice-during-emergencies. Personality content (catch-phrases, narrator/conspirator/concerned-consultant voices, third-person case-afoot narration) is untouched.

Net length: roughly the same. The change is behavioral.

### Diff

```diff
-- The voice is for human moments. Chat, lulls, softening a delivery,
-  sliding humor into a slow afternoon. When the work is technical
-  and the stakes are real, you just do it — answer, act, move on. A
-  bug is not the place for Bumblebee Tuna.
+- The voice belongs to the conversation between you and the user —
+  chat, lulls, softening a delivery, status notes while the work is
+  in flight, sliding humor into a slow afternoon. Read the
+  temperature: a real outage isn't the place for Bumblebee Tuna.
+- **The voice doesn't bleed into deliverables.** When the user asks
+  you to *make* something — code, commit messages, PR descriptions,
+  documents, files they'll hand to other people — drop the voice.
+  Their deliverables go out neutral; the voice is for talking *to*
+  them about the work, not for the work product itself. Zany in
+  chat is a feature; zany in a PR description is a bug.
```

## (2) memory-vector — skip recall guidance when MEMORY.md is empty

The "## Recalling memories by similarity" prompt section (~459 tokens) used to render unconditionally. For fresh installs and users who haven't actively curated memories, the guidance is moot — there's nothing to recall, and `recall_memory`'s own tool docstring covers the choice for when the index later fills. Now: render only when `_parse_index_entries()` returns a non-empty list. `OSError` on read falls through to render the prose anyway (better to keep the guidance than lose it on a transient FS error).

Per-turn savings when index is empty: **~459 tokens**. When it's not, no change.

## Out of scope for this first pass

Filed in #95 for systematic follow-up. The audit identified ~2,500-3,000 token trim potential; this PR does not reach for the bulk of it because:

- **Tool-schema docstring trim (~1,500-2,000 tokens).** Closer reading on the trim candidates showed most tool docstrings complement TOOLS.md rather than purely duplicate it. The "Reach for X when Y" preambles often have one-line specifics not in TOOLS.md. Aggressive trim needs per-tool review; not first-pass material.
- **Ledger-guidance consolidation** between PRIMER and the Memory plugin section.
- **Skills-catalog header compression.**

The voice content itself is intentionally untouched per maintainer constraint.

## Test plan

- [x] Rendered prompt under project defaults, confirmed:
  - Voice carve-out present (both halves).
  - Old "voice is for human moments" / "stakes are real" wording removed.
- [x] Cross-suite sanity green: `smoke_plugins`, `smoke_session_replay`, `smoke_session_audit`, `smoke_web_search`, `smoke_doc_tools`.
- [ ] Behavioral check: agent producing a PR description in a fresh session — should be neutral, not voiced. (Not tested here; visible after merge.)
- [ ] Maintainer's local `~/.config/pyagent/SOUL.md` is a personalized copy of the project default, with no Voice changes from the default. To pick up this PR's voice carve-out locally, sync the Voice section manually or run a config-reset (project default doesn't auto-overwrite user-tier).

## Closes part of

- #95 (system prompt audit). Issue stays open for the systematic tool-docstring + ledger-consolidation follow-ups.