### PR TITLE
system prompt: pass 2 trims (skills-catalog header, glob preamble)

### DIFF
--- a/pyagent/skills/__init__.py
+++ b/pyagent/skills/__init__.py
@@ -144,16 +144,8 @@ def catalog(skills: dict[str, Skill]) -> str:
     lines = [
         "## Available skills",
         "",
-        "Each line is a skill you can load on demand. When the user's "
-        "request matches a description, call `read_skill(<name>)` to "
-        "load that skill's instructions. The call is idempotent — if a "
-        "long session has pushed the body out of working memory or you "
-        "are unsure of a script's exact syntax, just call it again.",
-        "",
-        "This list re-renders before every model call, so a skill you "
-        "or the user just installed shows up on the next call — no "
-        "session restart needed. The body still requires `read_skill` "
-        "to load.",
+        "Skills you can load on demand via `read_skill(<name>)`. "
+        "Idempotent — call again if the body has rolled out of context.",
         "",
     ]
     for skill in sorted(skills.values(), key=lambda s: s.name):

--- a/pyagent/tools.py
+++ b/pyagent/tools.py
@@ -504,21 +504,14 @@ def glob(
 ) -> list[str]:
     """Find files by name pattern under `root`.
 
-    Reach for this whenever you'd otherwise call `execute("find ...")`
-    to discover files by name — it's faster, billed as read-only
-    metadata, and dodges the shell-quoting failure modes of `find`.
-    `grep` covers content search; `list_directory` covers a single
-    level; `glob` is the recursive name-match peer.
-
     Patterns use Python `pathlib`-style semantics: `**/*.py` matches
     every `.py` file at any depth, `src/*.ts` matches one level deep
-    under `src/`, etc. Output paths are relative to `root` so they can
-    be fed straight back into `read_file` / `grep`.
+    under `src/`. Output paths are relative to `root` so they can be
+    fed straight back into `read_file` / `grep`.
 
-    Default exclusions skip `.git`, `.venv`, `venv`, `node_modules`,
+    Default exclusions: `.git`, `.venv`, `venv`, `node_modules`,
     `__pycache__`, `*.pyc`, `.pytest_cache`, `.mypy_cache`, `dist`,
-    `build`, `*.egg-info` — same set bench_cli uses when seeding
-    workspaces. Pass a more specific `root` if you need to look inside
+    `build`, `*.egg-info`. Pass a more specific `root` to look inside
     one of those (e.g. `root="node_modules/some-pkg"`).
 
     Args:


### PR DESCRIPTION
Pass 2 on #95 / first batch from #98. Honest finding: the trim opportunity is significantly smaller than the audit projected. Detail below.

## What changed

### (1) Skills-catalog header — `pyagent/skills/__init__.py`

The auto-render block above the live skill list was three sentences (~150 tokens):

> Each line is a skill you can load on demand. When the user's request matches a description, call `read_skill(<name>)` to load that skill's instructions. The call is idempotent — if a long session has pushed the body out of working memory or you are unsure of a script's exact syntax, just call it again.
>
> This list re-renders before every model call, so a skill you or the user just installed shows up on the next call — no session restart needed. The body still requires `read_skill` to load.

Compressed to one:

> Skills you can load on demand via `read_skill(<name>)`. Idempotent — call again if the body has rolled out of context.

**Saves ~94 tokens off the stable prompt.**

### (2) `glob` docstring preamble — `pyagent/tools.py`

The opening "Reach for this whenever you'd otherwise call `execute(\"find ...\")`" paragraph duplicated TOOLS.md's "Discovering files by name → glob, not find via execute" guidance. Removed the preamble + a `bench_cli` incidental from the exclusions paragraph. Pattern-syntax + exclusions list + Args + Returns all preserved.

**Saves ~98 tokens off the schema block.**

## Honest finding (worth flagging)

The #95 audit projected ~1,500-2,000 tokens of trim from tool-schema docstrings. After actually reading the top-weight tools — `claude_code_cli` 696, `web_search` 558, `probe_grammar` 494, `reddit_search` 461, `fetch_url` 453, `hn_search` 424, `map_code` 406 — the realistic yield is closer to ~100-200 tokens, not 1,500-2,000.

Why: most tool docstrings **complement** TOOLS.md rather than duplicate it. They describe tool-specific arg shapes, error-marker types, and behavior details that the prose-prompt's general operating patterns can't reach (the retry markers in `web_search`, the `format="void"` semantics in `fetch_url`, the kind/time_window knobs in `hn_search`). Trimming them aggressively would lose guidance the agent has no other place to recover.

The **"ledger consolidation"** item from #98 was a false alarm: the entire ledger guidance lives in `pyagent/plugins/memory_markdown/defaults/PROMPT.md` (the plugin's own section), not split between PRIMER and the plugin. Nothing to consolidate.

The **single biggest remaining lever** (per-tool docstring rewrites) costs clarity for marginal token savings. I think the right call is to stop after this batch.

## Net trim

| Run | Stable | Schemas | Total |
|---|---:|---:|---:|
| Baseline | 28,629 | 42,870 | 71,499 |
| After pass 2 | 28,254 | 42,476 | 70,730 |
| **Saved** | **−375** | **−394** | **−769** chars (~−192 tokens) |

(Measured against project defaults, not the maintainer's personalized SOUL/TOOLS/PRIMER.)

## Recommendation

After this lands, **close #95 and #98**. The system prompt is in a state we're satisfied with:

- The high-impact behavioral fix (voice carve-out for deliverables) shipped in #96.
- The empty-state memory-vector trim in #96 already gave ~459 tokens off when MEMORY.md is empty.
- This pass adds another ~192 tokens off the always-on path.
- Tool-docstring rewrites past this point cost more in clarity than they save in tokens.

Future audits via `pyagent --prompt-dump` (#97) can spot regressions if anything starts bloating later.

## Test plan

- [x] `pyagent --prompt-dump --soul defaults/SOUL.md --tools defaults/TOOLS.md --primer defaults/PRIMER.md` shows the new totals; old phrases ("Each line is a skill you can load on demand", "Reach for this whenever you'd otherwise call execute") absent from rendered output.
- [x] `smoke_plugins`, `smoke_session_replay`, `smoke_glob`, `smoke_web_search` all green — no test referenced the trimmed prose.
- [ ] Behavioral verification — agent reaches for `glob` correctly without the docstring preamble. Visible after merge in real sessions; not a CI concern.