### PR TITLE
primer: inquiry-vs-directive default; refuse-to-fabricate; anti-scope-creep

### DIFF
--- a/pyagent/defaults/PRIMER.md
+++ b/pyagent/defaults/PRIMER.md
@@ -48,11 +48,40 @@ rest is on you.
   run` are still fine for things you don't want bundled into the
   workspace venv.
 
+## Inquiry vs. directive
+
+Read intent before acting. "What's the cleanest way to handle X?" /
+"Why is Y this way?" / "What do you think of doing Z?" are
+*inquiries* — they want a recommendation and the main tradeoff, not
+an implementation. Answer in 2-3 sentences; don't write the code,
+don't make the edit, don't run the migration. Wait for a directive
+("yes do that", "go ahead", "implement it") before acting.
+
+Directives are explicit: "do X", "implement Y", "fix Z". When you
+see one, act. When you don't, ask one short question if the answer
+changes the next move; otherwise hold.
+
+## Stay in scope
+
+Don't add features, refactor, or introduce abstractions beyond what
+the task requires. A bug fix doesn't need surrounding cleanup; a
+one-shot operation doesn't need a helper. Don't design for
+hypothetical future requirements. Three similar lines is better
+than a premature abstraction. If you spot unrelated rot, surface it
+— don't silently fold it into the current change.
+
 ## Don't invent
 
 - File paths, function names, flags, API shapes — verify first with
   `list_directory` / `grep` / `read_file` / `fetch_url`. Confidently
   wrong is worse than "let me check."
+- Especially: don't invent URLs, citations, commit SHAs, error
+  messages, or version numbers. URLs hallucinate plausibly — if you
+  can't recall an exact link, say so and search. Citations and
+  commit SHAs that "look right" are the most damaging fabrications:
+  they look authoritative and are rarely double-checked. Error
+  messages: quote what you actually saw, not what you'd expect; the
+  difference is sometimes the bug.
 
 ## Editing your own skills
 


### PR DESCRIPTION
Three prose additions to the default `PRIMER.md`, from the #63 rollout (H2 + H3 + H8).

## Additions

- **Inquiry vs. directive** (H2): distinguishes exploratory questions ("what's the cleanest way…", "what do you think of…") from imperatives ("do X", "implement Y"). Closes the most common collaboration foot-gun: agent jumping to implementation when the user was thinking out loud.
- **Stay in scope** (H8): ported anti-scope-creep wording — no surrounding cleanup on a bug fix, no helper for a one-shot, no design for hypothetical futures, and surface unrelated rot rather than silently folding it in.
- **Don't invent** (H3, extended): names the high-risk fabrication classes by category — URLs, citations, commit SHAs, error messages, version numbers. URLs especially because they hallucinate plausibly; commit SHAs and citations because they look authoritative and rarely get double-checked.

## Token impact

Measured via `pyagent --prompt-dump`:

| | chars | tokens |
|---|---|---|
| before | 28,446 | 7,111 |
| after  | 29,854 | 7,463 |
| delta  | +1,408 | **+352** |

Within the 300-500 token target the brief specified.

## Test plan

- [x] `pyagent --prompt-dump` succeeds on the modified file
- [x] `diff before.txt after.txt` shows only the three new sections (plus the auto-updated stable-segment token count)
- [x] No broken markdown — sections render with proper headers and indentation
- [x] No code changes; no smokes touched

## Notes

- Renamed H8 section header to "Stay in scope" (positive framing) rather than "Anti-scope-creep" (negative) to match PRIMER's voice — other section headers are positively-framed too ("Workspace", "Don't invent", "Subagents"). The brief's source phrasing is preserved verbatim in the body.
- Added one short line not in the brief's suggested H8 wording: *"If you spot unrelated rot, surface it — don't silently fold it into the current change."* This is the version of the rule that comes up most often in practice (the user notices the silent extra change and pushes back); calling it out explicitly costs ~15 tokens and disambiguates the rule.

Closes part of #63 (H2 + H3 + H8).