### PR TITLE
grep: support before/after/context lines for one-shot context retrieval

### DIFF
--- a/pyagent/tools.py
+++ b/pyagent/tools.py
@@ -430,7 +430,14 @@ def list_directory(path: str) -> list[str]:
     return sorted(f"{e.name}/" if e.is_dir() else e.name for e in entries)
 
 
-def grep(pattern: str, path: str) -> list[str]:
+def grep(
+    pattern: str,
+    path: str,
+    *,
+    before: int = 0,
+    after: int = 0,
+    context: int = 0,
+) -> list[str]:
     """Search for a regex pattern in a file or directory tree.
 
     First reach for any "where does X appear?" question — cheaper than
@@ -439,13 +446,50 @@ def grep(pattern: str, path: str) -> list[str]:
     Output line numbers match `read_file`'s `start`/`end` so you can
     pipe a hit into a targeted read.
 
+    With `before` / `after` / `context` set, surrounding lines come
+    back in the same call so you don't need a follow-up `read_file`.
+    Semantics mirror GNU `grep`'s `-B` / `-A` / `-C`: `context=N` is
+    shorthand for `before=N, after=N`; an explicit non-zero `before`
+    or `after` overrides the corresponding side of `context`.
+
+    Output uses GNU-grep's separator convention: matched lines stay
+    `path:lineno:line` (colon), while context lines use a dash —
+    `path:lineno-line`. Adjacent matches whose context windows touch
+    or overlap collapse into one contiguous excerpt with no duplicate
+    lines. When context is non-zero, runs of output from the same
+    file are separated by a `--` line.
+
     Args:
         pattern: Regex pattern to search for.
         path: File or directory to search.
+        before: Number of lines of leading context per match.
+        after: Number of lines of trailing context per match.
+        context: Shorthand for `before=N, after=N`. Explicit `before`
+            / `after` win when both are non-zero.
 
     Returns:
-        List of matches formatted as "path:lineno:line".
+        List of matches. Without context: `path:lineno:line` per match.
+        With context: matches keep the colon, surrounding lines use a
+        dash, and same-file runs are separated by `--`.
     """
+    try:
+        before_i = int(before)
+        after_i = int(after)
+        context_i = int(context)
+    except (TypeError, ValueError):
+        return [
+            f"<error: before/after/context must be integers, got "
+            f"before={before!r}, after={after!r}, context={context!r}>"
+        ]
+    if before_i < 0 or after_i < 0 or context_i < 0:
+        return [
+            f"<error: before/after/context must be non-negative, got "
+            f"before={before_i}, after={after_i}, context={context_i}>"
+        ]
+    # Explicit before/after override the matching side of context.
+    eff_before = before_i if before_i > 0 else context_i
+    eff_after = after_i if after_i > 0 else context_i
+
     if not permissions.require_access(path):
         return [_denied(path)]
     regex = re.compile(pattern)
@@ -453,17 +497,50 @@ def grep(pattern: str, path: str) -> list[str]:
     if not root.exists():
         return [f"<path not found: {path}>"]
     candidates = [root] if root.is_file() else root.rglob("*")
+    use_context = eff_before > 0 or eff_after > 0
     results: list[str] = []
-    for f in candidates:
+    for f in sorted(candidates):
         if not f.is_file():
             continue
         try:
             text = f.read_text()
         except (UnicodeDecodeError, PermissionError):
             continue
-        for i, line in enumerate(text.splitlines(), start=1):
-            if regex.search(line):
-                results.append(f"{f}:{i}:{line}")
+        lines = text.splitlines()
+        match_idxs = [
+            i for i, line in enumerate(lines) if regex.search(line)
+        ]
+        if not match_idxs:
+            continue
+        if not use_context:
+            for i in match_idxs:
+                results.append(f"{f}:{i + 1}:{lines[i]}")
+            continue
+        # Build collapsed groups: a new group starts when the next
+        # match's leading context window doesn't touch the previous
+        # group's trailing context window.
+        match_set = set(match_idxs)
+        groups: list[tuple[int, int]] = []  # inclusive (start, end) line idx
+        cur_start = max(0, match_idxs[0] - eff_before)
+        cur_end = min(len(lines) - 1, match_idxs[0] + eff_after)
+        for m in match_idxs[1:]:
+            m_start = max(0, m - eff_before)
+            m_end = min(len(lines) - 1, m + eff_after)
+            if m_start <= cur_end + 1:
+                # Windows touch or overlap — extend.
+                if m_end > cur_end:
+                    cur_end = m_end
+            else:
+                groups.append((cur_start, cur_end))
+                cur_start, cur_end = m_start, m_end
+        groups.append((cur_start, cur_end))
+
+        for gi, (g_start, g_end) in enumerate(groups):
+            if gi > 0:
+                results.append("--")
+            for li in range(g_start, g_end + 1):
+                sep = ":" if li in match_set else "-"
+                results.append(f"{f}:{li + 1}{sep}{lines[li]}")
     return results
 
 

--- a/tests/smoke_grep.py
+++ b/tests/smoke_grep.py
@@ -1,0 +1,218 @@
+"""Smoke for grep.
+
+Exercises (in-process):
+  1. Default behavior: bare pattern/path returns `path:lineno:line`,
+     no context.
+  2. `before=N` emits N leading lines per match using the dash
+     separator.
+  3. `after=N` emits N trailing lines per match.
+  4. `context=N` is shorthand for `before=N, after=N`.
+  5. Explicit `before` overrides `context` on the leading side.
+  6. Match near file start/end truncates context without going OOB.
+  7. Adjacent matches collapse: context lines aren't duplicated and
+     no `--` separator appears inside the merged group.
+  8. Multiple files: matches in different files are emitted in path
+     order; per-file groups are separated by `--` only within a file.
+  9. Bad input: negative / non-coercible context returns an
+     `<error: ...>` marker.
+
+Run with:
+
+    .venv/bin/python -m tests.smoke_grep
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from pyagent import permissions
+from pyagent.tools import grep
+
+
+SAMPLE = """\
+line 1
+line 2
+def helper():
+    \"\"\"Compute the answer.\"\"\"
+    return 42
+line 6
+line 7
+def other():
+    return 99
+line 10
+line 11
+line 12
+"""
+
+
+def _seed(tmp: Path) -> Path:
+    f = tmp / "sample.py"
+    f.write_text(SAMPLE)
+    return f
+
+
+def main() -> None:
+    tmp = Path(tempfile.mkdtemp(prefix="pyagent-smoke-grep-")).resolve()
+    permissions.set_workspace(tmp)
+    f = _seed(tmp)
+    fp = str(f)
+
+    # 1. Default behavior — no context, colon separator only.
+    out = grep(r"return", fp)
+    assert out == [f"{fp}:5:    return 42", f"{fp}:9:    return 99"], out
+    print(f"[ok] default behavior: {len(out)} matches")
+
+    # 2. before=2: two leading lines per match (dash separator).
+    out = grep(r"return 42", fp, before=2)
+    assert out == [
+        f"{fp}:3-def helper():",
+        f"{fp}:4-    \"\"\"Compute the answer.\"\"\"",
+        f"{fp}:5:    return 42",
+    ], out
+    print(f"[ok] before=2: {out}")
+
+    # 3. after=2: two trailing lines per match.
+    out = grep(r"return 42", fp, after=2)
+    assert out == [
+        f"{fp}:5:    return 42",
+        f"{fp}:6-line 6",
+        f"{fp}:7-line 7",
+    ], out
+    print(f"[ok] after=2: {out}")
+
+    # 4. context=2 == before=2 + after=2.
+    out_ctx = grep(r"return 42", fp, context=2)
+    out_ba = grep(r"return 42", fp, before=2, after=2)
+    assert out_ctx == out_ba, (out_ctx, out_ba)
+    assert out_ctx == [
+        f"{fp}:3-def helper():",
+        f"{fp}:4-    \"\"\"Compute the answer.\"\"\"",
+        f"{fp}:5:    return 42",
+        f"{fp}:6-line 6",
+        f"{fp}:7-line 7",
+    ], out_ctx
+    print(f"[ok] context=2 equals before=2,after=2")
+
+    # 5. Explicit before wins over context. context=2, before=1 →
+    # 1 leading line, 2 trailing lines.
+    out = grep(r"return 42", fp, context=2, before=1)
+    assert out == [
+        f"{fp}:4-    \"\"\"Compute the answer.\"\"\"",
+        f"{fp}:5:    return 42",
+        f"{fp}:6-line 6",
+        f"{fp}:7-line 7",
+    ], out
+    print(f"[ok] explicit before overrides context: {len(out)} lines")
+
+    # 6. Truncation at boundaries. Match on line 1 with before=5
+    # must not produce negative line numbers; match on last line
+    # with after=5 must not exceed file length.
+    edge = tmp / "edge.txt"
+    edge.write_text("alpha\nbeta\ngamma\n")
+    ep = str(edge)
+    out = grep(r"alpha", ep, before=5, after=1)
+    assert out == [f"{ep}:1:alpha", f"{ep}:2-beta"], out
+    out = grep(r"gamma", ep, before=1, after=5)
+    assert out == [f"{ep}:2-beta", f"{ep}:3:gamma"], out
+    print(f"[ok] context truncates at file boundaries")
+
+    # 7. Adjacent matches collapse: pattern hits both `return 42`
+    # (line 5) and `return 99` (line 9). With context=2, windows
+    # are [3..7] and [7..11] — they touch, so one merged group, no
+    # `--` separator between them, line 7 emitted exactly once.
+    out = grep(r"return", fp, context=2)
+    assert out == [
+        f"{fp}:3-def helper():",
+        f"{fp}:4-    \"\"\"Compute the answer.\"\"\"",
+        f"{fp}:5:    return 42",
+        f"{fp}:6-line 6",
+        f"{fp}:7-line 7",
+        f"{fp}:8-def other():",
+        f"{fp}:9:    return 99",
+        f"{fp}:10-line 10",
+        f"{fp}:11-line 11",
+    ], out
+    assert "--" not in out, out
+    # Sanity: each line appears at most once.
+    assert len(out) == len(set(out)), out
+    print(f"[ok] adjacent matches collapse without duplication")
+
+    # 7b. Non-adjacent matches keep the `--` separator. context=0,
+    # before=1: window [4..5] then [8..9] don't touch.
+    out = grep(r"return", fp, before=1)
+    assert out == [
+        f"{fp}:4-    \"\"\"Compute the answer.\"\"\"",
+        f"{fp}:5:    return 42",
+        "--",
+        f"{fp}:8-def other():",
+        f"{fp}:9:    return 99",
+    ], out
+    print(f"[ok] non-adjacent matches separated by --")
+
+    # 8. Multiple files: hits in different files are emitted in
+    # alphabetical path order, each file's groups separated by `--`
+    # only when context is non-zero.
+    other = tmp / "other.py"
+    other.write_text("hello world\nreturn 7\nbye\n")
+    op = str(other)
+    out = grep(r"return", str(tmp), context=1)
+    # Files emerge in alphabetical order: other.py, sample.py.
+    # edge.txt has no "return". sample.py groups (lines 4-6, 8-10)
+    # are non-adjacent (gap at line 7) so they get a `--` between
+    # them. Cross-file boundaries are *not* separated by `--` (the
+    # path itself signals the split).
+    expected = [
+        f"{op}:1-hello world",
+        f"{op}:2:return 7",
+        f"{op}:3-bye",
+        f"{fp}:4-    \"\"\"Compute the answer.\"\"\"",
+        f"{fp}:5:    return 42",
+        f"{fp}:6-line 6",
+        "--",
+        f"{fp}:8-def other():",
+        f"{fp}:9:    return 99",
+        f"{fp}:10-line 10",
+    ]
+    assert out == expected, out
+    print(f"[ok] multiple files emit `--` between groups")
+
+    # 8b. Same multi-file search without context: no `--` lines at
+    # all, plain colon separator throughout, sorted by file then
+    # line.
+    out = grep(r"return", str(tmp))
+    assert out == [
+        f"{op}:2:return 7",
+        f"{fp}:5:    return 42",
+        f"{fp}:9:    return 99",
+    ], out
+    assert "--" not in out, out
+    print(f"[ok] no-context multi-file output stays flat")
+
+    # 9. Bad input: negative integer / non-coercible string.
+    out = grep(r"return", fp, before=-1)
+    assert len(out) == 1 and out[0].startswith("<error:") and "non-negative" in out[0], out
+    print(f"[ok] negative before: {out[0]!r}")
+
+    out = grep(r"return", fp, context=-3)
+    assert len(out) == 1 and "non-negative" in out[0], out
+    print(f"[ok] negative context: {out[0]!r}")
+
+    out = grep(r"return", fp, after="banana")  # type: ignore[arg-type]
+    assert len(out) == 1 and out[0].startswith("<error:") and "integers" in out[0], out
+    print(f"[ok] non-coercible after: {out[0]!r}")
+
+    # Coercion: numeric string is accepted.
+    out = grep(r"return 42", fp, before="2")  # type: ignore[arg-type]
+    assert out == [
+        f"{fp}:3-def helper():",
+        f"{fp}:4-    \"\"\"Compute the answer.\"\"\"",
+        f"{fp}:5:    return 42",
+    ], out
+    print(f"[ok] string coerces to int")
+
+    print("\nALL CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Item **H7** from #63. Adds `before` / `after` / `context` keyword-only
parameters to the `grep` tool so the agent can pull surrounding lines
in a single call instead of grepping and then reading the file.

## Semantics

Mirrors GNU grep's `-B` / `-A` / `-C`:

- `context=N` is shorthand for `before=N, after=N`.
- An explicit non-zero `before` or `after` overrides the matching side
  of `context`.
- All zero (the default) preserves today's behavior exactly.

Output uses the conventional separator distinction:

- match line: `path:lineno:line` (colon, unchanged)
- context line: `path:lineno-line` (dash)

Adjacent matches whose context windows touch or overlap collapse into
one contiguous excerpt with no duplicate lines. Multiple non-adjacent
groups within a file are separated by `--`. Files are emitted in
sorted path order; line numbers stay 1-indexed and align with
`read_file`'s `start` / `end` for follow-up reads.

Negative or non-coercible values come back as the standard
`<error: ...>` marker rather than raising.

## Before / after

Before:

```
>>> grep("return 42", "src/foo.py")
['src/foo.py:11:    return 42']
>>> read_file("src/foo.py", start=8, end=14)   # follow-up
...
```

After:

```
>>> grep("return 42", "src/foo.py", context=2)
['src/foo.py:9-def helper():',
 'src/foo.py:10-    """Compute the answer."""',
 'src/foo.py:11:    return 42',
 'src/foo.py:12-',
 'src/foo.py:13-line_after']
```

## Test plan

- [x] `tests/smoke_grep.py` (new): default behavior unchanged, each of
      `before` / `after` / `context` in isolation, explicit-overrides-
      context, boundary truncation, adjacent-match collapse,
      multi-file ordering with `--`, negative / non-coercible input
      errors.
- [x] `tests/smoke_session_replay.py` passes (cross-suite sanity).
- [x] `tests/smoke_plugins.py` passes (cross-suite sanity).
- [x] `tests/smoke_session_audit.py` passes (existing reference to
      grep tool name unchanged).