### PR TITLE
memory: tier 2 — category-drift guard, taxonomy hint, render summary

### DIFF
--- a/pyagent/plugins/memory_markdown/__init__.py
+++ b/pyagent/plugins/memory_markdown/__init__.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import re
 import shutil
+from difflib import SequenceMatcher
 from pathlib import Path
 
 _LEDGERS = {"USER": "USER.md", "MEMORY": "MEMORY.md"}
@@ -35,6 +36,114 @@ _MEMORIES_DIRNAME = "memories"
 # from drifting into mixed-case or spaced filenames that look
 # inconsistent in the index.
 _FILENAME_RE = re.compile(r"^[a-z0-9][a-z0-9_]*\.md$")
+
+# Two-stage drift check:
+#
+# (1) Token-level containment. Splitting on whitespace, if the
+#     target's token set is a strict subset/superset of an existing
+#     category's, that's the "Code Style" / "Style" case — flag it.
+#     Pure character similarity misses this (ratio is only ~0.67),
+#     and lowering the threshold to catch it produces false positives
+#     on unrelated 1-char-different names ("Stack" vs "Slack").
+#
+# (2) Fuzzy similarity at 0.85 for the leftover cases — pluralization
+#     ("Database" vs "Databases" ~0.94, "Style" vs "Styles" ~0.91)
+#     and minor typos. 0.85 is high enough to ignore "Stack" vs
+#     "Slack" (0.80) and "Stack" vs "Snack" (0.80).
+_CATEGORY_FUZZY_THRESHOLD = 0.85
+
+# When the rendered MEMORY.md section has at least this many
+# categories, we prepend a compact "Categories in use: ..." summary
+# above the bulleted detail so the agent can scan available
+# headings without parsing the full structure. Below this count
+# the bullets are short enough that scanning them is cheap.
+_CATEGORY_SUMMARY_MIN = 5
+
+
+def _extract_categories(index_text: str) -> list[str]:
+    """Walk ``MEMORY.md``-style text and return its ``## <heading>``
+    names in document order, deduplicated case-insensitively (the
+    insert path matches headings case-insensitively so two ``##``
+    lines that differ only in case shouldn't both surface)."""
+    out: list[str] = []
+    seen: set[str] = set()
+    for line in index_text.splitlines():
+        stripped = line.lstrip()
+        if not stripped.startswith("## "):
+            continue
+        name = stripped[3:].strip()
+        if not name:
+            continue
+        key = name.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(name)
+    return out
+
+
+def _find_similar_category(
+    target: str, existing: list[str]
+) -> str | None:
+    """Return the closest existing category name if it's confusingly
+    close to ``target``, else None. Case-insensitive comparison.
+
+    Two-stage check (see comment block on the threshold constant for
+    why):
+
+      1. Token-level subset/superset — catches compound-vs-bare
+         names like ``Code Style`` vs ``Style``. Pure character
+         similarity misses this case.
+      2. Fuzzy similarity ≥ 0.85 — catches pluralization
+         (``Database`` vs ``Databases``, ``Decision`` vs
+         ``Decisions``) without flagging unrelated short names that
+         differ by one character (``Stack`` vs ``Slack``).
+
+    Exact case-insensitive matches return None — those collapse via
+    ``_insert_index_bullet``'s existing case-insensitive matching, no
+    warning needed.
+    """
+    target_lc = target.lower().strip()
+    if not target_lc:
+        return None
+
+    # If ANY existing category matches case-insensitively, defer to
+    # _insert_index_bullet's case-insensitive collapse. Without this
+    # short-circuit, ``add_memory("STYLE")`` against an index that
+    # already has both ``Style`` and ``Code Style`` would trip the
+    # subset check on ``Code Style`` and refuse — but the canonical
+    # destination is the existing literal-match ``Style``.
+    for cat in existing:
+        if cat.lower().strip() == target_lc:
+            return None
+
+    target_tokens = set(target_lc.split())
+
+    # Stage 1: token containment (strict subset / superset).
+    for cat in existing:
+        cat_lc = cat.lower().strip()
+        if not cat_lc:
+            continue
+        cat_tokens = set(cat_lc.split())
+        if not target_tokens or not cat_tokens:
+            continue
+        if target_tokens < cat_tokens or cat_tokens < target_tokens:
+            return cat
+
+    # Stage 2: fuzzy similarity for the leftover near-equal cases.
+    best_ratio = 0.0
+    best_match: str | None = None
+    for cat in existing:
+        cat_lc = cat.lower().strip()
+        if not cat_lc:
+            continue
+        r = SequenceMatcher(None, target_lc, cat_lc).ratio()
+        if r > best_ratio:
+            best_ratio = r
+            best_match = cat
+    if best_ratio >= _CATEGORY_FUZZY_THRESHOLD:
+        return best_match
+    return None
 
 
 def _validate_memory_filename(file: str) -> str | None:
@@ -237,6 +346,7 @@ def register(api):
         filename: str,
         hook: str,
         content: str,
+        force_new_category: bool = False,
     ) -> str:
         """Add a new memory in one call — body file plus index entry.
 
@@ -250,11 +360,21 @@ def register(api):
         place, use `write_ledger("MEMORY", content, file=...)`. To
         prune, edit MEMORY.md and delete the body file directly.
 
+        Category drift guard: if `category` is close (but not equal)
+        to an existing heading in MEMORY.md, this call refuses with
+        a marker pointing at the closer match. Re-call with the
+        existing category to file under it, or pass
+        `force_new_category=True` to confirm a deliberately new
+        heading. The guard prevents drift toward parallel headings
+        (`Style` + `Code Style` + `Conventions` for one concept).
+
         Args:
             category: H2 section to file under (e.g. "Database",
                 "Style", "Gotchas"). Matched case-insensitively
                 against existing headings; new heading created at
-                the end of the index if no match.
+                the end of the index if no match. Close-but-not-
+                equal matches against existing headings are
+                refused unless `force_new_category=True`.
             title: Short topical name used as the link text.
             filename: Bare filename under `memories/`, must end
                 in `.md`. Cannot collide with an existing file.
@@ -263,10 +383,14 @@ def register(api):
                 whether to fetch. May be empty if the title alone
                 is enough.
             content: Full body markdown for the new memory file.
+            force_new_category: When True, skip the drift guard and
+                file under `category` even if it's close to an
+                existing heading. Use when you genuinely want a new
+                heading near an existing one (rare).
 
         Returns:
             A confirmation string with both written paths, or an
-            error in `<...>` form.
+            error / drift-warning in `<...>` form.
         """
         if not category or not category.strip():
             return "<category is empty>"
@@ -281,6 +405,21 @@ def register(api):
         index_text = (
             index_path.read_text() if index_path.exists() else ""
         )
+
+        # Drift guard: refuse close-but-not-equal category matches.
+        # Exact case-insensitive matches fall through to
+        # _insert_index_bullet which collapses them.
+        if not force_new_category:
+            existing_cats = _extract_categories(index_text)
+            similar = _find_similar_category(category, existing_cats)
+            if similar is not None:
+                return (
+                    f"<category {category!r} is close to existing "
+                    f"category {similar!r} — re-call with "
+                    f"category={similar!r} to file under it, or pass "
+                    f"force_new_category=True to confirm a "
+                    f"deliberately new heading>"
+                )
         # Same disambiguation guidance whether the collision is on
         # disk, in the index, or both: pick a different filename, or
         # inspect the existing memory before deciding what to do.
@@ -345,12 +484,35 @@ def register(api):
         """Auto-load the MEMORY.md index into every prompt so the
         agent always sees the catalog without a tool call. Body
         files under memories/ are fetched on demand via
-        read_ledger("MEMORY", file=...)."""
+        read_ledger("MEMORY", file=...).
+
+        When the index has many headings, prepend a one-line
+        ``Categories in use: ...`` summary so the agent can scan
+        available categories before picking one for ``add_memory``
+        without parsing the full bulleted detail. The summary is
+        synthesized at render time only — the source MEMORY.md
+        file stays clean so ``write_ledger`` round-trips don't
+        fight a derived line.
+        """
         _seed_if_missing("MEMORY")
         target = _ledger_path("MEMORY")
         if not target.exists():
             return ""
-        return target.read_text()
+        text = target.read_text()
+        cats = _extract_categories(text)
+        if len(cats) >= _CATEGORY_SUMMARY_MIN:
+            summary = (
+                f"\n*Categories in use: {', '.join(sorted(cats))}.*\n"
+            )
+            # Insert immediately after the H1 heading line so the
+            # summary sits at the top of the section, above the
+            # template preamble and the bulleted detail.
+            head, sep, tail = text.partition("\n")
+            if head.startswith("# ") and sep:
+                text = f"{head}{sep}{summary}{tail}"
+            else:
+                text = f"{summary}\n{text}"
+        return text
 
     api.register_prompt_section(
         "memory-guidance", render_memory_guidance, volatile=False

--- a/pyagent/plugins/memory_markdown/defaults/PROMPT.md
+++ b/pyagent/plugins/memory_markdown/defaults/PROMPT.md
@@ -49,6 +49,22 @@ across the filesystem.
     file="filename.md")` once you've spotted it in the index or
     located it with `recall_memory(query)`.
 
+  **Categories: prefer existing over new.** Before picking a
+  `category`, scan the `## <heading>` lines already in MEMORY.md
+  (visible above your conversation; when 5+ categories exist a
+  one-line *Categories in use:* summary is rendered up top). Use
+  the closest existing heading rather than spawning a near-
+  duplicate; `add_memory` will refuse a close-but-not-equal new
+  category and point at the existing one. Common shapes that
+  recur across users: **Architecture** (system shape, deployment,
+  service boundaries), **Database** (schema, migrations, query
+  notes), **Style** (code conventions, formatting, idioms),
+  **Gotchas** (non-obvious failure modes worth remembering),
+  **Decisions** (the *why* behind a choice, especially the ones
+  that surprised future-you), **References** (links, dashboards,
+  channels). New categories are fine when nothing fits — but
+  ask "is this really not Decisions / Gotchas?" first.
+
   **Filenames are search-friendly** — `recall_memory` embeds the
   filename's tokens alongside the title and hook, so descriptive
   filenames pull their weight at recall time. Use lowercase

--- a/tests/smoke_memory_category_drift.py
+++ b/tests/smoke_memory_category_drift.py
@@ -1,0 +1,248 @@
+"""Smoke for the Tier-2 memory category-drift improvements.
+
+Locks four behaviors:
+
+  1. **`_extract_categories` walks `## <heading>` lines correctly.**
+     Returns names in document order, deduplicates case-insensitively,
+     ignores non-H2 lines.
+  2. **`_find_similar_category` flags near-but-not-equal matches.**
+     "Style" vs "Code Style" / "Database" vs "Databases" trigger;
+     "Style" vs "Stack" doesn't; exact case-insensitive matches
+     return None (those collapse via existing matching).
+  3. **`add_memory` refuses close-existing categories**, with an
+     override path via `force_new_category=True`.
+  4. **`render_memory_index` prepends a compact "Categories in use"
+     summary** when ≥ 5 categories exist; below threshold, the
+     rendered text is unchanged.
+
+Run with:
+    .venv/bin/python -m tests.smoke_memory_category_drift
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from pyagent.plugins.memory_markdown import (
+    _CATEGORY_SUMMARY_MIN,
+    _extract_categories,
+    _find_similar_category,
+)
+from pyagent.plugins.memory_markdown import register as md_register
+
+
+def _check_extract_categories() -> None:
+    text = (
+        "# Memory\n\n"
+        "Some preamble.\n\n"
+        "## Stack\n\n"
+        "- [a](a.md) — x\n\n"
+        "## Database\n"
+        "- [b](b.md) — y\n\n"
+        "## stack\n"  # case-insensitive duplicate; should be ignored
+        "- [c](c.md) — z\n\n"
+        "## Style\n"
+        "- [d](d.md) — w\n"
+    )
+    cats = _extract_categories(text)
+    assert cats == ["Stack", "Database", "Style"], cats
+    print("✓ _extract_categories: ordered, dedup case-insensitive")
+
+
+def _check_find_similar_category() -> None:
+    """Flag near-but-not-equal matches; ignore exact and far-apart."""
+    existing = ["Stack", "Database", "Style", "Gotchas"]
+
+    # Exact case-insensitive match → None (handled by existing
+    # case-insensitive collapse).
+    assert _find_similar_category("Stack", existing) is None
+    assert _find_similar_category("STACK", existing) is None
+    assert _find_similar_category("stack", existing) is None
+
+    # Near misses → flagged.
+    assert _find_similar_category("Stacks", existing) == "Stack"
+    assert _find_similar_category("Databases", existing) == "Database"
+    assert _find_similar_category("Styles", existing) == "Style"
+    assert _find_similar_category("Code Style", existing) == "Style"
+    assert _find_similar_category("Gotcha", existing) == "Gotchas"
+
+    # Genuinely different short names → None.
+    assert _find_similar_category("Architecture", existing) is None
+    assert _find_similar_category("References", existing) is None
+    assert _find_similar_category("Decisions", existing) is None
+
+    # Empty inputs are safe.
+    assert _find_similar_category("", existing) is None
+    assert _find_similar_category("Stack", []) is None
+    print("✓ _find_similar_category: near hits flagged; exact/far ignored")
+
+
+def _check_add_memory_refuses_close_category() -> None:
+    """`add_memory` refuses a close-but-not-equal new category and
+    points at the existing match. `force_new_category=True` overrides.
+    """
+    captured: dict = {"tools": {}}
+
+    class _FakeAPI:
+        _tmp = Path(tempfile.mkdtemp(prefix="pyagent-mem-drift-"))
+
+        @property
+        def user_data_dir(self):
+            return self._tmp
+
+        @property
+        def config_dir(self):
+            return self._tmp
+
+        def log(self, level, msg):
+            pass
+
+        def register_tool(self, name, fn):
+            captured["tools"][name] = fn
+
+        def register_prompt_section(self, name, renderer, *, volatile=False):
+            pass
+
+        def on_session_start(self, fn):
+            pass
+
+    api = _FakeAPI()
+    md_register(api)
+    add_memory = captured["tools"]["add_memory"]
+
+    # Seed an existing memory under "Style".
+    out = add_memory(
+        "Style", "py conventions", "python_style.md", "py style", "body"
+    )
+    assert "added index entry" in out, out
+
+    # Drift attempt: "Code Style" is close to "Style" → refused.
+    out = add_memory(
+        "Code Style", "more py conventions", "python_style_2.md", "h", "body"
+    )
+    assert out.startswith("<category 'Code Style' is close to existing"), out
+    assert "'Style'" in out, out
+    assert "force_new_category=True" in out, out
+
+    # Override: pass force_new_category=True → succeeds.
+    out = add_memory(
+        "Code Style",
+        "more py conventions",
+        "python_style_2.md",
+        "h",
+        "body",
+        force_new_category=True,
+    )
+    assert "added index entry" in out, out
+
+    # Genuine new category (not close to any existing) → succeeds
+    # without override.
+    out = add_memory(
+        "Architecture",
+        "service boundaries",
+        "service_boundaries.md",
+        "h",
+        "body",
+    )
+    assert "added index entry" in out, out
+
+    # Exact case-insensitive match → falls through to existing
+    # case-insensitive collapse, no drift warning.
+    out = add_memory(
+        "STYLE",  # matches existing "Style"
+        "another py conventions",
+        "python_style_3.md",
+        "h",
+        "body",
+    )
+    assert "added index entry" in out, out
+    assert "close to existing" not in out, out
+
+    print("✓ add_memory: refuses close-existing; force_new_category=True overrides")
+
+
+def _check_render_summary_above_threshold() -> None:
+    """`render_memory_index` prepends 'Categories in use: ...' once
+    the index has at least `_CATEGORY_SUMMARY_MIN` headings."""
+    from pyagent.plugins import memory_markdown as md_mod
+
+    # Reach into render_memory_index by invoking register() with a
+    # fake api against a tempdir, then grabbing the captured renderer.
+    sections: dict = {}
+
+    class _FakeAPI:
+        _tmp = Path(tempfile.mkdtemp(prefix="pyagent-mem-render-"))
+
+        @property
+        def user_data_dir(self):
+            return self._tmp
+
+        @property
+        def config_dir(self):
+            return self._tmp
+
+        def log(self, level, msg):
+            pass
+
+        def register_tool(self, name, fn):
+            pass
+
+        def register_prompt_section(self, name, renderer, *, volatile=False):
+            sections[name] = renderer
+
+        def on_session_start(self, fn):
+            pass
+
+    api = _FakeAPI()
+    md_register(api)
+    render_index = sections["memory-index"]
+
+    # Below threshold: 3 categories → no summary.
+    storage = api._tmp
+    storage.mkdir(parents=True, exist_ok=True)
+    (storage / "MEMORY.md").write_text(
+        "# Memory\n\n"
+        "## Stack\n- [a](a.md) — x\n\n"
+        "## Database\n- [b](b.md) — y\n\n"
+        "## Style\n- [c](c.md) — z\n"
+    )
+    rendered = render_index(None)
+    assert "Categories in use" not in rendered, rendered
+
+    # Above threshold: build an index with the configured minimum +
+    # one to be unambiguous.
+    cats = ["Architecture", "Database", "Decisions", "Gotchas", "Style", "Stack"]
+    assert len(cats) >= _CATEGORY_SUMMARY_MIN
+    index_text = "# Memory\n\n"
+    for c in cats:
+        index_text += f"## {c}\n- [x](x_{c.lower()}.md) — y\n\n"
+    (storage / "MEMORY.md").write_text(index_text)
+    rendered = render_index(None)
+    assert "Categories in use" in rendered, rendered
+    # Summary lists categories alphabetically; spot-check.
+    for c in cats:
+        assert c in rendered, (c, rendered)
+    # Summary sits right after the H1 line.
+    head_index = rendered.find("# Memory")
+    summary_index = rendered.find("Categories in use")
+    assert head_index < summary_index, (head_index, summary_index)
+    # Source file unchanged — derived line is render-only.
+    on_disk = (storage / "MEMORY.md").read_text()
+    assert "Categories in use" not in on_disk, on_disk
+    print(
+        f"✓ render_memory_index: 'Categories in use' prepended at "
+        f">= {_CATEGORY_SUMMARY_MIN} cats; source file untouched"
+    )
+
+
+def main() -> None:
+    _check_extract_categories()
+    _check_find_similar_category()
+    _check_add_memory_refuses_close_category()
+    _check_render_summary_above_threshold()
+    print("\nALL CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Tier 2 from the memory deep-dive — four small changes that compose to prevent category-drift in MEMORY.md. Builds directly on PR #104 (Tier 1).

## (d) Canonical taxonomy in PROMPT.md

Names six common categories (Architecture, Database, Style, Gotchas, Decisions, References) with one-line guidance on what belongs in each. Before picking a category, the agent has a reference shape to anchor against. New categories are still allowed, but the prose nudges "is this really not Decisions / Gotchas?" first. ~120 tokens.

## (e) Drift guard at `add_memory`

The agent picks `category="Code Style"` when "Style" already exists. Today, this silently spawns a near-duplicate heading. With this change, `add_memory` refuses with a marker pointing at the existing match:

> `<category 'Code Style' is close to existing category 'Style' — re-call with category='Style' to file under it, or pass force_new_category=True to confirm a deliberately new heading>`

Detection is two-stage:

1. **Token containment** (strict subset/superset on whitespace-split tokens). Catches `Code Style` ⊃ `Style`, `Stack Architecture` ⊃ `Architecture`. Pure character similarity misses this case (`Code Style` vs `Style` SequenceMatcher ratio is only ~0.67).
2. **Fuzzy similarity ≥ 0.85**. Catches pluralization (`Database` vs `Databases` ratio ~0.94, `Decision` vs `Decisions` ratio ~0.95) without flagging unrelated short names that differ by one character (`Stack` vs `Slack` ratio ~0.80, ignored).

Case-insensitive equals fall through to the existing collapse — `add_memory("STYLE")` still files under existing `"Style"` without a warning.

Override path: `force_new_category=True` for the rare case where the agent genuinely wants a new heading near an existing one.

**Zero token cost on the system prompt** — the marker only surfaces when drift fires.

## (i) Compact "Categories in use:" summary

When MEMORY.md has at least 5 categories, `render_memory_index` prepends a one-line summary above the bulleted detail:

```
# Memory

*Categories in use: Architecture, Database, Decisions, Gotchas, Stack, Style.*

## Architecture
- ...
```

Lets the agent scan available categories at a glance without parsing the full bulleted index. Below 5 categories, no summary — bullets are short enough to scan directly. Source MEMORY.md stays untouched — the summary is synthesized at render time only, so `write_ledger` round-trips don't fight a derived line.

## (iii) "Prefer existing over new" wording nudge

Folded into the same taxonomy paragraph in PROMPT.md: scan the `## headings` in MEMORY.md before picking; use the closest existing rather than spawning a near-duplicate; `add_memory` will refuse the close cases anyway. Reinforces the discipline at three levels (visibility, guardrail, prose) so the failure mode is covered at every decision point.

## Why bundle the four

All four target the same failure mode (category drift over time → parallel headings for one concept). Each operates at a different layer:

| Layer | Mechanism | Cost |
|---|---|---|
| Visibility | Compact summary at top of rendered MEMORY.md | runtime, ~5 tokens per category once threshold hits |
| Guidance | Canonical taxonomy + scan-before-pick prose | always-on, ~234 tokens |
| Guardrail | Drift refusal at write time | zero on the system prompt; surfaces in tool results only |

Independently each is small. Together they form a defense-in-depth for the named failure.

## Token impact

| Change | Always-on | Runtime |
|---|---:|---:|
| (d) + (iii) taxonomy + nudge prose | +234 tokens | — |
| (e) drift refusal | 0 | tool-result only |
| (i) compact summary | 0 | ~5 tokens × N categories when N ≥ 5 |

## Test plan

- [x] `tests/smoke_memory_category_drift.py` — four checks:
  - `_extract_categories` ordering and case-insensitive dedup.
  - `_find_similar_category` two-stage logic (token containment, fuzzy threshold, exact match short-circuit, far-apart names ignored).
  - `add_memory` refuses close-existing categories; `force_new_category=True` overrides; case-insensitive equals fall through to existing collapse.
  - `render_memory_index` prepends "Categories in use" at threshold; source file untouched.
- [x] Tier 1 regression-guard: `smoke_memory_recall_improvements` still green.
- [x] Cross-suite: `smoke_plugins`, `smoke_session_replay` green.
- [x] `pyagent --prompt-dump` shows the new prose renders correctly.

## Out of scope (Tier 3, defer)

- Body chunking for long memories.
- Hybrid keyword fallback in `recall_memory`.
- Category-rename / merge tool.
- Strip the bulleted detail from rendered MEMORY.md once total exceeds ~1.5K tokens; switch to headers + count and let the agent drill in via `read_ledger` / `recall_memory`. Architecture question raised during this PR's design; see thread for the trade-off analysis.