### PR TITLE
license: MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Derek Wisong
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -79,5 +79,4 @@ Local Ollama needs no key — just the daemon running and a model pulled.
 
 ## License
 
-Copyright © 2026 Derek Wisong. All rights reserved. No license is
-granted for use, modification, or redistribution at this time.
+MIT — see [LICENSE](LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ build-backend = "setuptools.build_meta"
 name = "pyagent"
 version = "0.1.0"
 requires-python = ">=3.11"
+license = {text = "MIT"}
+license-files = ["LICENSE"]
 dependencies = [
     "anthropic>=0.40",
     "beautifulsoup4>=4.12",


### PR DESCRIPTION
Replaces the all-rights-reserved notice from #108 with MIT licensing.

## Changes

- **`LICENSE`** — new file, canonical MIT text, `Copyright (c) 2026 Derek Wisong`.
- **`pyproject.toml`** — adds `license = {text = "MIT"}` and `license-files = ["LICENSE"]` under `[project]` so build tooling and any future PyPI publish carry the license metadata correctly.
- **`README.md`** — License section now reads `MIT — see [LICENSE](LICENSE).` Link resolves.

## Why MIT

Stated intent: "okay for people to use it; not committing to support." MIT matches that — the warranty disclaimer in the canonical text explicitly covers the no-support posture (`THE SOFTWARE IS PROVIDED "AS IS"`). License doesn't carry support obligations, never has.

## Test plan

- [x] `tomllib` parses the updated pyproject.
- [x] `smoke_plugins` green (cross-suite sanity; this is a metadata change, no code paths touched).