### PR TITLE
readme: document OLLAMA_HOST + OLLAMA_MODEL env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ callbacks, the permissions gate, and a la carte feature attach.
 | `ANTHROPIC_API_KEY` | `--model anthropic` | |
 | `OPENAI_API_KEY` | `--model openai` | |
 | `GEMINI_API_KEY` | `--model gemini` | `GOOGLE_API_KEY` is accepted as a fallback. |
+| `OLLAMA_HOST` | `--model ollama/...` | Optional. Default `http://localhost:11434`. Set when Ollama runs on a non-default host or port. |
+| `OLLAMA_MODEL` | `--model ollama` | Optional. Default model when no `/<name>` suffix is given. |
 
 Local Ollama needs no key — just the daemon running and a model pulled.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -41,6 +41,12 @@ If `--model` is omitted, pyagent picks one in this order:
 The session header prints the resolved provider/model so you can confirm
 what was picked.
 
+Ollama uses the local daemon at `http://localhost:11434` by default. Set
+`OLLAMA_HOST` to point at a different host/port (e.g.,
+`OLLAMA_HOST=http://192.168.1.10:11434`). `OLLAMA_MODEL` sets the default
+model name when `--model ollama` is passed without a `/<name>` suffix.
+Neither variable is required for the standard local setup.
+
 ### Switching models mid-session
 
 At the prompt, type `/model <spec>` to swap the running agent's LLM


### PR DESCRIPTION
The README's library quickstart now shows `ollama/llama3.2:latest` as the active example, but the Environment variables section only listed cloud-provider API keys. Anyone running Ollama on a non-default host (different machine, custom port) had no pointer to `OLLAMA_HOST`.

## Changes

- **`README.md`** — env-vars table gains two rows for the optional Ollama configuration:
  - `OLLAMA_HOST` — default `http://localhost:11434`.
  - `OLLAMA_MODEL` — default model when `--model ollama` has no `/<name>` suffix.
- **`docs/cli.md`** — same note added after the model-selection table so users coming in from the CLI docs find it too.

Both variables are optional. The standard local setup (Ollama running on default host/port) needs neither.

## Test plan

- [x] README renders correctly via `pyagent --prompt-dump` doesn't apply (this is repo-level docs, not the agent's prompt). Visual check shows the table reads cleanly with the two new rows.
- [x] No code paths touched.