### PR TITLE
Fix TOML rendering crash on float config values

### DIFF
--- a/pyagent/config.py
+++ b/pyagent/config.py
@@ -228,6 +228,8 @@ def _render_toml_value(v: Any) -> str:
         return "true" if v else "false"
     if isinstance(v, int):
         return str(v)
+    if isinstance(v, float):
+        return repr(v)
     if isinstance(v, str):
         escaped = v.replace("\\", "\\\\").replace('"', '\\"')
         return f'"{escaped}"'


### PR DESCRIPTION
## Problem

`pyagent-config init` crashed with `TypeError: unsupported toml value: 0.3`:

```
File "pyagent/config.py", line 236, in _render_toml_value
    raise TypeError(f"unsupported toml value: {v!r}")
TypeError: unsupported toml value: 0.3
```

`_render_toml_value` handled `bool`, `int`, `str`, and `list`, but not `float` — so rendering the commented default template blew up on the `0.3` temperature default in `DEFAULTS`.

## Fix

Add a `float` branch to `_render_toml_value` that emits `repr(v)`.

## Test plan

- [x] `pyagent-config init --force` succeeds and writes the default config + seeds roles